### PR TITLE
88 phase 2 add themecolor multi fidelity semantic color

### DIFF
--- a/TUI/Rendering/Styles/Style.cpp
+++ b/TUI/Rendering/Styles/Style.cpp
@@ -1,5 +1,46 @@
 #include "Rendering/Styles/Style.h"
 
+Style::StyleColorValue::StyleColorValue(const Color& color)
+    : m_concreteColor(color)
+{
+}
+
+Style::StyleColorValue::StyleColorValue(const ThemeColor& themeColor)
+    : m_themeColor(themeColor)
+{
+}
+
+bool Style::StyleColorValue::hasConcreteColor() const
+{
+    return m_concreteColor.has_value();
+}
+
+bool Style::StyleColorValue::hasThemeColor() const
+{
+    return m_themeColor.has_value();
+}
+
+const std::optional<Color>& Style::StyleColorValue::concreteColor() const
+{
+    return m_concreteColor;
+}
+
+const std::optional<ThemeColor>& Style::StyleColorValue::themeColor() const
+{
+    return m_themeColor;
+}
+
+bool Style::StyleColorValue::operator==(const StyleColorValue& other) const
+{
+    return m_concreteColor == other.m_concreteColor
+        && m_themeColor == other.m_themeColor;
+}
+
+bool Style::StyleColorValue::operator!=(const StyleColorValue& other) const
+{
+    return !(*this == other);
+}
+
 Style::Style() = default;
 
 const std::optional<Color>& Style::foreground() const
@@ -10,6 +51,26 @@ const std::optional<Color>& Style::foreground() const
 const std::optional<Color>& Style::background() const
 {
     return m_background;
+}
+
+const std::optional<ThemeColor>& Style::foregroundThemeColor() const
+{
+    return m_foregroundThemeColor;
+}
+
+const std::optional<ThemeColor>& Style::backgroundThemeColor() const
+{
+    return m_backgroundThemeColor;
+}
+
+const std::optional<Style::StyleColorValue>& Style::foregroundColorValue() const
+{
+    return m_foregroundColorValue;
+}
+
+const std::optional<Style::StyleColorValue>& Style::backgroundColorValue() const
+{
+    return m_backgroundColorValue;
 }
 
 bool Style::bold() const
@@ -102,6 +163,26 @@ bool Style::hasBackground() const
     return m_background.has_value();
 }
 
+bool Style::hasForegroundThemeColor() const
+{
+    return m_foregroundThemeColor.has_value();
+}
+
+bool Style::hasBackgroundThemeColor() const
+{
+    return m_backgroundThemeColor.has_value();
+}
+
+bool Style::hasForegroundColorValue() const
+{
+    return m_foregroundColorValue.has_value();
+}
+
+bool Style::hasBackgroundColorValue() const
+{
+    return m_backgroundColorValue.has_value();
+}
+
 bool Style::hasBold() const
 {
     return m_bold.has_value();
@@ -146,6 +227,10 @@ bool Style::isEmpty() const
 {
     return !m_foreground.has_value()
         && !m_background.has_value()
+        && !m_foregroundThemeColor.has_value()
+        && !m_backgroundThemeColor.has_value()
+        && !m_foregroundColorValue.has_value()
+        && !m_backgroundColorValue.has_value()
         && !m_bold.has_value()
         && !m_dim.has_value()
         && !m_underline.has_value()
@@ -160,6 +245,17 @@ Style Style::withForeground(const Color& color) const
 {
     Style copy = *this;
     copy.m_foreground = color;
+    copy.m_foregroundThemeColor.reset();
+    copy.m_foregroundColorValue = StyleColorValue(color);
+    return copy;
+}
+
+Style Style::withForeground(const ThemeColor& themeColor) const
+{
+    Style copy = *this;
+    copy.m_foreground.reset();
+    copy.m_foregroundThemeColor = themeColor;
+    copy.m_foregroundColorValue = StyleColorValue(themeColor);
     return copy;
 }
 
@@ -167,6 +263,17 @@ Style Style::withBackground(const Color& color) const
 {
     Style copy = *this;
     copy.m_background = color;
+    copy.m_backgroundThemeColor.reset();
+    copy.m_backgroundColorValue = StyleColorValue(color);
+    return copy;
+}
+
+Style Style::withBackground(const ThemeColor& themeColor) const
+{
+    Style copy = *this;
+    copy.m_background.reset();
+    copy.m_backgroundThemeColor = themeColor;
+    copy.m_backgroundColorValue = StyleColorValue(themeColor);
     return copy;
 }
 
@@ -174,6 +281,8 @@ Style Style::withoutForeground() const
 {
     Style copy = *this;
     copy.m_foreground.reset();
+    copy.m_foregroundThemeColor.reset();
+    copy.m_foregroundColorValue.reset();
     return copy;
 }
 
@@ -181,6 +290,8 @@ Style Style::withoutBackground() const
 {
     Style copy = *this;
     copy.m_background.reset();
+    copy.m_backgroundThemeColor.reset();
+    copy.m_backgroundColorValue.reset();
     return copy;
 }
 
@@ -300,6 +411,10 @@ bool Style::operator==(const Style& other) const
 {
     return m_foreground == other.m_foreground
         && m_background == other.m_background
+        && m_foregroundThemeColor == other.m_foregroundThemeColor
+        && m_backgroundThemeColor == other.m_backgroundThemeColor
+        && m_foregroundColorValue == other.m_foregroundColorValue
+        && m_backgroundColorValue == other.m_backgroundColorValue
         && m_bold == other.m_bold
         && m_dim == other.m_dim
         && m_underline == other.m_underline

--- a/TUI/Rendering/Styles/Style.h
+++ b/TUI/Rendering/Styles/Style.h
@@ -3,17 +3,45 @@
 #include <optional>
 
 #include "Rendering/Styles/Color.h"
+#include "Rendering/Styles/ThemeColor.h"
 
 class Style
 {
 public:
     using AttributeState = std::optional<bool>;
 
+    class StyleColorValue
+    {
+    public:
+        StyleColorValue() = default;
+        StyleColorValue(const Color& color);
+        StyleColorValue(const ThemeColor& themeColor);
+
+        bool hasConcreteColor() const;
+        bool hasThemeColor() const;
+
+        const std::optional<Color>& concreteColor() const;
+        const std::optional<ThemeColor>& themeColor() const;
+
+        bool operator==(const StyleColorValue& other) const;
+        bool operator!=(const StyleColorValue& other) const;
+
+    private:
+        std::optional<Color> m_concreteColor;
+        std::optional<ThemeColor> m_themeColor;
+    };
+
 public:
     Style();
 
     const std::optional<Color>& foreground() const;
     const std::optional<Color>& background() const;
+
+    const std::optional<ThemeColor>& foregroundThemeColor() const;
+    const std::optional<ThemeColor>& backgroundThemeColor() const;
+
+    const std::optional<StyleColorValue>& foregroundColorValue() const;
+    const std::optional<StyleColorValue>& backgroundColorValue() const;
 
     bool bold() const;
     bool dim() const;
@@ -36,6 +64,12 @@ public:
     bool hasForeground() const;
     bool hasBackground() const;
 
+    bool hasForegroundThemeColor() const;
+    bool hasBackgroundThemeColor() const;
+
+    bool hasForegroundColorValue() const;
+    bool hasBackgroundColorValue() const;
+
     bool hasBold() const;
     bool hasDim() const;
     bool hasUnderline() const;
@@ -48,7 +82,10 @@ public:
     bool isEmpty() const;
 
     Style withForeground(const Color& color) const;
+    Style withForeground(const ThemeColor& themeColor) const;
+
     Style withBackground(const Color& color) const;
+    Style withBackground(const ThemeColor& themeColor) const;
 
     Style withoutForeground() const;
     Style withoutBackground() const;
@@ -77,6 +114,12 @@ public:
 private:
     std::optional<Color> m_foreground;
     std::optional<Color> m_background;
+
+    std::optional<ThemeColor> m_foregroundThemeColor;
+    std::optional<ThemeColor> m_backgroundThemeColor;
+
+    std::optional<StyleColorValue> m_foregroundColorValue;
+    std::optional<StyleColorValue> m_backgroundColorValue;
 
     AttributeState m_bold;
     AttributeState m_dim;

--- a/TUI/Rendering/Styles/StyleBuilder.cpp
+++ b/TUI/Rendering/Styles/StyleBuilder.cpp
@@ -22,7 +22,17 @@ namespace style
         return Style().withForeground(color);
     }
 
+    Style Fg(const ThemeColor& color)
+    {
+        return Style().withForeground(color);
+    }
+
     Style Bg(const Color& color)
+    {
+        return Style().withBackground(color);
+    }
+
+    Style Bg(const ThemeColor& color)
     {
         return Style().withBackground(color);
     }

--- a/TUI/Rendering/Styles/StyleBuilder.h
+++ b/TUI/Rendering/Styles/StyleBuilder.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Rendering/Styles/Style.h"
+#include "Rendering/Styles/ThemeColor.h"
 
 namespace style
 {
@@ -118,7 +119,10 @@ namespace style
     inline constexpr StrikeAtom Strike{};
 
     Style Fg(const Color& color);
+    Style Fg(const ThemeColor& color);
+
     Style Bg(const Color& color);
+    Style Bg(const ThemeColor& color);
 }
 
 // NOTE:

--- a/TUI/Rendering/Styles/StyleMerge.cpp
+++ b/TUI/Rendering/Styles/StyleMerge.cpp
@@ -50,16 +50,30 @@ namespace
     {
         if (foreground)
         {
-            if (source.hasForeground())
+            if (source.hasForegroundColorValue())
             {
-                result = result.withForeground(*source.foreground());
+                if (source.hasForeground())
+                {
+                    result = result.withForeground(*source.foreground());
+                }
+                else if (source.hasForegroundThemeColor())
+                {
+                    result = result.withForeground(*source.foregroundThemeColor());
+                }
             }
         }
         else
         {
-            if (source.hasBackground())
+            if (source.hasBackgroundColorValue())
             {
-                result = result.withBackground(*source.background());
+                if (source.hasBackground())
+                {
+                    result = result.withBackground(*source.background());
+                }
+                else if (source.hasBackgroundThemeColor())
+                {
+                    result = result.withBackground(*source.backgroundThemeColor());
+                }
             }
         }
     }

--- a/TUI/Rendering/Styles/StylePolicy.cpp
+++ b/TUI/Rendering/Styles/StylePolicy.cpp
@@ -71,10 +71,36 @@ ResolvedStyle StylePolicy::resolve(const Style& style) const
             result.presentedStyle = result.presentedStyle.withoutForeground();
         }
     }
+    else if (result.presentedStyle.hasForegroundThemeColor())
+    {
+        const std::optional<Color> authoredBasic = resolveThemeColorToBasic(*result.presentedStyle.foregroundThemeColor());
+        const std::optional<Color> resolved = resolveBasicAuthoredColor(authoredBasic);
+        if (resolved.has_value())
+        {
+            result.presentedStyle = result.presentedStyle.withForeground(*resolved);
+        }
+        else
+        {
+            result.presentedStyle = result.presentedStyle.withoutForeground();
+        }
+    }
 
     if (result.presentedStyle.hasBackground())
     {
         const std::optional<Color> resolved = resolveColor(result.presentedStyle.background());
+        if (resolved.has_value())
+        {
+            result.presentedStyle = result.presentedStyle.withBackground(*resolved);
+        }
+        else
+        {
+            result.presentedStyle = result.presentedStyle.withoutBackground();
+        }
+    }
+    else if (result.presentedStyle.hasBackgroundThemeColor())
+    {
+        const std::optional<Color> authoredBasic = resolveThemeColorToBasic(*result.presentedStyle.backgroundThemeColor());
+        const std::optional<Color> resolved = resolveBasicAuthoredColor(authoredBasic);
         if (resolved.has_value())
         {
             result.presentedStyle = result.presentedStyle.withBackground(*resolved);
@@ -314,6 +340,26 @@ std::optional<Color> StylePolicy::resolveColor(const std::optional<Color>& color
     }
 
     return *color;
+}
+
+std::optional<Color> StylePolicy::resolveThemeColorToBasic(const ThemeColor& themeColor) const
+{
+    if (themeColor.hasBasic())
+    {
+        return themeColor.basic();
+    }
+
+    return std::nullopt;
+}
+
+std::optional<Color> StylePolicy::resolveBasicAuthoredColor(const std::optional<Color>& color) const
+{
+    if (!color.has_value())
+    {
+        return std::nullopt;
+    }
+
+    return applyColorMode(*color, m_basicColorMode);
 }
 
 std::optional<Color> StylePolicy::applyColorMode(const Color& color, ColorRenderMode mode) const

--- a/TUI/Rendering/Styles/StylePolicy.h
+++ b/TUI/Rendering/Styles/StylePolicy.h
@@ -5,6 +5,7 @@
 
 #include "Rendering/Styles/Color.h"
 #include "Rendering/Styles/Style.h"
+#include "Rendering/Styles/ThemeColor.h"
 
 enum class ColorRenderMode
 {
@@ -86,6 +87,8 @@ private:
 
 private:
     std::optional<Color> resolveColor(const std::optional<Color>& color) const;
+    std::optional<Color> resolveThemeColorToBasic(const ThemeColor& themeColor) const;
+    std::optional<Color> resolveBasicAuthoredColor(const std::optional<Color>& color) const;
     std::optional<Color> applyColorMode(const Color& color, ColorRenderMode mode) const;
 
     Color downgradeToBasic(const Color& color) const;

--- a/TUI/Rendering/Styles/ThemeColor.cpp
+++ b/TUI/Rendering/Styles/ThemeColor.cpp
@@ -1,0 +1,174 @@
+#include "Rendering/Styles/ThemeColor.h"
+
+#include <stdexcept>
+
+ThemeColor::ThemeColor() = default;
+
+ThemeColor ThemeColor::Basic(const Color& basic)
+{
+    ThemeColor color;
+    validateBasicColor(basic);
+    color.m_basic = basic;
+    return color;
+}
+
+ThemeColor ThemeColor::Indexed(const Color& indexed)
+{
+    ThemeColor color;
+    validateIndexedColor(indexed);
+    color.m_indexed = indexed;
+    return color;
+}
+
+ThemeColor ThemeColor::Rgb(const Color& rgb)
+{
+    ThemeColor color;
+    validateRgbColor(rgb);
+    color.m_rgb = rgb;
+    return color;
+}
+
+ThemeColor ThemeColor::BasicIndexed(
+    const Color& basic,
+    const Color& indexed)
+{
+    ThemeColor color;
+    validateBasicColor(basic);
+    validateIndexedColor(indexed);
+
+    color.m_basic = basic;
+    color.m_indexed = indexed;
+    return color;
+}
+
+ThemeColor ThemeColor::BasicRgb(
+    const Color& basic,
+    const Color& rgb)
+{
+    ThemeColor color;
+    validateBasicColor(basic);
+    validateRgbColor(rgb);
+
+    color.m_basic = basic;
+    color.m_rgb = rgb;
+    return color;
+}
+
+ThemeColor ThemeColor::IndexedRgb(
+    const Color& indexed,
+    const Color& rgb)
+{
+    ThemeColor color;
+    validateIndexedColor(indexed);
+    validateRgbColor(rgb);
+
+    color.m_indexed = indexed;
+    color.m_rgb = rgb;
+    return color;
+}
+
+ThemeColor ThemeColor::Basic256Rgb(
+    const Color& basic,
+    const Color& indexed,
+    const Color& rgb)
+{
+    ThemeColor color;
+    validateBasicColor(basic);
+    validateIndexedColor(indexed);
+    validateRgbColor(rgb);
+
+    color.m_basic = basic;
+    color.m_indexed = indexed;
+    color.m_rgb = rgb;
+    return color;
+}
+
+ThemeColor ThemeColor::WithBasic(const Color& basic) const
+{
+    ThemeColor copy = *this;
+    validateBasicColor(basic);
+    copy.m_basic = basic;
+    return copy;
+}
+
+ThemeColor ThemeColor::WithIndexed(const Color& indexed) const
+{
+    ThemeColor copy = *this;
+    validateIndexedColor(indexed);
+    copy.m_indexed = indexed;
+    return copy;
+}
+
+ThemeColor ThemeColor::WithRgb(const Color& rgb) const
+{
+    ThemeColor copy = *this;
+    validateRgbColor(rgb);
+    copy.m_rgb = rgb;
+    return copy;
+}
+
+bool ThemeColor::hasBasic() const
+{
+    return m_basic.has_value();
+}
+
+bool ThemeColor::hasIndexed() const
+{
+    return m_indexed.has_value();
+}
+
+bool ThemeColor::hasRgb() const
+{
+    return m_rgb.has_value();
+}
+
+const std::optional<Color>& ThemeColor::basic() const
+{
+    return m_basic;
+}
+
+const std::optional<Color>& ThemeColor::indexed() const
+{
+    return m_indexed;
+}
+
+const std::optional<Color>& ThemeColor::rgb() const
+{
+    return m_rgb;
+}
+
+bool ThemeColor::operator==(const ThemeColor& other) const
+{
+    return m_basic == other.m_basic
+        && m_indexed == other.m_indexed
+        && m_rgb == other.m_rgb;
+}
+
+bool ThemeColor::operator!=(const ThemeColor& other) const
+{
+    return !(*this == other);
+}
+
+void ThemeColor::validateBasicColor(const Color& color)
+{
+    if (!color.isBasic() && !color.isBasic16())
+    {
+        throw std::invalid_argument("ThemeColor basic slot requires a Basic16 Color.");
+    }
+}
+
+void ThemeColor::validateIndexedColor(const Color& color)
+{
+    if (!color.isIndexed() && !color.isIndexed256())
+    {
+        throw std::invalid_argument("ThemeColor indexed slot requires an Indexed256 Color.");
+    }
+}
+
+void ThemeColor::validateRgbColor(const Color& color)
+{
+    if (!color.isRgb() && !color.isTrueColor())
+    {
+        throw std::invalid_argument("ThemeColor rgb slot requires an RGB Color.");
+    }
+}

--- a/TUI/Rendering/Styles/ThemeColor.h
+++ b/TUI/Rendering/Styles/ThemeColor.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <optional>
+
+#include "Rendering/Styles/Color.h"
+
+class ThemeColor
+{
+public:
+    ThemeColor();
+
+    static ThemeColor Basic(const Color& basic);
+    static ThemeColor Indexed(const Color& indexed);
+    static ThemeColor Rgb(const Color& rgb);
+
+    static ThemeColor BasicIndexed(
+        const Color& basic,
+        const Color& indexed);
+
+    static ThemeColor BasicRgb(
+        const Color& basic,
+        const Color& rgb);
+
+    static ThemeColor IndexedRgb(
+        const Color& indexed,
+        const Color& rgb);
+
+    static ThemeColor Basic256Rgb(
+        const Color& basic,
+        const Color& indexed,
+        const Color& rgb);
+
+    ThemeColor WithBasic(const Color& basic) const;
+    ThemeColor WithIndexed(const Color& indexed) const;
+    ThemeColor WithRgb(const Color& rgb) const;
+
+    bool hasBasic() const;
+    bool hasIndexed() const;
+    bool hasRgb() const;
+
+    const std::optional<Color>& basic() const;
+    const std::optional<Color>& indexed() const;
+    const std::optional<Color>& rgb() const;
+
+    bool operator==(const ThemeColor& other) const;
+    bool operator!=(const ThemeColor& other) const;
+
+private:
+    static void validateBasicColor(const Color& color);
+    static void validateIndexedColor(const Color& color);
+    static void validateRgbColor(const Color& color);
+
+private:
+    std::optional<Color> m_basic;
+    std::optional<Color> m_indexed;
+    std::optional<Color> m_rgb;
+};

--- a/TUI/Rendering/Styles/Themes.h
+++ b/TUI/Rendering/Styles/Themes.h
@@ -56,9 +56,25 @@ namespace Themes
     // Base surfaces / page backgrounds
     // =========================================================
 
+    
     inline const Style Background =
         style::Fg(Color::FromBasic(Color::Basic::BrightWhite))
         + style::Bg(Color::FromBasic(Color::Basic::Black));
+    
+
+    // examples of how to declare colors in the new color system
+    // won't be active till phase 4
+    /*
+    inline const Style Background =
+          style::Fg(ThemeColor::Basic256Rgb(
+            Color::FromBasic(Color::Basic::BrightWhite),
+            Color::FromIndexed(15),
+            Color::FromRgb(255, 255, 255)))
+        + style::Bg(ThemeColor::Basic256Rgb(
+            Color::FromBasic(Color::Basic::Black),
+            Color::FromIndexed(0),
+            Color::FromRgb(0, 0, 0)));
+    */
 
     inline const Style Window =
         style::Bold
@@ -92,9 +108,17 @@ namespace Themes
     inline const Style MutedText =
         style::Dim
         + style::Fg(Color::FromBasic(Color::Basic::White));
-
+ 
     inline const Style Frame =
         style::Fg(Color::FromBasic(Color::Basic::BrightWhite));
+ 
+    /*
+    inline const Style Frame =
+        style::Fg(ThemeColor::Basic256Rgb(
+            Color::FromBasic(Color::Basic::White),
+            Color::FromIndexed(7),
+            Color::FromRgb(192, 192, 192)));
+    */
 
     inline const Style Focused =
         style::Bold
@@ -121,10 +145,19 @@ namespace Themes
     inline const Style TitleShadow =
         style::Bold
         + style::Fg(Color::FromBasic(Color::Basic::BrightBlack));
-
+    
     inline const Style Subtitle =
         style::Bold
         + style::Fg(Color::FromBasic(Color::Basic::BrightWhite));
+    
+    /*
+    inline const Style Subtitle =
+        style::Bold
+        + style::Fg(ThemeColor::Basic256Rgb(
+            Color::FromBasic(Color::Basic::BrightWhite),
+            Color::FromIndexed(15),
+            Color::FromRgb(255, 255, 255)));
+    */
 
     inline const Style SectionHeader =
         style::Bold
@@ -150,8 +183,14 @@ namespace Themes
 
     inline const Style Warning =
         style::Bold
-        + style::Fg(Color::FromBasic(Color::Basic::BrightYellow))
-        + style::Bg(Color::FromBasic(Color::Basic::Red));
+        + style::Fg(ThemeColor::Basic256Rgb(
+            Color::FromBasic(Color::Basic::BrightYellow),
+            Color::FromIndexed(11),
+            Color::FromRgb(255, 255, 0)))
+        + style::Bg(ThemeColor::Basic256Rgb(
+            Color::FromBasic(Color::Basic::Red),
+            Color::FromIndexed(1),
+            Color::FromRgb(128, 0, 0)));
 
     inline const Style Danger =
         style::Bold

--- a/TUI/TUI.vcxproj
+++ b/TUI/TUI.vcxproj
@@ -166,6 +166,7 @@
     <ClInclude Include="Rendering\Styles\StyleBuilder.h" />
     <ClInclude Include="Rendering\Styles\StyleMerge.h" />
     <ClInclude Include="Rendering\Styles\StylePolicy.h" />
+    <ClInclude Include="Rendering\Styles\ThemeColor.h" />
     <ClInclude Include="Rendering\Styles\UIThemes.h" />
     <ClInclude Include="Rendering\Surface.h" />
     <ClInclude Include="Rendering\TerminalRenderer.h">
@@ -214,6 +215,7 @@
     <ClCompile Include="Rendering\Styles\StyleBuilder.cpp" />
     <ClCompile Include="Rendering\Styles\StyleMerge.cpp" />
     <ClCompile Include="Rendering\Styles\StylePolicy.cpp" />
+    <ClCompile Include="Rendering\Styles\ThemeColor.cpp" />
     <ClCompile Include="Rendering\Surface.cpp" />
     <ClCompile Include="Rendering\TerminalRenderer.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</ExcludedFromBuild>

--- a/TUI/TUI.vcxproj.filters
+++ b/TUI/TUI.vcxproj.filters
@@ -159,6 +159,9 @@
     <ClInclude Include="Rendering\SgrEmitter.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="Rendering\Styles\ThemeColor.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Rendering\ScreenBuffer.cpp">
@@ -261,6 +264,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="Rendering\SgrEmitter.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Rendering\Styles\ThemeColor.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
Introduce a ThemeColor type that allows multiple fidelity representations (basic fallback, indexed preference, RGB preference). Introduced minimum safe resolution path for new color system. 

Closes: #88 