### PR TITLE
ConsoleRenderer: Integrate ColorResolver into ConsoleRenderer.

### DIFF
--- a/TUI/Rendering/ConsoleRenderer.cpp
+++ b/TUI/Rendering/ConsoleRenderer.cpp
@@ -7,6 +7,8 @@
 #include <vector>
 
 #include "Rendering/Diagnostics/RenderDiagnosticsWriter.h"
+#include "Rendering/Capabilities/ColorSupport.h"
+#include "Rendering/Styles/ColorResolver.h"
 #include "Utilities/Unicode/UnicodeConversion.h"
 #include "Utilities/Unicode/UnicodeWidth.h"
 
@@ -212,7 +214,7 @@ namespace
         default:
             return TextAttributeRenderMode::Omit;
         }
-    } 
+    }
 
     StylePolicy buildStylePolicyFromCapabilities(const RendererCapabilities& capabilities)
     {
@@ -878,7 +880,7 @@ void ConsoleRenderer::writeSpan(const ScreenBuffer& frame, int y, int xStart, in
         }
 
         moveCursor(runStart, y);
-        setStyle(runStyle);
+        setResolvedStyle(runStyle, resolvedRunStyle);
 
         if (!runText.empty())
         {
@@ -1003,10 +1005,14 @@ void ConsoleRenderer::moveCursor(int x, int y)
 
 void ConsoleRenderer::setStyle(const Style& style)
 {
-    const ResolvedStyle resolved = m_stylePolicy.resolve(style);
-    const Style& presentedStyle = resolved.presentedStyle;
+    setResolvedStyle(style, m_stylePolicy.resolve(style));
+}
 
-    recordStyleUsage(style, resolved);
+void ConsoleRenderer::setResolvedStyle(const Style& authoredStyle, const ResolvedStyle& resolvedStyle)
+{
+    const Style& presentedStyle = resolvedStyle.presentedStyle;
+
+    recordStyleUsage(authoredStyle, resolvedStyle);
 
     if (presentedStyle == m_currentStyle)
     {
@@ -1195,14 +1201,20 @@ void ConsoleRenderer::recordStyleUsage(const Style& authoredStyle, const Resolve
 
     const Style& presentedStyle = resolvedStyle.presentedStyle;
 
+    const std::optional<Color> authoredForeground =
+        ColorResolver::resolve(authoredStyle.foregroundColorValue(), ColorSupport::Rgb24);
+
+    const std::optional<Color> authoredBackground =
+        ColorResolver::resolve(authoredStyle.backgroundColorValue(), ColorSupport::Rgb24);
+
     recordColorFeature(
         StyleFeature::ForegroundColor,
-        authoredStyle.foreground(),
+        authoredForeground,
         presentedStyle.foreground());
 
     recordColorFeature(
         StyleFeature::BackgroundColor,
-        authoredStyle.background(),
+        authoredBackground,
         presentedStyle.background());
 
     recordTextFeature(
@@ -1549,3 +1561,4 @@ void ConsoleRenderer::recordBlinkFeature(
             logicalState);
     }
 }
+

--- a/TUI/Rendering/ConsoleRenderer.h
+++ b/TUI/Rendering/ConsoleRenderer.h
@@ -60,6 +60,7 @@ private:
 
     void moveCursor(int x, int y);
     void setStyle(const Style& style);
+    void setResolvedStyle(const Style& authoredStyle, const ResolvedStyle& resolvedStyle);
     void resetStyle();
 
     bool queryVisibleConsoleSize(int& width, int& height) const;


### PR DESCRIPTION
Modifies:
- Rendering/ConsoleRenderer.h/.cpp

The render flow is now:
- ScreenBuffer provides authored Style

- ConsoleRenderer::writeSpan() resolves that run style once through m_stylePolicy.resolve(runStyle)

- StylePolicy uses ColorResolver to turn StyleColorValue into concrete Color

- ConsoleRenderer receives the already-presented style and maps only Basic16 colors into Win32 attributes

- actual emission still happens through SetConsoleTextAttribute

The two important practical improvements are:
- color resolution is now part of the render flow before emission
- resolution is done once per style run and reused, instead of resolving again inside setStyle()

Closes: #93 