### PR TITLE
4 phase 1   23 implement screenbuffer

### DIFF
--- a/TUI/Rendering/ScreenBuffer.cpp
+++ b/TUI/Rendering/ScreenBuffer.cpp
@@ -89,7 +89,10 @@ void ScreenBuffer::writeChar(int x, int y, char glyph, const Style& style)
 
 void ScreenBuffer::writeString(int x, int y, const std::string& text, const Style& style)
 {
-
+    for (std::size_t i = 0; i < text.size(); ++i)
+    {
+        writeChar(x + static_cast<int>(i), y, text[i], style);
+    }
 }
 
 void ScreenBuffer::fillRect(const Rect& rect, char glyph, const Style& style)

--- a/TUI/Rendering/ScreenBuffer.cpp
+++ b/TUI/Rendering/ScreenBuffer.cpp
@@ -57,12 +57,22 @@ const ScreenCell& ScreenBuffer::getCell(int x, int y) const
 
 ScreenCell& ScreenBuffer::getCell(int x, int y)
 {
+    if (!inBounds(x, y))
+    {
+        throw std::out_of_range("ScreenBuffer::getCell out of bounds.");
+    }
 
+    return m_cells[static_cast<std::size_t>(index(x, y))];
 }
 
 void ScreenBuffer::setCell(int x, int y, const ScreenCell& cell)
 {
+    if (!inBounds(x, y))
+    {
+        return;
+    }
 
+    m_cells[static_cast<std::size_t>(index(x, y))] = cell;
 }
 
 void ScreenBuffer::writeChar(int x, int y, char glyph, const Style& style)

--- a/TUI/Rendering/ScreenBuffer.cpp
+++ b/TUI/Rendering/ScreenBuffer.cpp
@@ -37,7 +37,7 @@ int ScreenBuffer::getWidth() const
 
 int ScreenBuffer::getHeight() const
 {
-
+    return m_height;
 }
 
 bool ScreenBuffer::inBounds(int x, int y) const

--- a/TUI/Rendering/ScreenBuffer.cpp
+++ b/TUI/Rendering/ScreenBuffer.cpp
@@ -42,7 +42,7 @@ int ScreenBuffer::getHeight() const
 
 bool ScreenBuffer::inBounds(int x, int y) const
 {
-
+    return x >= 0 && x < m_width && y >= 0 && y < m_height;
 }
 
 const ScreenCell& ScreenBuffer::getCell(int x, int y) const

--- a/TUI/Rendering/ScreenBuffer.cpp
+++ b/TUI/Rendering/ScreenBuffer.cpp
@@ -47,7 +47,12 @@ bool ScreenBuffer::inBounds(int x, int y) const
 
 const ScreenCell& ScreenBuffer::getCell(int x, int y) const
 {
+    if (!inBounds(x, y))
+    {
+        throw std::out_of_range("ScreenBuffer::getCell out of bounds.");
+    }
 
+    return m_cells[static_cast<std::size_t>(index(x, y))];
 }
 
 ScreenCell& ScreenBuffer::getCell(int x, int y)

--- a/TUI/Rendering/ScreenBuffer.cpp
+++ b/TUI/Rendering/ScreenBuffer.cpp
@@ -77,7 +77,14 @@ void ScreenBuffer::setCell(int x, int y, const ScreenCell& cell)
 
 void ScreenBuffer::writeChar(int x, int y, char glyph, const Style& style)
 {
+    if (!inBounds(x, y))
+    {
+        return;
+    }
 
+    ScreenCell& cell = m_cells[static_cast<std::size_t>(index(x, y))];
+    cell.glyph = static_cast<char32_t>(static_cast<unsigned char>(glyph));
+    cell.style = style;
 }
 
 void ScreenBuffer::writeString(int x, int y, const std::string& text, const Style& style)

--- a/TUI/Rendering/ScreenBuffer.cpp
+++ b/TUI/Rendering/ScreenBuffer.cpp
@@ -97,7 +97,18 @@ void ScreenBuffer::writeString(int x, int y, const std::string& text, const Styl
 
 void ScreenBuffer::fillRect(const Rect& rect, char glyph, const Style& style)
 {
+    const int xStart = std::max(0, rect.position.x);
+    const int yStart = std::max(0, rect.position.y);
+    const int xEnd = std::min(m_width, rect.position.x + rect.size.width);
+    const int yEnd = std::min(m_height, rect.position.y + rect.size.height);
 
+    for (int y = yStart; y < yEnd; ++y)
+    {
+        for (int x = xStart; x < xEnd; ++x)
+        {
+            writeChar(x, y, glyph, style);
+        }
+    }
 }
 
 void ScreenBuffer::drawFrame(const Rect& rect, const Style& style)

--- a/TUI/Rendering/ScreenBuffer.cpp
+++ b/TUI/Rendering/ScreenBuffer.cpp
@@ -1,5 +1,7 @@
 #include "Rendering/ScreenBuffer.h"
 
+#include <stdexcept>
+
 ScreenBuffer::ScreenBuffer() = default;
 
 ScreenBuffer::ScreenBuffer(int width, int height)
@@ -9,7 +11,14 @@ ScreenBuffer::ScreenBuffer(int width, int height)
 
 void ScreenBuffer::resize(int width, int height)
 {
+    if (width < 0 || height < 0)
+    {
+        throw std::invalid_argument("ScreenBuffer dimensions cannot be negative.");
+    }
 
+    m_width = width;
+    m_height = height;
+    m_cells.assign(static_cast<std::size_t>(m_width * m_height), ScreenCell{});
 }
 
 void ScreenBuffer::clear(const Style& style = Style())

--- a/TUI/Rendering/ScreenBuffer.cpp
+++ b/TUI/Rendering/ScreenBuffer.cpp
@@ -164,5 +164,5 @@ std::string ScreenBuffer::renderToString() const
 
 int ScreenBuffer::index(int x, int y) const
 {
-
+    return y * m_width + x;
 }

--- a/TUI/Rendering/ScreenBuffer.cpp
+++ b/TUI/Rendering/ScreenBuffer.cpp
@@ -23,7 +23,11 @@ void ScreenBuffer::resize(int width, int height)
 
 void ScreenBuffer::clear(const Style& style = Style())
 {
-
+    for (auto& cell : m_cells)
+    {
+        cell.glyph = U' ';
+        cell.style = style;
+    }
 }
 
 int ScreenBuffer::getWidth() const

--- a/TUI/Rendering/ScreenBuffer.cpp
+++ b/TUI/Rendering/ScreenBuffer.cpp
@@ -143,7 +143,23 @@ void ScreenBuffer::drawFrame(const Rect& rect, const Style& style)
 
 std::string ScreenBuffer::renderToString() const
 {
+    std::string out;
+    out.reserve(static_cast<std::size_t>(m_width * m_height + m_height));
 
+    for (int y = 0; y < m_height; ++y)
+    {
+        for (int x = 0; x < m_width; ++x)
+        {
+            out.push_back(static_cast<char>(getCell(x, y).glyph));
+        }
+
+        if (y + 1 < m_height)
+        {
+            out.push_back('\n');
+        }
+    }
+
+    return out;
 }
 
 int ScreenBuffer::index(int x, int y) const

--- a/TUI/Rendering/ScreenBuffer.cpp
+++ b/TUI/Rendering/ScreenBuffer.cpp
@@ -1,13 +1,10 @@
 #include "Rendering/ScreenBuffer.h"
 
-ScreenBuffer::ScreenBuffer()
-{
-
-}
+ScreenBuffer::ScreenBuffer() = default;
 
 ScreenBuffer::ScreenBuffer(int width, int height)
 {
-
+	resize(width, height);
 }
 
 void ScreenBuffer::resize(int width, int height)

--- a/TUI/Rendering/ScreenBuffer.cpp
+++ b/TUI/Rendering/ScreenBuffer.cpp
@@ -1,0 +1,81 @@
+#include "Rendering/ScreenBuffer.h"
+
+ScreenBuffer::ScreenBuffer()
+{
+
+}
+
+ScreenBuffer::ScreenBuffer(int width, int height)
+{
+
+}
+
+void ScreenBuffer::resize(int width, int height)
+{
+
+}
+
+void ScreenBuffer::clear(const Style& style = Style())
+{
+
+}
+
+int ScreenBuffer::getWidth() const
+{
+
+}
+
+int ScreenBuffer::getHeight() const
+{
+
+}
+
+bool ScreenBuffer::inBounds(int x, int y) const
+{
+
+}
+
+const ScreenCell& ScreenBuffer::getCell(int x, int y) const
+{
+
+}
+
+ScreenCell& ScreenBuffer::getCell(int x, int y)
+{
+
+}
+
+void ScreenBuffer::setCell(int x, int y, const ScreenCell& cell)
+{
+
+}
+
+void ScreenBuffer::writeChar(int x, int y, char glyph, const Style& style)
+{
+
+}
+
+void ScreenBuffer::writeString(int x, int y, const std::string& text, const Style& style)
+{
+
+}
+
+void ScreenBuffer::fillRect(const Rect& rect, char glyph, const Style& style)
+{
+
+}
+
+void ScreenBuffer::drawFrame(const Rect& rect, const Style& style)
+{
+
+}
+
+std::string ScreenBuffer::renderToString() const
+{
+
+}
+
+int ScreenBuffer::index(int x, int y) const
+{
+
+}

--- a/TUI/Rendering/ScreenBuffer.cpp
+++ b/TUI/Rendering/ScreenBuffer.cpp
@@ -32,7 +32,7 @@ void ScreenBuffer::clear(const Style& style = Style())
 
 int ScreenBuffer::getWidth() const
 {
-
+    return m_width;
 }
 
 int ScreenBuffer::getHeight() const

--- a/TUI/Rendering/ScreenBuffer.cpp
+++ b/TUI/Rendering/ScreenBuffer.cpp
@@ -113,7 +113,32 @@ void ScreenBuffer::fillRect(const Rect& rect, char glyph, const Style& style)
 
 void ScreenBuffer::drawFrame(const Rect& rect, const Style& style)
 {
+    if (rect.size.width < 2 || rect.size.height < 2)
+    {
+        return;
+    }
 
+    const int left = rect.position.x;
+    const int right = rect.position.x + rect.size.width - 1;
+    const int top = rect.position.y;
+    const int bottom = rect.position.y + rect.size.height - 1;
+
+    writeChar(left, top, '+', style);
+    writeChar(right, top, '+', style);
+    writeChar(left, bottom, '+', style);
+    writeChar(right, bottom, '+', style);
+
+    for (int x = left + 1; x < right; ++x)
+    {
+        writeChar(x, top, '-', style);
+        writeChar(x, bottom, '-', style);
+    }
+
+    for (int y = top + 1; y < bottom; ++y)
+    {
+        writeChar(left, y, '|', style);
+        writeChar(right, y, '|', style);
+    }
 }
 
 std::string ScreenBuffer::renderToString() const

--- a/TUI/Rendering/ScreenBuffer.h
+++ b/TUI/Rendering/ScreenBuffer.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "Core/Rect.h"
+#include "Rendering/ScreenCell.h"
+#include "Rendering/Style.h"
+
+class ScreenBuffer
+{
+public:
+    ScreenBuffer();
+    ScreenBuffer(int width, int height);
+
+    void resize(int width, int height);
+    void clear(const Style& style = Style());
+
+    int getWidth() const;
+    int getHeight() const;
+
+    bool inBounds(int x, int y) const;
+
+    const ScreenCell& getCell(int x, int y) const;
+    ScreenCell& getCell(int x, int y);
+
+    void setCell(int x, int y, const ScreenCell& cell);
+
+    void writeChar(int x, int y, char glyph, const Style& style);
+    void writeString(int x, int y, const std::string& text, const Style& style);
+
+    void fillRect(const Rect& rect, char glyph, const Style& style);
+    void drawFrame(const Rect& rect, const Style& style);
+
+    std::string renderToString() const;
+
+private:
+    int index(int x, int y) const;
+
+private:
+    int m_width = 0;
+    int m_height = 0;
+    std::vector<ScreenCell> m_cells;
+};

--- a/TUI/TUI.vcxproj
+++ b/TUI/TUI.vcxproj
@@ -131,7 +131,11 @@
     <ClInclude Include="Core\Point.h" />
     <ClInclude Include="Core\Rect.h" />
     <ClInclude Include="Core\Size.h" />
+    <ClInclude Include="Rendering\ScreenBuffer.h" />
     <ClInclude Include="Rendering\ScreenCell.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="Rendering\ScreenBuffer.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">


### PR DESCRIPTION
Implements the ScreenBuffer system, which represents the logical screen surface used by the rendering engine.

The ScreenBuffer manages a grid of ScreenCell objects and provides the foundational drawing operations required by later systems.

Responsibilities implemented:

- Logical screen width and height
- Resize support
- Clear screen
- Cell access (getCell / setCell)
- Bounds checking (inBounds)
- Character drawing (writeChar)
- Text drawing (writeString)
- Rectangle fill (fillRect)
- Frame drawing (drawFrame)
- Debug rendering (renderToString)

Implementation details:

- Screen data is stored as a flat std::vector<ScreenCell>.
- The index(x, y) helper converts 2D coordinates into a 1D vector index.
- All drawing operations validate coordinates using inBounds().
- Rectangle operations use the new Rect structure introduced in Phase 1 - 2.1.

Files added:

Rendering/
- ScreenBuffer.h
- ScreenBuffer.cpp

Definition of Done:

- ScreenBuffer compiles independently
- All core drawing operations implemented
- Buffer can render to text for debugging/testing
- Compatible with existing Core geometry types
- Ready for integration with later rendering systems

Closes #4