### PR TITLE
6 phase 1 - 2.5 implement renderer interface

### DIFF
--- a/TUI/Rendering/IRenderer.h
+++ b/TUI/Rendering/IRenderer.h
@@ -1,0 +1,38 @@
+#pragma once
+
+class ScreenBuffer;
+
+/*
+    IRenderer exists to separate the rendering engine from the specific
+    output system (console, SDLwindow, web terminal, etc)
+
+    IRenderer creates an abstraction layer between the TUI engine and 
+    the Rendering implementation. So this makes adding additional
+    backends clean and neat. 
+
+    With IRenderer the engine depends on the interface:
+    std::unique_ptr<IRenderer> renderer;
+
+    Then at runtime you decide which renderer to use:
+        renderer = std::make_unique<ConsoleRenderer>();
+        renderer = std::make_unique<SDLRenderer();
+        renderer = std::make_unique<WebRenderer();
+        etc...
+
+        The engine does not know or care what type of renderer is
+        behind it. The interface describes what a renderer must
+        be able to do. So any renderer must implement IRenderer 
+        functions.
+
+        Because the interface has been standardized, the engine code
+        doesn't change at all.The engine becomes platform independent. 
+*/
+
+class IRenderer
+{
+public:
+    virtual bool initialize() = 0;
+    virtual void shutdown() = 0;
+    virtual void present(const ScreenBuffer& frame) = 0;
+    virtual void resize(int width, int height) = 0;
+};

--- a/TUI/TUI.vcxproj
+++ b/TUI/TUI.vcxproj
@@ -131,6 +131,7 @@
     <ClInclude Include="Core\Point.h" />
     <ClInclude Include="Core\Rect.h" />
     <ClInclude Include="Core\Size.h" />
+    <ClInclude Include="Rendering\IRenderer.h" />
     <ClInclude Include="Rendering\ScreenBuffer.h" />
     <ClInclude Include="Rendering\ScreenCell.h" />
     <ClInclude Include="Rendering\Surface.h" />


### PR DESCRIPTION
Implements the IRenderer interface, which defines the abstraction layer between the TUI rendering engine and the underlying output system.

The renderer interface allows the engine to present a completed ScreenBuffer without being coupled to a specific rendering backend such as a console, SDL window, or other display system.

Responsibilities implemented:

- Renderer initialization
- Renderer shutdown
- Present a completed ScreenBuffer
- Handle renderer resize events

Implementation details:

- IRenderer is defined as a pure virtual interface.
- The interface provides the minimal contract required for any rendering backend.
- Rendering systems will implement this interface to display ScreenBuffer frames.
- The rendering engine interacts only with IRenderer, allowing different rendering implementations to be swapped without modifying engine code.

Interface methods:

- initialize()
- shutdown()
- present(const ScreenBuffer&)
- resize(int width, int height)

Files added:

Rendering/
- IRenderer.h

Definition of Done:

- IRenderer compiles independently
- Interface defines the minimal rendering contract
- No backend-specific logic exists in the interface
- Ready for renderer implementations (e.g., ConsoleRenderer) in later phases

Closes #6