### PR TITLE
Themes: Update themes to take full advantage of the new ThemeColor sy…

### DIFF
--- a/TUI/Rendering/Styles/BannerThemes.h
+++ b/TUI/Rendering/Styles/BannerThemes.h
@@ -2,6 +2,7 @@
 
 #include "Rendering/Styles/Color.h"
 #include "Rendering/Styles/StyleBuilder.h"
+#include "Rendering/Styles/ThemeColor.h"
 
 namespace BannerThemes
 {
@@ -11,37 +12,73 @@ namespace BannerThemes
 
     inline const Style Title =
         style::Bold
-        + style::Fg(Color::FromBasic(Color::Basic::BrightCyan));
+        + style::Fg(ThemeColor::Basic256Rgb(
+            Color::FromBasic(Color::Basic::BrightCyan),
+            Color::FromIndexed(51),
+            Color::FromRgb(95, 255, 255)));
 
     inline const Style TitleShadow =
         style::Bold
-        + style::Fg(Color::FromBasic(Color::Basic::BrightBlack));
+        + style::Fg(ThemeColor::Basic256Rgb(
+            Color::FromBasic(Color::Basic::BrightBlack),
+            Color::FromIndexed(240),
+            Color::FromRgb(88, 88, 88)));
 
     inline const Style Subtitle =
         style::Bold
-        + style::Fg(Color::FromBasic(Color::Basic::BrightWhite));
+        + style::Fg(ThemeColor::Basic256Rgb(
+            Color::FromBasic(Color::Basic::BrightWhite),
+            Color::FromIndexed(255),
+            Color::FromRgb(255, 255, 255)));
 
     inline const Style SectionHeader =
         style::Bold
-        + style::Fg(Color::FromBasic(Color::Basic::BrightYellow));
+        + style::Fg(ThemeColor::Basic256Rgb(
+            Color::FromBasic(Color::Basic::BrightYellow),
+            Color::FromIndexed(226),
+            Color::FromRgb(255, 255, 0)));
 
     inline const Style InfoBanner =
         style::Bold
-        + style::Fg(Color::FromBasic(Color::Basic::BrightCyan))
-        + style::Bg(Color::FromBasic(Color::Basic::Blue));
+        + style::Fg(ThemeColor::Basic256Rgb(
+            Color::FromBasic(Color::Basic::BrightWhite),
+            Color::FromIndexed(255),
+            Color::FromRgb(255, 255, 255)))
+        + style::Bg(ThemeColor::Basic256Rgb(
+            Color::FromBasic(Color::Basic::Blue),
+            Color::FromIndexed(24),
+            Color::FromRgb(0, 95, 135)));
 
     inline const Style SuccessBanner =
         style::Bold
-        + style::Fg(Color::FromBasic(Color::Basic::BrightWhite))
-        + style::Bg(Color::FromBasic(Color::Basic::Green));
+        + style::Fg(ThemeColor::Basic256Rgb(
+            Color::FromBasic(Color::Basic::BrightWhite),
+            Color::FromIndexed(255),
+            Color::FromRgb(255, 255, 255)))
+        + style::Bg(ThemeColor::Basic256Rgb(
+            Color::FromBasic(Color::Basic::Green),
+            Color::FromIndexed(28),
+            Color::FromRgb(0, 135, 0)));
 
     inline const Style WarningBanner =
         style::Bold
-        + style::Fg(Color::FromBasic(Color::Basic::BrightYellow))
-        + style::Bg(Color::FromBasic(Color::Basic::Red));
+        + style::Fg(ThemeColor::Basic256Rgb(
+            Color::FromBasic(Color::Basic::BrightYellow),
+            Color::FromIndexed(226),
+            Color::FromRgb(255, 255, 0)))
+        + style::Bg(ThemeColor::Basic256Rgb(
+            Color::FromBasic(Color::Basic::Red),
+            Color::FromIndexed(88),
+            Color::FromRgb(135, 0, 0)));
 
     inline const Style RetroBanner =
         style::Bold
-        + style::Fg(Color::FromBasic(Color::Basic::BrightGreen))
-        + style::Bg(Color::FromBasic(Color::Basic::Black));
+        + style::Fg(ThemeColor::Basic256Rgb(
+            Color::FromBasic(Color::Basic::BrightGreen),
+            Color::FromIndexed(46),
+            Color::FromRgb(0, 255, 95)))
+        + style::Bg(ThemeColor::Basic256Rgb(
+            Color::FromBasic(Color::Basic::Black),
+            Color::FromIndexed(16),
+            Color::FromRgb(0, 0, 0)));
 }

--- a/TUI/Rendering/Styles/Themes.h
+++ b/TUI/Rendering/Styles/Themes.h
@@ -2,6 +2,16 @@
 
 #include "Rendering/Styles/Color.h"
 #include "Rendering/Styles/StyleBuilder.h"
+#include "Rendering/Styles/ThemeColor.h"
+
+/*
+    These themes preserve the ANSI / DOS / BBS feel of the project first.
+
+    Richer ThemeColor definitions are used selectively so:
+        - Basic16 still looks correct and intentional
+        - Indexed256 and Rgb24 can gain a little extra polish
+        - the visual identity stays retro rather than drifting modern
+*/
 
 /*
     Can also create styles like this:
@@ -19,6 +29,7 @@
     Personally I prefer the current ANSI retro feel.
 */
 
+
 namespace Themes
 {
     // =========================================================
@@ -26,114 +37,114 @@ namespace Themes
     // =========================================================
 
     inline const Style Background =
-          style::Fg(ThemeColor::Basic256Rgb(
+        style::Fg(ThemeColor::Basic256Rgb(
             Color::FromBasic(Color::Basic::White),
-            Color::FromIndexed(15),
-            Color::FromRgb(255, 255, 255)))
+            Color::FromIndexed(250),
+            Color::FromRgb(230, 230, 230)))
         + style::Bg(ThemeColor::Basic256Rgb(
             Color::FromBasic(Color::Basic::Black),
-            Color::FromIndexed(0),
-            Color::FromRgb(0, 0, 0)));
+            Color::FromIndexed(16),
+            Color::FromRgb(12, 12, 12)));
 
     inline const Style Window =
         style::Fg(ThemeColor::Basic256Rgb(
             Color::FromBasic(Color::Basic::White),
-            Color::FromIndexed(15),
+            Color::FromIndexed(255),
             Color::FromRgb(255, 255, 255)))
         + style::Bg(ThemeColor::Basic256Rgb(
             Color::FromBasic(Color::Basic::Blue),
-            Color::FromIndexed(4),
-            Color::FromRgb(0, 0, 128)));
+            Color::FromIndexed(18),
+            Color::FromRgb(0, 0, 135)));
 
     inline const Style Panel =
         style::Fg(ThemeColor::Basic256Rgb(
             Color::FromBasic(Color::Basic::BrightWhite),
-            Color::FromIndexed(15),
+            Color::FromIndexed(255),
             Color::FromRgb(255, 255, 255)))
         + style::Bg(ThemeColor::Basic256Rgb(
             Color::FromBasic(Color::Basic::Black),
-            Color::FromIndexed(0),
-            Color::FromRgb(0, 0, 0)));
+            Color::FromIndexed(233),
+            Color::FromRgb(18, 18, 18)));
 
     inline const Style AccentSurface =
         style::Fg(ThemeColor::Basic256Rgb(
             Color::FromBasic(Color::Basic::BrightWhite),
-            Color::FromIndexed(15),
+            Color::FromIndexed(255),
             Color::FromRgb(255, 255, 255)))
         + style::Bg(ThemeColor::Basic256Rgb(
             Color::FromBasic(Color::Basic::Blue),
-            Color::FromIndexed(4),
-            Color::FromRgb(0, 0, 128)));
+            Color::FromIndexed(24),
+            Color::FromRgb(0, 95, 135)));
 
     inline const Style RetroTerminal =
         style::Bold
         + style::Fg(ThemeColor::Basic256Rgb(
             Color::FromBasic(Color::Basic::BrightGreen),
-            Color::FromIndexed(10),
-            Color::FromRgb(0, 255, 0)))
+            Color::FromIndexed(46),
+            Color::FromRgb(0, 255, 95)))
         + style::Bg(ThemeColor::Basic256Rgb(
             Color::FromBasic(Color::Basic::Black),
-            Color::FromIndexed(0),
+            Color::FromIndexed(16),
             Color::FromRgb(0, 0, 0)));
 
     // =========================================================
     // Neutral UI text styles
     // =========================================================
-    // When using Foreground only styles, make sure you are 
-    // placing the glyphs on a cell where the background is 
+    // When using Foreground only styles, make sure you are
+    // placing the glyphs on a cell where the background is
     // already owned. (ie a cell where the background has already
-    // been directly specified) 
+    // been directly specified)
 
     inline const Style PanelTitle =
         style::Bold
         + style::Fg(ThemeColor::Basic256Rgb(
             Color::FromBasic(Color::Basic::BrightWhite),
-            Color::FromIndexed(15),
+            Color::FromIndexed(255),
             Color::FromRgb(255, 255, 255)));
 
     inline const Style Text =
         style::Fg(ThemeColor::Basic256Rgb(
             Color::FromBasic(Color::Basic::BrightWhite),
-            Color::FromIndexed(15),
-            Color::FromRgb(255, 255, 255)));
+            Color::FromIndexed(252),
+            Color::FromRgb(238, 238, 238)));
 
     inline const Style MutedText =
         style::Dim
         + style::Fg(ThemeColor::Basic256Rgb(
             Color::FromBasic(Color::Basic::White),
-            Color::FromIndexed(7),
-            Color::FromRgb(192, 192, 192)));
+            Color::FromIndexed(245),
+            Color::FromRgb(148, 148, 148)));
 
     inline const Style Frame =
         style::Fg(ThemeColor::Basic256Rgb(
             Color::FromBasic(Color::Basic::White),
-            Color::FromIndexed(7),
-            Color::FromRgb(192, 192, 192)));
+            Color::FromIndexed(246),
+            Color::FromRgb(168, 168, 168)));
 
     inline const Style Focused =
         style::Bold
         + style::Fg(ThemeColor::Basic256Rgb(
             Color::FromBasic(Color::Basic::BrightYellow),
-            Color::FromIndexed(11),
-            Color::FromRgb(255, 255, 0)));
+            Color::FromIndexed(227),
+            Color::FromRgb(255, 255, 95)));
 
     inline const Style Selected =
         style::Bold
         + style::Fg(ThemeColor::Basic256Rgb(
             Color::FromBasic(Color::Basic::Black),
-            Color::FromIndexed(0),
+            Color::FromIndexed(16),
             Color::FromRgb(0, 0, 0)))
         + style::Bg(ThemeColor::Basic256Rgb(
             Color::FromBasic(Color::Basic::BrightWhite),
-            Color::FromIndexed(15),
-            Color::FromRgb(255, 255, 255)));
+            Color::FromIndexed(153),
+            Color::FromRgb(175, 215, 255)));
 
     inline const Style Disabled =
         style::Dim
         + style::Fg(ThemeColor::Basic256Rgb(
             Color::FromBasic(Color::Basic::White),
-            Color::FromIndexed(7),
-            Color::FromRgb(192, 192, 192)));
+            Color::FromIndexed(243),
+            Color::FromRgb(118, 118, 118)));
 
     // =========================================================
     // Titles / headings / labels
@@ -143,28 +154,28 @@ namespace Themes
         style::Bold
         + style::Fg(ThemeColor::Basic256Rgb(
             Color::FromBasic(Color::Basic::BrightCyan),
-            Color::FromIndexed(14),
-            Color::FromRgb(0, 255, 255)));
+            Color::FromIndexed(51),
+            Color::FromRgb(95, 255, 255)));
 
     inline const Style TitleShadow =
         style::Bold
         + style::Fg(ThemeColor::Basic256Rgb(
             Color::FromBasic(Color::Basic::BrightBlack),
-            Color::FromIndexed(8),
-            Color::FromRgb(128, 128, 128)));
+            Color::FromIndexed(240),
+            Color::FromRgb(88, 88, 88)));
 
     inline const Style Subtitle =
         style::Bold
         + style::Fg(ThemeColor::Basic256Rgb(
             Color::FromBasic(Color::Basic::BrightWhite),
-            Color::FromIndexed(15),
+            Color::FromIndexed(255),
             Color::FromRgb(255, 255, 255)));
 
     inline const Style SectionHeader =
         style::Bold
         + style::Fg(ThemeColor::Basic256Rgb(
             Color::FromBasic(Color::Basic::BrightYellow),
-            Color::FromIndexed(11),
+            Color::FromIndexed(226),
             Color::FromRgb(255, 255, 0)));
 
     inline const Style Emphasis =
@@ -172,8 +183,8 @@ namespace Themes
         + style::Underline
         + style::Fg(ThemeColor::Basic256Rgb(
             Color::FromBasic(Color::Basic::BrightCyan),
-            Color::FromIndexed(14),
-            Color::FromRgb(0, 255, 255)));
+            Color::FromIndexed(87),
+            Color::FromRgb(95, 255, 255)));
 
     // =========================================================
     // Informational / feedback / status styles
@@ -183,72 +194,70 @@ namespace Themes
         style::Bold
         + style::Fg(ThemeColor::Basic256Rgb(
             Color::FromBasic(Color::Basic::BrightCyan),
-            Color::FromIndexed(14),
-            Color::FromRgb(0, 255, 255)));
+            Color::FromIndexed(51),
+            Color::FromRgb(95, 255, 255)));
 
     inline const Style Success =
         style::Bold
         + style::Fg(ThemeColor::Basic256Rgb(
             Color::FromBasic(Color::Basic::BrightGreen),
-            Color::FromIndexed(10),
-            Color::FromRgb(0, 255, 0)));
+            Color::FromIndexed(46),
+            Color::FromRgb(0, 255, 95)));
 
     inline const Style Warning =
         style::Bold
         + style::Fg(ThemeColor::Basic256Rgb(
             Color::FromBasic(Color::Basic::BrightYellow),
-            Color::FromIndexed(11),
+            Color::FromIndexed(226),
             Color::FromRgb(255, 255, 0)))
         + style::Bg(ThemeColor::Basic256Rgb(
             Color::FromBasic(Color::Basic::Red),
-            Color::FromIndexed(1),
-            Color::FromRgb(128, 0, 0)));
+            Color::FromIndexed(52),
+            Color::FromRgb(95, 0, 0)));
 
     inline const Style Danger =
         style::Bold
         + style::FastBlink
         + style::Fg(ThemeColor::Basic256Rgb(
             Color::FromBasic(Color::Basic::BrightWhite),
-            Color::FromIndexed(15),
+            Color::FromIndexed(255),
             Color::FromRgb(255, 255, 255)))
         + style::Bg(ThemeColor::Basic256Rgb(
             Color::FromBasic(Color::Basic::Red),
-            Color::FromIndexed(1),
-            Color::FromRgb(128, 0, 0)));
+            Color::FromIndexed(160),
+            Color::FromRgb(215, 0, 0)));
 
     inline const Style Hightlight =
         style::Bold
         + style::Fg(ThemeColor::Basic256Rgb(
             Color::FromBasic(Color::Basic::Black),
-            Color::FromIndexed(0),
+            Color::FromIndexed(16),
             Color::FromRgb(0, 0, 0)))
         + style::Bg(ThemeColor::Basic256Rgb(
             Color::FromBasic(Color::Basic::BrightYellow),
-            Color::FromIndexed(11),
-            Color::FromRgb(255, 255, 0)));
-
+            Color::FromIndexed(228),
+            Color::FromRgb(255, 255, 135)));
 
     inline const Style Dimmed =
         style::Dim
         + style::Fg(ThemeColor::Basic256Rgb(
             Color::FromBasic(Color::Basic::White),
-            Color::FromIndexed(7),
-            Color::FromRgb(192, 192, 192)));
+            Color::FromIndexed(245),
+            Color::FromRgb(148, 148, 148)));
 
     inline const Style SlowBlink =
         style::SlowBlink
         + style::Fg(ThemeColor::Basic256Rgb(
             Color::FromBasic(Color::Basic::White),
-            Color::FromIndexed(7),
-            Color::FromRgb(192, 192, 192)));
-
+            Color::FromIndexed(250),
+            Color::FromRgb(210, 210, 210)));
 
     inline const Style FastBlink =
         style::FastBlink
         + style::Fg(ThemeColor::Basic256Rgb(
             Color::FromBasic(Color::Basic::White),
-            Color::FromIndexed(7),
-            Color::FromRgb(192, 192, 192)));
+            Color::FromIndexed(255),
+            Color::FromRgb(255, 255, 255)));
 
     // =========================================================
     // Generic framework demo / object styles
@@ -258,20 +267,20 @@ namespace Themes
         style::Bold
         + style::Fg(ThemeColor::Basic256Rgb(
             Color::FromBasic(Color::Basic::BrightMagenta),
-            Color::FromIndexed(13),
-            Color::FromRgb(255, 0, 255)));
+            Color::FromIndexed(213),
+            Color::FromRgb(255, 135, 255)));
 
     inline const Style DemoObject =
         style::Bold
         + style::Fg(ThemeColor::Basic256Rgb(
             Color::FromBasic(Color::Basic::BrightGreen),
-            Color::FromIndexed(10),
-            Color::FromRgb(0, 255, 0)));
+            Color::FromIndexed(46),
+            Color::FromRgb(0, 255, 95)));
 
     inline const Style DemoObjectAlt =
         style::Bold
         + style::Fg(ThemeColor::Basic256Rgb(
             Color::FromBasic(Color::Basic::BrightCyan),
-            Color::FromIndexed(14),
-            Color::FromRgb(0, 255, 255)));
+            Color::FromIndexed(51),
+            Color::FromRgb(95, 255, 255)));
 }

--- a/TUI/Rendering/Styles/UIThemes.h
+++ b/TUI/Rendering/Styles/UIThemes.h
@@ -1,86 +1,163 @@
 #pragma once
 
+#include "Rendering/Styles/Color.h"
 #include "Rendering/Styles/StyleBuilder.h"
+#include "Rendering/Styles/ThemeColor.h"
 
 namespace UIThemes
 {
-    inline Style NormalText = Style();
+    inline const Style NormalText = Style();
 
     inline const Style DisabledText =
-          style::Dim
-        + style::Fg(Color::FromBasic(Color::Basic::BrightBlack));
-
+        style::Dim
+        + style::Fg(ThemeColor::Basic256Rgb(
+            Color::FromBasic(Color::Basic::BrightBlack),
+            Color::FromIndexed(243),
+            Color::FromRgb(118, 118, 118)));
 
     inline const Style Label =
-          style::Fg(Color::FromBasic(Color::Basic::BrightWhite));
- 
-    inline const Style Value =
-          style::Fg(Color::FromBasic(Color::Basic::BrightCyan));
+        style::Fg(ThemeColor::Basic256Rgb(
+            Color::FromBasic(Color::Basic::BrightWhite),
+            Color::FromIndexed(255),
+            Color::FromRgb(255, 255, 255)));
 
+    inline const Style Value =
+        style::Fg(ThemeColor::Basic256Rgb(
+            Color::FromBasic(Color::Basic::BrightCyan),
+            Color::FromIndexed(51),
+            Color::FromRgb(95, 255, 255)));
 
     inline const Style DialogTitle =
-          style::Bold
-        + style::Fg(Color::FromBasic(Color::Basic::BrightWhite))
-        + style::Bg(Color::FromBasic(Color::Basic::Blue));
- 
+        style::Bold
+        + style::Fg(ThemeColor::Basic256Rgb(
+            Color::FromBasic(Color::Basic::BrightWhite),
+            Color::FromIndexed(255),
+            Color::FromRgb(255, 255, 255)))
+        + style::Bg(ThemeColor::Basic256Rgb(
+            Color::FromBasic(Color::Basic::Blue),
+            Color::FromIndexed(18),
+            Color::FromRgb(0, 0, 135)));
 
     inline const Style PanelTitle =
-          style::Bold
-        + style::Fg(Color::FromBasic(Color::Basic::BrightCyan));
+        style::Bold
+        + style::Fg(ThemeColor::Basic256Rgb(
+            Color::FromBasic(Color::Basic::BrightCyan),
+            Color::FromIndexed(51),
+            Color::FromRgb(95, 255, 255)));
 
-    inline const Style StatusBar = 
-          style::Fg(Color::FromBasic(Color::Basic::Black))
-        + style::Bg(Color::FromBasic(Color::Basic::White));
+    inline const Style StatusBar =
+        style::Fg(ThemeColor::Basic256Rgb(
+            Color::FromBasic(Color::Basic::Black),
+            Color::FromIndexed(16),
+            Color::FromRgb(0, 0, 0)))
+        + style::Bg(ThemeColor::Basic256Rgb(
+            Color::FromBasic(Color::Basic::White),
+            Color::FromIndexed(250),
+            Color::FromRgb(210, 210, 210)));
 
-    inline const Style Selection = 
-          style::Bold
-        + style::Fg(Color::FromBasic(Color::Basic::Black))
-        + style::Bg(Color::FromBasic(Color::Basic::BrightCyan));
+    inline const Style Selection =
+        style::Bold
+        + style::Fg(ThemeColor::Basic256Rgb(
+            Color::FromBasic(Color::Basic::Black),
+            Color::FromIndexed(16),
+            Color::FromRgb(0, 0, 0)))
+        + style::Bg(ThemeColor::Basic256Rgb(
+            Color::FromBasic(Color::Basic::BrightCyan),
+            Color::FromIndexed(123),
+            Color::FromRgb(135, 255, 255)));
 
-    inline const Style Focused = 
-          style::Bold
+    inline const Style Focused =
+        style::Bold
         + style::Underline;
 
-    inline const Style ButtonNormal = 
-          style::Bold
-        + style::Fg(Color::FromBasic(Color::Basic::BrightWhite))
-        + style::Bg(Color::FromBasic(Color::Basic::Blue));
+    inline const Style ButtonNormal =
+        style::Bold
+        + style::Fg(ThemeColor::Basic256Rgb(
+            Color::FromBasic(Color::Basic::BrightWhite),
+            Color::FromIndexed(255),
+            Color::FromRgb(255, 255, 255)))
+        + style::Bg(ThemeColor::Basic256Rgb(
+            Color::FromBasic(Color::Basic::Blue),
+            Color::FromIndexed(19),
+            Color::FromRgb(0, 0, 175)));
 
-    inline const Style ButtonHot = 
-          style::Bold
-        + style::Fg(Color::FromBasic(Color::Basic::BrightYellow))
-        + style::Bg(Color::FromBasic(Color::Basic::Blue));
+    inline const Style ButtonHot =
+        style::Bold
+        + style::Fg(ThemeColor::Basic256Rgb(
+            Color::FromBasic(Color::Basic::BrightYellow),
+            Color::FromIndexed(227),
+            Color::FromRgb(255, 255, 95)))
+        + style::Bg(ThemeColor::Basic256Rgb(
+            Color::FromBasic(Color::Basic::Blue),
+            Color::FromIndexed(24),
+            Color::FromRgb(0, 95, 135)));
 
-    inline const Style ButtonDisabled = 
-          style::Dim
-            + style::Fg(Color::FromBasic(Color::Basic::BrightBlack))
-            + style::Bg(Color::FromBasic(Color::Basic::Black));
+    inline const Style ButtonDisabled =
+        style::Dim
+        + style::Fg(ThemeColor::Basic256Rgb(
+            Color::FromBasic(Color::Basic::BrightBlack),
+            Color::FromIndexed(243),
+            Color::FromRgb(118, 118, 118)))
+        + style::Bg(ThemeColor::Basic256Rgb(
+            Color::FromBasic(Color::Basic::Black),
+            Color::FromIndexed(233),
+            Color::FromRgb(18, 18, 18)));
 
     inline const Style Border =
-          style::Fg(Color::FromBasic(Color::Basic::BrightBlue));
+        style::Fg(ThemeColor::Basic256Rgb(
+            Color::FromBasic(Color::Basic::BrightBlue),
+            Color::FromIndexed(39),
+            Color::FromRgb(0, 175, 255)));
 
-    inline const Style Header = 
-          style::Bold
-        + style::Fg(Color::FromBasic(Color::Basic::BrightWhite))
-        + style::Bg(Color::FromBasic(Color::Basic::BrightBlack));
+    inline const Style Header =
+        style::Bold
+        + style::Fg(ThemeColor::Basic256Rgb(
+            Color::FromBasic(Color::Basic::BrightWhite),
+            Color::FromIndexed(255),
+            Color::FromRgb(255, 255, 255)))
+        + style::Bg(ThemeColor::Basic256Rgb(
+            Color::FromBasic(Color::Basic::BrightBlack),
+            Color::FromIndexed(238),
+            Color::FromRgb(68, 68, 68)));
 
-    inline const Style Footer = 
-          style::Fg(Color::FromBasic(Color::Basic::White))
-        + style::Bg(Color::FromBasic(Color::Basic::Black));
+    inline const Style Footer =
+        style::Fg(ThemeColor::Basic256Rgb(
+            Color::FromBasic(Color::Basic::White),
+            Color::FromIndexed(250),
+            Color::FromRgb(210, 210, 210)))
+        + style::Bg(ThemeColor::Basic256Rgb(
+            Color::FromBasic(Color::Basic::Black),
+            Color::FromIndexed(233),
+            Color::FromRgb(18, 18, 18)));
 
-    inline const Style Tooltip = 
-          style::Fg(Color::FromBasic(Color::Basic::Black))
-        + style::Bg(Color::FromBasic(Color::Basic::BrightYellow));
+    inline const Style Tooltip =
+        style::Fg(ThemeColor::Basic256Rgb(
+            Color::FromBasic(Color::Basic::Black),
+            Color::FromIndexed(16),
+            Color::FromRgb(0, 0, 0)))
+        + style::Bg(ThemeColor::Basic256Rgb(
+            Color::FromBasic(Color::Basic::BrightYellow),
+            Color::FromIndexed(228),
+            Color::FromRgb(255, 255, 135)));
 
-    inline const Style ErrorText = 
-          style::Bold
-        + style::Fg(Color::FromBasic(Color::Basic::BrightRed));
+    inline const Style ErrorText =
+        style::Bold
+        + style::Fg(ThemeColor::Basic256Rgb(
+            Color::FromBasic(Color::Basic::BrightRed),
+            Color::FromIndexed(196),
+            Color::FromRgb(255, 0, 0)));
 
-    inline const Style WarningText = 
-          style::Bold
-        + style::Fg(Color::FromBasic(Color::Basic::BrightYellow));
+    inline const Style WarningText =
+        style::Bold
+        + style::Fg(ThemeColor::Basic256Rgb(
+            Color::FromBasic(Color::Basic::BrightYellow),
+            Color::FromIndexed(226),
+            Color::FromRgb(255, 255, 0)));
 
-    inline const Style SuccessText = 
-          style::Bold
-        + style::Fg(Color::FromBasic(Color::Basic::BrightGreen));
+    inline const Style SuccessText =
+        style::Bold
+        + style::Fg(ThemeColor::Basic256Rgb(
+            Color::FromBasic(Color::Basic::BrightGreen),
+            Color::FromIndexed(46),
+            Color::FromRgb(0, 255, 95)));
 }


### PR DESCRIPTION
…stem

Modifies:
- Rendering/Styles/BannerThemes.h
- Rendering/Styles/Themes.h
- Rendering/Styles/UIThemes

The selective upgrades fall into three groups.

First: surfaces and selection states.
These benefit the most from richer theme definitions because Indexed256/RGB can make blue panels, selected rows, status bars, and buttons look a little more deliberate without changing their retro character. That is why I upgraded Window, Panel, AccentSurface, Selected, Selection, StatusBar, ButtonNormal, ButtonHot, and the banner background styles.

Second: accent text styles.
Titles, cyan values, green success text, magenta accents, and yellow warnings are already core to your ANSI look. Giving those a slightly richer 256/RGB form keeps the same family but makes them cleaner on richer backends. That is why Title, SectionHeader, Value, Info, Success, WarningText, SuccessText, and Accent were good candidates.

Third: subdued neutrals.
Muted text, disabled text, shadows, borders, and frames are places where richer tiers can help the palette feel less harsh. I kept those changes small on purpose so they still degrade to classic ANSI grays and bright-black cleanly.

Closes: #94 