### PR TITLE
32 phase 1a6   debug export

### DIFF
--- a/TUI/Utilities/Unicode/GraphemeSegmentation.cpp
+++ b/TUI/Utilities/Unicode/GraphemeSegmentation.cpp
@@ -1,0 +1,73 @@
+#include "Utilities/Unicode/GraphemeSegmentation.h"
+
+#include "Utilities/Unicode/UnicodeConversion.h"
+#include "Utilities/Unicode/UnicodeWidth.h"
+
+/*
+    Purpose:
+
+    Provides future-safe grapheme-like segmentation for writing and wrapping
+
+    Checklist:
+        - Add segmentation function
+        - Keep this as a helper layer, not part of ScreenCell
+*/
+
+namespace
+{
+    int toDisplayWidth(CellWidth width)
+    {
+        switch (width)
+        {
+        case CellWidth::Zero:
+            return 0;
+
+        case CellWidth::Two:
+            return 2;
+
+        case CellWidth::One:
+        default:
+            return 1;
+        }
+    }
+}
+
+namespace GraphemeSegmentation
+{
+    std::vector<TextCluster> segment(std::u32string_view text)
+    {
+        std::vector<TextCluster> clusters;
+        clusters.reserve(text.size());
+
+        for (char32_t codePoint : text)
+        {
+            codePoint = UnicodeConversion::sanitizeCodePoint(codePoint);
+
+            if (UnicodeWidth::isCombiningMark(codePoint))
+            {
+                if (!clusters.empty())
+                {
+                    clusters.back().codePoints.push_back(codePoint);
+                }
+                else
+                {
+                    TextCluster cluster;
+                    cluster.codePoints.push_back(codePoint);
+                    cluster.displayWidth = 0;
+                    clusters.push_back(cluster);
+                }
+
+                continue;
+            }
+
+            TextCluster cluster;
+            cluster.codePoints.push_back(codePoint);
+            cluster.displayWidth =
+                toDisplayWidth(UnicodeWidth::measureCodePointWidth(codePoint));
+
+            clusters.push_back(cluster);
+        }
+
+        return clusters;
+    }
+}

--- a/TUI/Utilities/Unicode/GraphemeSegmentation.h
+++ b/TUI/Utilities/Unicode/GraphemeSegmentation.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "Rendering/Text/TextCluster.h"
+
+/*
+    Purpose:
+
+    Provides future-safe grapheme segmentation for writing and wrapping
+*/
+
+namespace GraphemeSegmentation
+{
+    std::vector<TextCluster> segment(std::u32string_view text);
+}


### PR DESCRIPTION
Closes Phase 1 - Unicode 6

Upgrades ScreenBuffer debug/export functionality to preserve Unicode text.

Added:
- renderToU32String() for internal Unicode inspection
- renderToUtf8String() for logging and snapshot output

Updated:
- renderToString() now routes through UTF-8-safe export behavior

Removed:
- lossy char32_t -> char casting in debug output

Key improvements:
- enables accurate debugging of Unicode rendering behavior
- supports UTF-8-based snapshot testing and logging
- preserves backward compatibility for existing debug calls

Debug output now reflects the true internal Unicode state of the buffer.