### PR TITLE
63 phase 2   312 implement capability diagnostics model

### DIFF
--- a/TUI/Rendering/Capabilities/CapabilityReport.cpp
+++ b/TUI/Rendering/Capabilities/CapabilityReport.cpp
@@ -1,0 +1,328 @@
+#include "Rendering/Capabilities/CapabilityReport.h"
+
+CapabilityReport::CapabilityReport()
+{
+    const StyleFeature features[] =
+    {
+        StyleFeature::ForegroundColor,
+        StyleFeature::BackgroundColor,
+        StyleFeature::Bold,
+        StyleFeature::Dim,
+        StyleFeature::Underline,
+        StyleFeature::SlowBlink,
+        StyleFeature::FastBlink,
+        StyleFeature::Reverse,
+        StyleFeature::Invisible,
+        StyleFeature::Strike
+    };
+
+    const StyleAdaptationKind kinds[] =
+    {
+        StyleAdaptationKind::Direct,
+        StyleAdaptationKind::Downgraded,
+        StyleAdaptationKind::Approximated,
+        StyleAdaptationKind::Omitted,
+        StyleAdaptationKind::Emulated,
+        StyleAdaptationKind::LogicalOnly
+    };
+
+    for (StyleFeature feature : features)
+    {
+        for (StyleAdaptationKind kind : kinds)
+        {
+            StyleAdaptationCounter counter;
+            counter.feature = feature;
+            counter.kind = kind;
+            counter.count = 0;
+            m_counters.push_back(counter);
+        }
+    }
+}
+
+void CapabilityReport::setCapabilities(const ConsoleCapabilities& capabilities)
+{
+    m_capabilities = capabilities;
+}
+
+void CapabilityReport::setPolicy(const StylePolicy& policy)
+{
+    m_policy = policy;
+}
+
+const ConsoleCapabilities& CapabilityReport::capabilities() const
+{
+    return m_capabilities;
+}
+
+const StylePolicy& CapabilityReport::policy() const
+{
+    return m_policy;
+}
+
+void CapabilityReport::recordDirect(StyleFeature feature)
+{
+    increment(feature, StyleAdaptationKind::Direct);
+}
+
+void CapabilityReport::recordDowngraded(StyleFeature feature)
+{
+    increment(feature, StyleAdaptationKind::Downgraded);
+}
+
+void CapabilityReport::recordApproximated(StyleFeature feature)
+{
+    increment(feature, StyleAdaptationKind::Approximated);
+}
+
+void CapabilityReport::recordOmitted(StyleFeature feature)
+{
+    increment(feature, StyleAdaptationKind::Omitted);
+}
+
+void CapabilityReport::recordEmulated(StyleFeature feature)
+{
+    increment(feature, StyleAdaptationKind::Emulated);
+}
+
+void CapabilityReport::recordLogicalOnly(StyleFeature feature)
+{
+    increment(feature, StyleAdaptationKind::LogicalOnly);
+}
+
+void CapabilityReport::addExample(
+    StyleFeature feature,
+    StyleAdaptationKind kind,
+    const std::string& detail)
+{
+    StyleAdaptationExample example;
+    example.feature = feature;
+    example.kind = kind;
+    example.detail = detail;
+    m_examples.push_back(example);
+}
+
+std::size_t CapabilityReport::getCount(StyleFeature feature, StyleAdaptationKind kind) const
+{
+    for (const StyleAdaptationCounter& counter : m_counters)
+    {
+        if (counter.feature == feature && counter.kind == kind)
+        {
+            return counter.count;
+        }
+    }
+
+    return 0;
+}
+
+const std::vector<StyleAdaptationCounter>& CapabilityReport::counters() const
+{
+    return m_counters;
+}
+
+const std::vector<StyleAdaptationExample>& CapabilityReport::examples() const
+{
+    return m_examples;
+}
+
+void CapabilityReport::clearRuntimeData()
+{
+    for (StyleAdaptationCounter& counter : m_counters)
+    {
+        counter.count = 0;
+    }
+
+    m_examples.clear();
+}
+
+bool CapabilityReport::hasRuntimeData() const
+{
+    for (const StyleAdaptationCounter& counter : m_counters)
+    {
+        if (counter.count > 0)
+        {
+            return true;
+        }
+    }
+
+    return !m_examples.empty();
+}
+
+const char* CapabilityReport::toString(ConsoleColorTier tier)
+{
+    switch (tier)
+    {
+    case ConsoleColorTier::None:
+        return "None";
+
+    case ConsoleColorTier::Basic16:
+        return "Basic16";
+
+    case ConsoleColorTier::Indexed256:
+        return "Indexed256";
+
+    case ConsoleColorTier::TrueColor:
+        return "TrueColor";
+
+    default:
+        return "Unknown";
+    }
+}
+
+const char* CapabilityReport::toString(ConsoleFeatureSupport support)
+{
+    switch (support)
+    {
+    case ConsoleFeatureSupport::Unsupported:
+        return "Unsupported";
+
+    case ConsoleFeatureSupport::Supported:
+        return "Supported";
+
+    case ConsoleFeatureSupport::Emulated:
+        return "Emulated";
+
+    case ConsoleFeatureSupport::Unknown:
+        return "Unknown";
+
+    default:
+        return "Unknown";
+    }
+}
+
+const char* CapabilityReport::toString(ColorRenderMode mode)
+{
+    switch (mode)
+    {
+    case ColorRenderMode::Direct:
+        return "Direct";
+
+    case ColorRenderMode::DowngradeToBasic:
+        return "DowngradeToBasic";
+
+    case ColorRenderMode::DowngradeToIndexed256:
+        return "DowngradeToIndexed256";
+
+    case ColorRenderMode::Omit:
+        return "Omit";
+
+    default:
+        return "Unknown";
+    }
+}
+
+const char* CapabilityReport::toString(TextAttributeRenderMode mode)
+{
+    switch (mode)
+    {
+    case TextAttributeRenderMode::Direct:
+        return "Direct";
+
+    case TextAttributeRenderMode::Omit:
+        return "Omit";
+
+    default:
+        return "Unknown";
+    }
+}
+
+const char* CapabilityReport::toString(BlinkRenderMode mode)
+{
+    switch (mode)
+    {
+    case BlinkRenderMode::Direct:
+        return "Direct";
+
+    case BlinkRenderMode::Omit:
+        return "Omit";
+
+    case BlinkRenderMode::Emulate:
+        return "Emulate";
+
+    default:
+        return "Unknown";
+    }
+}
+
+const char* CapabilityReport::toString(StyleFeature feature)
+{
+    switch (feature)
+    {
+    case StyleFeature::ForegroundColor:
+        return "ForegroundColor";
+
+    case StyleFeature::BackgroundColor:
+        return "BackgroundColor";
+
+    case StyleFeature::Bold:
+        return "Bold";
+
+    case StyleFeature::Dim:
+        return "Dim";
+
+    case StyleFeature::Underline:
+        return "Underline";
+
+    case StyleFeature::SlowBlink:
+        return "SlowBlink";
+
+    case StyleFeature::FastBlink:
+        return "FastBlink";
+
+    case StyleFeature::Reverse:
+        return "Reverse";
+
+    case StyleFeature::Invisible:
+        return "Invisible";
+
+    case StyleFeature::Strike:
+        return "Strike";
+
+    default:
+        return "Unknown";
+    }
+}
+
+const char* CapabilityReport::toString(StyleAdaptationKind kind)
+{
+    switch (kind)
+    {
+    case StyleAdaptationKind::Direct:
+        return "Direct";
+
+    case StyleAdaptationKind::Downgraded:
+        return "Downgraded";
+
+    case StyleAdaptationKind::Approximated:
+        return "Approximated";
+
+    case StyleAdaptationKind::Omitted:
+        return "Omitted";
+
+    case StyleAdaptationKind::Emulated:
+        return "Emulated";
+
+    case StyleAdaptationKind::LogicalOnly:
+        return "LogicalOnly";
+
+    default:
+        return "Unknown";
+    }
+}
+
+void CapabilityReport::increment(StyleFeature feature, StyleAdaptationKind kind)
+{
+    for (StyleAdaptationCounter& counter : m_counters)
+    {
+        if (counter.feature == feature && counter.kind == kind)
+        {
+            ++counter.count;
+            return;
+        }
+    }
+
+    StyleAdaptationCounter counter;
+    counter.feature = feature;
+    counter.kind = kind;
+    counter.count = 1;
+    m_counters.push_back(counter);
+}

--- a/TUI/Rendering/Capabilities/CapabilityReport.h
+++ b/TUI/Rendering/Capabilities/CapabilityReport.h
@@ -1,0 +1,112 @@
+#pragma once
+
+#include <cstddef>
+#include <string>
+#include <vector>
+
+#include "Rendering/Capabilities/ConsoleCapabilities.h"
+#include "Rendering/Styles/StylePolicy.h"
+
+/*
+    Purpose:
+
+    CapabilityReport is a structured diagnostics model for renderer capability
+    reporting and style adaptation reporting.
+
+    It does not make rendering decisions.
+    It only records:
+        - detected backend capabilities
+        - selected renderer adaptation policy
+        - summary counts of adaptation outcomes
+        - optional representative examples
+
+    This model is intended to be optional and non-invasive.
+*/
+
+enum class StyleAdaptationKind
+{
+    Direct,
+    Downgraded,
+    Approximated,
+    Omitted,
+    Emulated,
+    LogicalOnly
+};
+
+enum class StyleFeature
+{
+    ForegroundColor,
+    BackgroundColor,
+    Bold,
+    Dim,
+    Underline,
+    SlowBlink,
+    FastBlink,
+    Reverse,
+    Invisible,
+    Strike
+};
+
+struct StyleAdaptationCounter
+{
+    StyleFeature feature = StyleFeature::ForegroundColor;
+    StyleAdaptationKind kind = StyleAdaptationKind::Direct;
+    std::size_t count = 0;
+};
+
+struct StyleAdaptationExample
+{
+    StyleFeature feature = StyleFeature::ForegroundColor;
+    StyleAdaptationKind kind = StyleAdaptationKind::Direct;
+    std::string detail;
+};
+
+class CapabilityReport
+{
+public:
+    CapabilityReport();
+
+    void setCapabilities(const ConsoleCapabilities& capabilities);
+    void setPolicy(const StylePolicy& policy);
+
+    const ConsoleCapabilities& capabilities() const;
+    const StylePolicy& policy() const;
+
+    void recordDirect(StyleFeature feature);
+    void recordDowngraded(StyleFeature feature);
+    void recordApproximated(StyleFeature feature);
+    void recordOmitted(StyleFeature feature);
+    void recordEmulated(StyleFeature feature);
+    void recordLogicalOnly(StyleFeature feature);
+
+    void addExample(
+        StyleFeature feature,
+        StyleAdaptationKind kind,
+        const std::string& detail);
+
+    std::size_t getCount(StyleFeature feature, StyleAdaptationKind kind) const;
+
+    const std::vector<StyleAdaptationCounter>& counters() const;
+    const std::vector<StyleAdaptationExample>& examples() const;
+
+    void clearRuntimeData();
+    bool hasRuntimeData() const;
+
+    static const char* toString(ConsoleColorTier tier);
+    static const char* toString(ConsoleFeatureSupport support);
+    static const char* toString(ColorRenderMode mode);
+    static const char* toString(TextAttributeRenderMode mode);
+    static const char* toString(BlinkRenderMode mode);
+    static const char* toString(StyleFeature feature);
+    static const char* toString(StyleAdaptationKind kind);
+
+private:
+    void increment(StyleFeature feature, StyleAdaptationKind kind);
+
+private:
+    ConsoleCapabilities m_capabilities{};
+    StylePolicy m_policy{};
+
+    std::vector<StyleAdaptationCounter> m_counters;
+    std::vector<StyleAdaptationExample> m_examples;
+};

--- a/TUI/TUI.vcxproj
+++ b/TUI/TUI.vcxproj
@@ -134,6 +134,7 @@
     <ClInclude Include="Core\Rect.h" />
     <ClInclude Include="Core\Size.h" />
     <ClInclude Include="Rendering\Backends\ConsoleCapabilityDetector.h" />
+    <ClInclude Include="Rendering\Capabilities\CapabilityReport.h" />
     <ClInclude Include="Rendering\Capabilities\ConsoleCapabilities.h" />
     <ClInclude Include="Rendering\ConsoleRenderer.h" />
     <ClInclude Include="Rendering\FrameDiff.h" />
@@ -163,6 +164,7 @@
     <ClCompile Include="App\ScreenManager.cpp" />
     <ClCompile Include="main.cpp" />
     <ClCompile Include="Rendering\Backends\ConsoleCapabilityDetector.cpp" />
+    <ClCompile Include="Rendering\Capabilities\CapabilityReport.cpp" />
     <ClCompile Include="Rendering\Capabilities\ConsoleCapabilities.cpp" />
     <ClCompile Include="Rendering\ConsoleRenderer.cpp" />
     <ClCompile Include="Rendering\FrameDiff.cpp" />

--- a/TUI/TUI.vcxproj.filters
+++ b/TUI/TUI.vcxproj.filters
@@ -102,6 +102,12 @@
     <ClInclude Include="Rendering\Capabilities\ConsoleCapabilities.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="Rendering\Backends\ConsoleCapabilityDetector.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Rendering\Capabilities\CapabilityReport.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Rendering\ScreenBuffer.cpp">
@@ -153,6 +159,12 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="Rendering\Capabilities\ConsoleCapabilities.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Rendering\Backends\ConsoleCapabilityDetector.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Rendering\Capabilities\CapabilityReport.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
CapabilityReport should answer three kinds of questions:

What did the backend say it could do?
What policy did the renderer choose from that?
What actually happened to style fields at presentation time:
direct
downgraded
approximated
omitted
emulated
preserved logically but not physically rendered

To keep it useful and non-invasive, this design separates:

static session-level data
detected capabilities
selected renderer policy
runtime counters
how often each adaptation happened
optional representative examples
short notes/examples developers can inspect later

This makes it easy to write to a file in the next phase without forcing diagnostics into normal rendering.