### PR TITLE
64 phase 2   313 implement renderer diagnostics logging

### DIFF
--- a/TUI/Rendering/Diagnostics/RenderDiagnostics.cpp
+++ b/TUI/Rendering/Diagnostics/RenderDiagnostics.cpp
@@ -1,0 +1,51 @@
+#include "Rendering/Diagnostics/RenderDiagnostics.h"
+
+RenderDiagnostics::RenderDiagnostics() = default;
+
+void RenderDiagnostics::setEnabled(bool enabled)
+{
+    m_enabled = enabled;
+}
+
+bool RenderDiagnostics::isEnabled() const
+{
+    return m_enabled;
+}
+
+void RenderDiagnostics::setOutputPath(const std::string& outputPath)
+{
+    if (!outputPath.empty())
+    {
+        m_outputPath = outputPath;
+    }
+}
+
+const std::string& RenderDiagnostics::outputPath() const
+{
+    return m_outputPath;
+}
+
+void RenderDiagnostics::setAppendMode(bool appendMode)
+{
+    m_appendMode = appendMode;
+}
+
+bool RenderDiagnostics::appendMode() const
+{
+    return m_appendMode;
+}
+
+CapabilityReport& RenderDiagnostics::report()
+{
+    return m_report;
+}
+
+const CapabilityReport& RenderDiagnostics::report() const
+{
+    return m_report;
+}
+
+void RenderDiagnostics::resetRuntimeData()
+{
+    m_report.clearRuntimeData();
+}

--- a/TUI/Rendering/Diagnostics/RenderDiagnostics.h
+++ b/TUI/Rendering/Diagnostics/RenderDiagnostics.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <string>
+
+#include "Rendering/Capabilities/CapabilityReport.h"
+
+/*
+    Purpose:
+
+    RenderDiagnostics is the optional renderer-side diagnostics state holder.
+
+    It does not control rendering.
+    It only stores:
+        - whether diagnostics are enabled
+        - where diagnostics should be written
+        - whether the file should be appended or replaced
+        - the structured capability/adaptation report data
+
+    Renderer code can populate this object during initialization and rendering,
+    and a writer can later serialize it to a human-readable file.
+*/
+
+class RenderDiagnostics
+{
+public:
+    RenderDiagnostics();
+
+    void setEnabled(bool enabled);
+    bool isEnabled() const;
+
+    void setOutputPath(const std::string& outputPath);
+    const std::string& outputPath() const;
+
+    void setAppendMode(bool appendMode);
+    bool appendMode() const;
+
+    CapabilityReport& report();
+    const CapabilityReport& report() const;
+
+    void resetRuntimeData();
+
+private:
+    bool m_enabled = false;
+    bool m_appendMode = false;
+    std::string m_outputPath = "render_diagnostics_report.txt";
+    CapabilityReport m_report;
+};

--- a/TUI/Rendering/Diagnostics/RenderDiagnosticsWriter.cpp
+++ b/TUI/Rendering/Diagnostics/RenderDiagnosticsWriter.cpp
@@ -1,0 +1,157 @@
+#include "Rendering/Diagnostics/RenderDiagnosticsWriter.h"
+
+#include <fstream>
+#include <ios>
+
+namespace
+{
+    void writeSectionHeader(std::ofstream& out, const char* title)
+    {
+        out << title << "\n";
+
+        for (const char* p = title; *p != '\0'; ++p)
+        {
+            out << '=';
+        }
+
+        out << "\n\n";
+    }
+}
+
+bool RenderDiagnosticsWriter::write(const RenderDiagnostics& diagnostics)
+{
+    if (!diagnostics.isEnabled())
+    {
+        return true;
+    }
+
+    const std::ios::openmode mode =
+        std::ios::out |
+        (diagnostics.appendMode() ? std::ios::app : std::ios::trunc);
+
+    std::ofstream out(diagnostics.outputPath(), mode);
+    if (!out)
+    {
+        return false;
+    }
+
+    const CapabilityReport& report = diagnostics.report();
+    const ConsoleCapabilities& capabilities = report.capabilities();
+    const StylePolicy& policy = report.policy();
+
+    writeSectionHeader(out, "Render Diagnostics Report");
+
+    out << "Configuration\n";
+    out << "-------------\n";
+    out << "Output path: " << diagnostics.outputPath() << "\n";
+    out << "Append mode: " << (diagnostics.appendMode() ? "true" : "false") << "\n";
+    out << "Diagnostics enabled: " << (diagnostics.isEnabled() ? "true" : "false") << "\n\n";
+
+    out << "Detected Backend Capabilities\n";
+    out << "-----------------------------\n";
+    out << "Virtual terminal processing: "
+        << (capabilities.virtualTerminalProcessing ? "true" : "false") << "\n";
+    out << "Unicode output: "
+        << (capabilities.unicodeOutput ? "true" : "false") << "\n";
+    out << "Color tier: "
+        << CapabilityReport::toString(capabilities.colorTier) << "\n";
+    out << "Bold: "
+        << CapabilityReport::toString(capabilities.bold) << "\n";
+    out << "Dim: "
+        << CapabilityReport::toString(capabilities.dim) << "\n";
+    out << "Underline: "
+        << CapabilityReport::toString(capabilities.underline) << "\n";
+    out << "Reverse: "
+        << CapabilityReport::toString(capabilities.reverse) << "\n";
+    out << "Invisible: "
+        << CapabilityReport::toString(capabilities.invisible) << "\n";
+    out << "Strike: "
+        << CapabilityReport::toString(capabilities.strike) << "\n";
+    out << "Slow blink: "
+        << CapabilityReport::toString(capabilities.slowBlink) << "\n";
+    out << "Fast blink: "
+        << CapabilityReport::toString(capabilities.fastBlink) << "\n\n";
+
+    out << "Resolved Renderer Adaptation Policy\n";
+    out << "----------------------------------\n";
+    out << "Basic colors: "
+        << CapabilityReport::toString(policy.basicColorMode()) << "\n";
+    out << "Indexed256 colors: "
+        << CapabilityReport::toString(policy.indexed256ColorMode()) << "\n";
+    out << "RGB colors: "
+        << CapabilityReport::toString(policy.rgbColorMode()) << "\n";
+    out << "Bold: "
+        << CapabilityReport::toString(policy.boldMode()) << "\n";
+    out << "Dim: "
+        << CapabilityReport::toString(policy.dimMode()) << "\n";
+    out << "Underline: "
+        << CapabilityReport::toString(policy.underlineMode()) << "\n";
+    out << "Reverse: "
+        << CapabilityReport::toString(policy.reverseMode()) << "\n";
+    out << "Invisible: "
+        << CapabilityReport::toString(policy.invisibleMode()) << "\n";
+    out << "Strike: "
+        << CapabilityReport::toString(policy.strikeMode()) << "\n";
+    out << "Slow blink: "
+        << CapabilityReport::toString(policy.slowBlinkMode()) << "\n";
+    out << "Fast blink: "
+        << CapabilityReport::toString(policy.fastBlinkMode()) << "\n\n";
+
+    out << "Adaptation Summary Counts\n";
+    out << "-------------------------\n";
+
+    for (const StyleAdaptationCounter& counter : report.counters())
+    {
+        if (counter.count == 0)
+        {
+            continue;
+        }
+
+        out
+            << CapabilityReport::toString(counter.feature)
+            << " / "
+            << CapabilityReport::toString(counter.kind)
+            << ": "
+            << counter.count
+            << "\n";
+    }
+
+    if (!report.hasRuntimeData())
+    {
+        out << "No runtime adaptation events were recorded.\n";
+    }
+
+    out << "\n";
+
+    out << "Representative Examples\n";
+    out << "-----------------------\n";
+
+    if (report.examples().empty())
+    {
+        out << "No examples recorded.\n";
+    }
+    else
+    {
+        for (const StyleAdaptationExample& example : report.examples())
+        {
+            out
+                << "["
+                << CapabilityReport::toString(example.feature)
+                << " / "
+                << CapabilityReport::toString(example.kind)
+                << "] "
+                << example.detail
+                << "\n";
+        }
+    }
+
+    out << "\n";
+
+    out << "Notes\n";
+    out << "-----\n";
+    out << "- Diagnostics describe renderer behavior only.\n";
+    out << "- Logical Style data stored in ScreenBuffer is not mutated by diagnostics or adaptation.\n";
+    out << "- Output differences between authored style and visible result may be caused by downgrade, omission, or deferred emulation.\n";
+
+    return true;
+}

--- a/TUI/Rendering/Diagnostics/RenderDiagnosticsWriter.h
+++ b/TUI/Rendering/Diagnostics/RenderDiagnosticsWriter.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "Rendering/Diagnostics/RenderDiagnostics.h"
+
+/*
+    Purpose:
+
+    RenderDiagnosticsWriter serializes RenderDiagnostics to a readable text file.
+
+    It is intentionally simple:
+        - no console output
+        - no rendering logic
+        - no mutation of renderer policy
+        - stable text format suitable for developer and author inspection
+*/
+
+class RenderDiagnosticsWriter
+{
+public:
+    static bool write(const RenderDiagnostics& diagnostics);
+};

--- a/TUI/TUI.vcxproj
+++ b/TUI/TUI.vcxproj
@@ -137,6 +137,8 @@
     <ClInclude Include="Rendering\Capabilities\CapabilityReport.h" />
     <ClInclude Include="Rendering\Capabilities\ConsoleCapabilities.h" />
     <ClInclude Include="Rendering\ConsoleRenderer.h" />
+    <ClInclude Include="Rendering\Diagnostics\RenderDiagnostics.h" />
+    <ClInclude Include="Rendering\Diagnostics\RenderDiagnosticsWriter.h" />
     <ClInclude Include="Rendering\FrameDiff.h" />
     <ClInclude Include="Rendering\IRenderer.h" />
     <ClInclude Include="Rendering\ScreenBuffer.h" />
@@ -167,6 +169,8 @@
     <ClCompile Include="Rendering\Capabilities\CapabilityReport.cpp" />
     <ClCompile Include="Rendering\Capabilities\ConsoleCapabilities.cpp" />
     <ClCompile Include="Rendering\ConsoleRenderer.cpp" />
+    <ClCompile Include="Rendering\Diagnostics\RenderDiagnostics.cpp" />
+    <ClCompile Include="Rendering\Diagnostics\RenderDiagnosticsWriter.cpp" />
     <ClCompile Include="Rendering\FrameDiff.cpp" />
     <ClCompile Include="Rendering\ScreenBuffer.cpp" />
     <ClCompile Include="Rendering\Styles\Color.cpp" />


### PR DESCRIPTION
Provide a file-based diagnostics output that authors can inspect after startup or render activity.

Purpose:
- save capability and adaptation information to a human-readable file
- help page authors understand why display output differs from authored intent
- make backend limitations visible during development and testing

Possible contents:
- renderer/backend identity
- console mode / VT status
- detected capability flags
- supported color tier
- supported decoration features
- downgrade rules currently in effect
- emulation rules currently in effect
- examples of unsupported style requests encountered during rendering
- summary of omitted or approximated style effects

Examples of reported events:
- RGB foreground requested, downgraded to nearest 16-color value
- underline requested, omitted because backend does not support underline
- blink requested, not emitted because blink is disabled or unsupported
- reverse requested, emitted directly
- logical style preserved in ScreenBuffer, physical output adapted in renderer

Requirements:
- diagnostics logging must be separate from normal render output
- diagnostics file generation must not clutter console output
- diagnostics logging should be optional or configurable
- diagnostics logging must not require page authors to change how they author styles
- diagnostics file format should be simple, readable, and stable
- renderer should be able to append events or write a fresh report per run according to configuration
