### PR TITLE
12 phase 2   31 implement color abstraction

### DIFF
--- a/TUI/Rendering/Styles/Color.cpp
+++ b/TUI/Rendering/Styles/Color.cpp
@@ -1,0 +1,116 @@
+#include "Rendering/Styles/Color.h"
+
+Color::Color()
+    : m_kind(Kind::Default)
+{
+}
+
+Color Color::Default()
+{
+    return Color(Kind::Default);
+}
+
+Color Color::FromBasic(Basic basic)
+{
+    return Color(basic);
+}
+
+Color Color::FromIndexed256(std::uint8_t index)
+{
+    return Color(index);
+}
+
+Color Color::FromRgb(std::uint8_t red, std::uint8_t green, std::uint8_t blue)
+{
+    return Color(red, green, blue);
+}
+
+Color::Kind Color::kind() const
+{
+    return m_kind;
+}
+
+bool Color::isDefault() const
+{
+    return m_kind == Kind::Default;
+}
+
+bool Color::isBasic() const
+{
+    return m_kind == Kind::Basic;
+}
+
+bool Color::isIndexed256() const
+{
+    return m_kind == Kind::Indexed256;
+}
+
+bool Color::isRgb() const
+{
+    return m_kind == Kind::Rgb;
+}
+
+Color::Basic Color::basic() const
+{
+    return m_basic;
+}
+
+std::uint8_t Color::index256() const
+{
+    return m_index256;
+}
+
+std::uint8_t Color::red() const
+{
+    return m_red;
+}
+
+std::uint8_t Color::green() const
+{
+    return m_green;
+}
+
+std::uint8_t Color::blue() const
+{
+    return m_blue;
+}
+
+bool Color::operator==(const Color& other) const
+{
+    return m_kind == other.m_kind
+        && m_basic == other.m_basic
+        && m_index256 == other.m_index256
+        && m_red == other.m_red
+        && m_green == other.m_green
+        && m_blue == other.m_blue;
+}
+
+bool Color::operator!=(const Color& other) const
+{
+    return !(*this == other);
+}
+
+Color::Color(Kind kind)
+    : m_kind(kind)
+{
+}
+
+Color::Color(Basic basic)
+    : m_kind(Kind::Basic)
+    , m_basic(basic)
+{
+}
+
+Color::Color(std::uint8_t index256)
+    : m_kind(Kind::Indexed256)
+    , m_index256(index256)
+{
+}
+
+Color::Color(std::uint8_t red, std::uint8_t green, std::uint8_t blue)
+    : m_kind(Kind::Rgb)
+    , m_red(red)
+    , m_green(green)
+    , m_blue(blue)
+{
+}

--- a/TUI/TUI.vcxproj
+++ b/TUI/TUI.vcxproj
@@ -156,6 +156,7 @@
     <ClCompile Include="Rendering\ConsoleRenderer.cpp" />
     <ClCompile Include="Rendering\FrameDiff.cpp" />
     <ClCompile Include="Rendering\ScreenBuffer.cpp" />
+    <ClCompile Include="Rendering\Styles\Color.cpp" />
     <ClCompile Include="Rendering\Surface.cpp" />
     <ClCompile Include="Utilities\Unicode\GraphemeSegmentation.cpp" />
     <ClCompile Include="Utilities\Unicode\UnicodeConversion.cpp" />

--- a/TUI/TUI.vcxproj.filters
+++ b/TUI/TUI.vcxproj.filters
@@ -110,5 +110,8 @@
     <ClCompile Include="Utilities\Unicode\UnicodeWidth.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="Rendering\Styles\Color.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Closes: #12 

Implements the Color abstraction layer required for the Phase 2 style system.

Summary of Work:
- Introduced a backend-agnostic Color representation
- Supports:
  - Standard ANSI colors
  - Bright color variants
  - Extended representation (256-color / RGB ready)
- Designed Color to be future-proof without coupling to any specific renderer

Key Design Decisions:
- Color is treated as a value type, not tied to ANSI codes
- Internal representation allows future expansion without breaking API
- No direct dependency on ConsoleRenderer or platform-specific logic

Result:
The system can now express color intent independently of how it is rendered, enabling consistent styling across future backends.

Closes: Phase 2 - 3.1