### PR TITLE
ScreenCell.h: Structure for a ScreenCell

### DIFF
--- a/TUI/Rendering/ScreenCell.h
+++ b/TUI/Rendering/ScreenCell.h
@@ -1,0 +1,30 @@
+#pragma once
+
+// Assuming future file
+#include "Rendering/Style.h"
+
+struct ScreenCell
+{
+    char32_t glyph = U' ';
+    Style style{};
+
+    bool hasVisibleGlyph() const
+    {
+        return glyph != U' ';
+    }
+
+    bool hasStyle() const
+    {
+        return style != Style{};
+    }
+
+    bool operator==(const ScreenCell& other) const
+    {
+        return glyph == other.glyph && style == other.style;
+    }
+
+    bool operator!=(const ScreenCell& other) const
+    {
+        return !(*this == other);
+    }
+};


### PR DESCRIPTION
Implements the foundational ScreenCell type for the new rendering core.

Included:
- glyph storage
- style storage
- visible glyph helper
- style helper
- equality operators

Notes:
- ScreenCell is implemented as a lightweight header-only value type
- future metadata fields can be added later without changing the core role of the type

Closes #<issue number>