### PR TITLE
95 phase 9 color diagnostics explain resolution downgrade

### DIFF
--- a/TUI/Rendering/Capabilities/CapabilityReport.cpp
+++ b/TUI/Rendering/Capabilities/CapabilityReport.cpp
@@ -1,5 +1,34 @@
 #include "Rendering/Capabilities/CapabilityReport.h"
 
+#include <sstream>
+
+namespace
+{
+    const char* basicColorName(Color::Basic color)
+    {
+        switch (color)
+        {
+        case Color::Basic::Black:         return "Black";
+        case Color::Basic::Red:           return "Red";
+        case Color::Basic::Green:         return "Green";
+        case Color::Basic::Yellow:        return "Yellow";
+        case Color::Basic::Blue:          return "Blue";
+        case Color::Basic::Magenta:       return "Magenta";
+        case Color::Basic::Cyan:          return "Cyan";
+        case Color::Basic::White:         return "White";
+        case Color::Basic::BrightBlack:   return "BrightBlack";
+        case Color::Basic::BrightRed:     return "BrightRed";
+        case Color::Basic::BrightGreen:   return "BrightGreen";
+        case Color::Basic::BrightYellow:  return "BrightYellow";
+        case Color::Basic::BrightBlue:    return "BrightBlue";
+        case Color::Basic::BrightMagenta: return "BrightMagenta";
+        case Color::Basic::BrightCyan:    return "BrightCyan";
+        case Color::Basic::BrightWhite:   return "BrightWhite";
+        default:                          return "UnknownBasic";
+        }
+    }
+}
+
 CapabilityReport::CapabilityReport()
 {
     const StyleFeature features[] =
@@ -125,6 +154,21 @@ void CapabilityReport::addLogicalStateExample(
     m_logicalStateExamples.push_back(example);
 }
 
+void CapabilityReport::addColorAdaptationExample(
+    StyleFeature feature,
+    StyleAdaptationKind kind,
+    const ColorResolutionDiagnostics& diagnostics)
+{
+    ColorAdaptationExample example;
+    example.feature = feature;
+    example.kind = kind;
+    example.supportedTier = diagnostics.supportedTier;
+    example.reason = diagnostics.reason;
+    example.authoredColor = diagnostics.authoredColor;
+    example.resolvedColor = diagnostics.resolvedColor;
+    m_colorAdaptationExamples.push_back(example);
+}
+
 std::size_t CapabilityReport::getCount(StyleFeature feature, StyleAdaptationKind kind) const
 {
     for (const StyleAdaptationCounter& counter : m_counters)
@@ -153,6 +197,11 @@ const std::vector<StyleLogicalStateExample>& CapabilityReport::logicalStateExamp
     return m_logicalStateExamples;
 }
 
+const std::vector<ColorAdaptationExample>& CapabilityReport::colorAdaptationExamples() const
+{
+    return m_colorAdaptationExamples;
+}
+
 void CapabilityReport::clearRuntimeData()
 {
     for (StyleAdaptationCounter& counter : m_counters)
@@ -162,6 +211,7 @@ void CapabilityReport::clearRuntimeData()
 
     m_examples.clear();
     m_logicalStateExamples.clear();
+    m_colorAdaptationExamples.clear();
 }
 
 bool CapabilityReport::hasRuntimeData() const
@@ -174,7 +224,9 @@ bool CapabilityReport::hasRuntimeData() const
         }
     }
 
-    return !m_examples.empty() || !m_logicalStateExamples.empty();
+    return !m_examples.empty()
+        || !m_logicalStateExamples.empty()
+        || !m_colorAdaptationExamples.empty();
 }
 
 const char* CapabilityReport::toString(ColorSupport support)
@@ -358,6 +410,95 @@ const char* CapabilityReport::toString(LogicalStyleValueState state)
     default:
         return "Unknown";
     }
+}
+
+const char* CapabilityReport::toString(ColorAdaptationReason reason)
+{
+    return ColorResolutionDiagnostics::toString(reason);
+}
+
+std::string CapabilityReport::formatColor(const Color& color)
+{
+    std::ostringstream stream;
+
+    if (color.isDefault())
+    {
+        return "Default";
+    }
+
+    if (color.isBasic16())
+    {
+        stream << "Basic16(" << basicColorName(color.basic()) << ")";
+        return stream.str();
+    }
+
+    if (color.isIndexed256())
+    {
+        stream << "Indexed256(" << static_cast<int>(color.index256()) << ")";
+        return stream.str();
+    }
+
+    if (color.isRgb())
+    {
+        stream
+            << "Rgb24("
+            << static_cast<int>(color.red()) << ","
+            << static_cast<int>(color.green()) << ","
+            << static_cast<int>(color.blue()) << ")";
+        return stream.str();
+    }
+
+    return "UnknownColor";
+}
+
+std::string CapabilityReport::formatAuthoredColor(const Style::StyleColorValue& colorValue)
+{
+    if (colorValue.hasConcreteColor())
+    {
+        return std::string("Concrete ") + formatColor(*colorValue.concreteColor());
+    }
+
+    if (colorValue.hasThemeColor())
+    {
+        const ThemeColor& themeColor = *colorValue.themeColor();
+
+        std::ostringstream stream;
+        stream << "ThemeColor(";
+
+        bool wroteAny = false;
+
+        if (themeColor.hasBasic())
+        {
+            stream << "basic=" << formatColor(*themeColor.basic());
+            wroteAny = true;
+        }
+
+        if (themeColor.hasIndexed())
+        {
+            if (wroteAny)
+            {
+                stream << ", ";
+            }
+
+            stream << "indexed=" << formatColor(*themeColor.indexed());
+            wroteAny = true;
+        }
+
+        if (themeColor.hasRgb())
+        {
+            if (wroteAny)
+            {
+                stream << ", ";
+            }
+
+            stream << "rgb=" << formatColor(*themeColor.rgb());
+        }
+
+        stream << ")";
+        return stream.str();
+    }
+
+    return "Unspecified";
 }
 
 void CapabilityReport::increment(StyleFeature feature, StyleAdaptationKind kind)

--- a/TUI/Rendering/Capabilities/CapabilityReport.h
+++ b/TUI/Rendering/Capabilities/CapabilityReport.h
@@ -1,10 +1,12 @@
 #pragma once
 
 #include <cstddef>
+#include <optional>
 #include <string>
 #include <vector>
 
 #include "Rendering/Capabilities/RendererCapabilities.h"
+#include "Rendering/Styles/ColorResolutionDiagnostics.h"
 #include "Rendering/Styles/StylePolicy.h"
 
 enum class StyleAdaptationKind
@@ -58,6 +60,16 @@ struct StyleLogicalStateExample
     StyleFeature feature = StyleFeature::ForegroundColor;
     LogicalStyleValueState logicalState = LogicalStyleValueState::Unspecified;
     std::string detail;
+};
+
+struct ColorAdaptationExample
+{
+    StyleFeature feature = StyleFeature::ForegroundColor;
+    StyleAdaptationKind kind = StyleAdaptationKind::Direct;
+    ColorSupport supportedTier = ColorSupport::None;
+    ColorAdaptationReason reason = ColorAdaptationReason::OmittedNoColorSupport;
+    Style::StyleColorValue authoredColor;
+    std::optional<Color> resolvedColor;
 };
 
 struct BackendStateSnapshot
@@ -125,11 +137,17 @@ public:
         LogicalStyleValueState logicalState,
         const std::string& detail);
 
+    void addColorAdaptationExample(
+        StyleFeature feature,
+        StyleAdaptationKind kind,
+        const ColorResolutionDiagnostics& diagnostics);
+
     std::size_t getCount(StyleFeature feature, StyleAdaptationKind kind) const;
 
     const std::vector<StyleAdaptationCounter>& counters() const;
     const std::vector<StyleAdaptationExample>& examples() const;
     const std::vector<StyleLogicalStateExample>& logicalStateExamples() const;
+    const std::vector<ColorAdaptationExample>& colorAdaptationExamples() const;
 
     void clearRuntimeData();
     bool hasRuntimeData() const;
@@ -142,6 +160,10 @@ public:
     static const char* toString(StyleFeature feature);
     static const char* toString(StyleAdaptationKind kind);
     static const char* toString(LogicalStyleValueState state);
+    static const char* toString(ColorAdaptationReason reason);
+
+    static std::string formatColor(const Color& color);
+    static std::string formatAuthoredColor(const Style::StyleColorValue& colorValue);
 
 private:
     void increment(StyleFeature feature, StyleAdaptationKind kind);
@@ -154,4 +176,5 @@ private:
     std::vector<StyleAdaptationCounter> m_counters;
     std::vector<StyleAdaptationExample> m_examples;
     std::vector<StyleLogicalStateExample> m_logicalStateExamples;
+    std::vector<ColorAdaptationExample> m_colorAdaptationExamples;
 };

--- a/TUI/Rendering/ConsoleRenderer.cpp
+++ b/TUI/Rendering/ConsoleRenderer.cpp
@@ -1192,6 +1192,7 @@ void ConsoleRenderer::flushDiagnosticsReport() const
     (void)wroteSuccessfully;
 }
 
+
 void ConsoleRenderer::recordStyleUsage(const Style& authoredStyle, const ResolvedStyle& resolvedStyle)
 {
     if (!m_renderDiagnostics.isEnabled())
@@ -1201,21 +1202,13 @@ void ConsoleRenderer::recordStyleUsage(const Style& authoredStyle, const Resolve
 
     const Style& presentedStyle = resolvedStyle.presentedStyle;
 
-    const std::optional<Color> authoredForeground =
-        ColorResolver::resolve(authoredStyle.foregroundColorValue(), ColorSupport::Rgb24);
-
-    const std::optional<Color> authoredBackground =
-        ColorResolver::resolve(authoredStyle.backgroundColorValue(), ColorSupport::Rgb24);
-
     recordColorFeature(
         StyleFeature::ForegroundColor,
-        authoredForeground,
-        presentedStyle.foreground());
+        resolvedStyle.foregroundColorDiagnostics);
 
     recordColorFeature(
         StyleFeature::BackgroundColor,
-        authoredBackground,
-        presentedStyle.background());
+        resolvedStyle.backgroundColorDiagnostics);
 
     recordTextFeature(
         StyleFeature::Bold,
@@ -1276,32 +1269,54 @@ void ConsoleRenderer::recordStyleUsage(const Style& authoredStyle, const Resolve
 
 void ConsoleRenderer::recordColorFeature(
     StyleFeature feature,
-    const std::optional<Color>& authoredColor,
-    const std::optional<Color>& presentedColor)
+    const std::optional<ColorResolutionDiagnostics>& diagnostics)
 {
-    if (!authoredColor.has_value())
+    if (!diagnostics.has_value())
     {
         return;
     }
 
     CapabilityReport& report = m_renderDiagnostics.report();
+    const std::optional<Color>& presentedColor = diagnostics->resolvedColor;
 
-    if (!presentedColor.has_value())
+    if (diagnostics->wasOmitted())
     {
         report.recordOmitted(feature);
 
         if (shouldCaptureExample(report, feature, StyleAdaptationKind::Omitted))
         {
+            report.addColorAdaptationExample(
+                feature,
+                StyleAdaptationKind::Omitted,
+                *diagnostics);
+
             report.addExample(
                 feature,
                 StyleAdaptationKind::Omitted,
-                buildColorExampleDetail("Color omitted", authoredColor, presentedColor));
+                "Color omitted after resolver/policy adaptation.");
         }
 
         return;
     }
 
-    if (*presentedColor == *authoredColor)
+    if (diagnostics->wasDowngraded())
+    {
+        report.recordDowngraded(feature);
+
+        if (shouldCaptureExample(report, feature, StyleAdaptationKind::Downgraded))
+        {
+            report.addColorAdaptationExample(
+                feature,
+                StyleAdaptationKind::Downgraded,
+                *diagnostics);
+
+            report.addExample(
+                feature,
+                StyleAdaptationKind::Downgraded,
+                "Color downgraded by resolver according to supported tier.");
+        }
+    }
+    else
     {
         if (!rendererPhysicallyRendersColor(presentedColor))
         {
@@ -1309,48 +1324,32 @@ void ConsoleRenderer::recordColorFeature(
 
             if (shouldCaptureExample(report, feature, StyleAdaptationKind::LogicalOnly))
             {
+                report.addColorAdaptationExample(
+                    feature,
+                    StyleAdaptationKind::LogicalOnly,
+                    *diagnostics);
+
                 report.addExample(
                     feature,
                     StyleAdaptationKind::LogicalOnly,
-                    buildColorExampleDetail("Color preserved logically but not mapped by Win32 attributes", authoredColor, presentedColor));
+                    "Resolved color remained logical-only on the active Win32 attribute path.");
             }
         }
         else
         {
             report.recordDirect(feature);
-        }
 
-        return;
-    }
-
-    const bool tierChanged = authoredColor->kind() != presentedColor->kind();
-
-    if (tierChanged)
-    {
-        report.recordDowngraded(feature);
-
-        if (shouldCaptureExample(report, feature, StyleAdaptationKind::Downgraded))
-        {
-            report.addExample(
-                feature,
-                StyleAdaptationKind::Downgraded,
-                buildColorExampleDetail("Color downgraded", authoredColor, presentedColor));
-        }
-    }
-    else
-    {
-        report.recordApproximated(feature);
-
-        if (shouldCaptureExample(report, feature, StyleAdaptationKind::Approximated))
-        {
-            report.addExample(
-                feature,
-                StyleAdaptationKind::Approximated,
-                buildColorExampleDetail("Color approximated", authoredColor, presentedColor));
+            if (shouldCaptureExample(report, feature, StyleAdaptationKind::Direct))
+            {
+                report.addColorAdaptationExample(
+                    feature,
+                    StyleAdaptationKind::Direct,
+                    *diagnostics);
+            }
         }
     }
 
-    if (!rendererPhysicallyRendersColor(presentedColor))
+    if (presentedColor.has_value() && !rendererPhysicallyRendersColor(presentedColor))
     {
         report.recordLogicalOnly(feature);
 
@@ -1359,7 +1358,7 @@ void ConsoleRenderer::recordColorFeature(
             report.addExample(
                 feature,
                 StyleAdaptationKind::LogicalOnly,
-                buildColorExampleDetail("Presented color remained non-basic and is not directly emitted by the Win32 attribute path", authoredColor, presentedColor));
+                "Presented color is resolved but not directly emitted by the Win32 attribute path.");
         }
     }
 }

--- a/TUI/Rendering/ConsoleRenderer.h
+++ b/TUI/Rendering/ConsoleRenderer.h
@@ -8,6 +8,7 @@
 #include "Rendering/Capabilities/RendererCapabilities.h"
 #include "Rendering/Diagnostics/RenderDiagnostics.h"
 #include "Rendering/Diagnostics/StartupDiagnosticsContext.h"
+#include "Rendering/Styles/ColorResolutionDiagnostics.h"
 #include "Rendering/FrameDiff.h"
 #include "Rendering/IRenderer.h"
 #include "Rendering/ScreenBuffer.h"
@@ -73,8 +74,7 @@ private:
     void recordStyleUsage(const Style& authoredStyle, const ResolvedStyle& resolvedStyle);
     void recordColorFeature(
         StyleFeature feature,
-        const std::optional<Color>& authoredColor,
-        const std::optional<Color>& presentedColor);
+        const std::optional<ColorResolutionDiagnostics>& diagnostics);
     void recordTextFeature(
         StyleFeature feature,
         const Style::AttributeState& authoredState,

--- a/TUI/Rendering/Diagnostics/RenderDiagnosticsWriter.cpp
+++ b/TUI/Rendering/Diagnostics/RenderDiagnosticsWriter.cpp
@@ -332,6 +332,43 @@ bool RenderDiagnosticsWriter::write(const RenderDiagnostics& diagnostics)
 
     out << "\n";
 
+    out << "Color Adaptation Decisions\n";
+    out << "--------------------------\n";
+
+    if (report.colorAdaptationExamples().empty())
+    {
+        out << "No color adaptation examples recorded.\n";
+    }
+    else
+    {
+        for (const ColorAdaptationExample& example : report.colorAdaptationExamples())
+        {
+            out
+                << "["
+                << CapabilityReport::toString(example.feature)
+                << " / "
+                << CapabilityReport::toString(example.kind)
+                << "] authored=" << CapabilityReport::formatAuthoredColor(example.authoredColor)
+                << ", supported tier=" << CapabilityReport::toString(example.supportedTier)
+                << ", resolved=";
+
+            if (example.resolvedColor.has_value())
+            {
+                out << CapabilityReport::formatColor(*example.resolvedColor);
+            }
+            else
+            {
+                out << "Omitted";
+            }
+
+            out
+                << ", reason=" << CapabilityReport::toString(example.reason)
+                << "\n";
+        }
+    }
+
+    out << "\n";
+
     out << "Tri-State Logical Style Examples\n";
     out << "--------------------------------\n";
     out << "Legend: Unspecified = field absent in authored style, ExplicitlyEnabled = field authored true, ExplicitlyDisabled = field authored false.\n";
@@ -411,7 +448,7 @@ bool RenderDiagnosticsWriter::write(const RenderDiagnostics& diagnostics)
     out << "- Host selection and renderer selection are reported separately on purpose.\n";
     out << "- VT enablement/availability and active renderer path are reported separately on purpose.\n";
     out << "- Output differences between authored style and visible result may be caused by downgrade, omission, approximation, or deferred emulation.\n";
-    out << "- Direct rendering can now increase when the backend capability/policy pair safely permits maximal feature use.\n";
+    out << "- Color adaptation reasons are reported from ColorResolver decisions rather than recreated in the renderer.\n";
     out << "- Bright basic color capability describes palette/intensity color presentation, not bold or dim text semantics.\n";
     out << "- Author-facing hints are advisory only and do not change rendering behavior.\n";
 

--- a/TUI/Rendering/Styles/ColorResolutionDiagnostics.cpp
+++ b/TUI/Rendering/Styles/ColorResolutionDiagnostics.cpp
@@ -1,0 +1,87 @@
+#include "Rendering/Styles/ColorResolutionDiagnostics.h"
+
+bool ColorResolutionDiagnostics::wasDowngraded() const
+{
+    switch (reason)
+    {
+    case ColorAdaptationReason::ConcreteIndexedDowngradedToBasic16:
+    case ColorAdaptationReason::ConcreteRgbDowngradedToIndexed256:
+    case ColorAdaptationReason::ConcreteRgbDowngradedToBasic16:
+    case ColorAdaptationReason::ThemeIndexedDowngradedToBasic16:
+    case ColorAdaptationReason::ThemeRgbDowngradedToIndexed256:
+    case ColorAdaptationReason::ThemeRgbDowngradedToBasic16:
+        return true;
+
+    default:
+        return false;
+    }
+}
+
+bool ColorResolutionDiagnostics::wasOmitted() const
+{
+    switch (reason)
+    {
+    case ColorAdaptationReason::OmittedByPolicy:
+    case ColorAdaptationReason::OmittedNoColorSupport:
+        return true;
+
+    default:
+        return false;
+    }
+}
+
+bool ColorResolutionDiagnostics::wasDirect() const
+{
+    return !wasDowngraded() && !wasOmitted();
+}
+
+const char* ColorResolutionDiagnostics::toString(ColorAdaptationReason reason)
+{
+    switch (reason)
+    {
+    case ColorAdaptationReason::ConcreteBasicUsedDirect:
+        return "Concrete basic color used directly";
+
+    case ColorAdaptationReason::ConcreteIndexedUsedDirect:
+        return "Concrete indexed color used directly";
+
+    case ColorAdaptationReason::ConcreteRgbUsedDirect:
+        return "Concrete RGB color used directly";
+
+    case ColorAdaptationReason::ConcreteIndexedDowngradedToBasic16:
+        return "Concrete indexed color downgraded to Basic16";
+
+    case ColorAdaptationReason::ConcreteRgbDowngradedToIndexed256:
+        return "Concrete RGB color downgraded to Indexed256";
+
+    case ColorAdaptationReason::ConcreteRgbDowngradedToBasic16:
+        return "Concrete RGB color downgraded to Basic16";
+
+    case ColorAdaptationReason::ThemeBasicUsedDirect:
+        return "ThemeColor basic fallback used directly";
+
+    case ColorAdaptationReason::ThemeIndexedUsedDirect:
+        return "ThemeColor indexed fallback used directly";
+
+    case ColorAdaptationReason::ThemeRgbUsedDirect:
+        return "ThemeColor RGB authored value used directly";
+
+    case ColorAdaptationReason::ThemeIndexedDowngradedToBasic16:
+        return "ThemeColor indexed fallback downgraded to Basic16";
+
+    case ColorAdaptationReason::ThemeRgbDowngradedToIndexed256:
+        return "ThemeColor RGB authored value downgraded to Indexed256";
+
+    case ColorAdaptationReason::ThemeRgbDowngradedToBasic16:
+        return "ThemeColor RGB authored value downgraded to Basic16";
+
+    case ColorAdaptationReason::OmittedByPolicy:
+        return "Color omitted by policy";
+
+    case ColorAdaptationReason::OmittedNoColorSupport:
+        return "Color omitted because no color support is available";
+
+    default:
+        return "Unknown";
+    }
+}

--- a/TUI/Rendering/Styles/ColorResolutionDiagnostics.h
+++ b/TUI/Rendering/Styles/ColorResolutionDiagnostics.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <optional>
+
+#include "Rendering/Capabilities/ColorSupport.h"
+#include "Rendering/Styles/Color.h"
+#include "Rendering/Styles/Style.h"
+
+enum class ColorAdaptationReason
+{
+    ConcreteBasicUsedDirect,
+    ConcreteIndexedUsedDirect,
+    ConcreteRgbUsedDirect,
+
+    ConcreteIndexedDowngradedToBasic16,
+    ConcreteRgbDowngradedToIndexed256,
+    ConcreteRgbDowngradedToBasic16,
+
+    ThemeBasicUsedDirect,
+    ThemeIndexedUsedDirect,
+    ThemeRgbUsedDirect,
+
+    ThemeIndexedDowngradedToBasic16,
+    ThemeRgbDowngradedToIndexed256,
+    ThemeRgbDowngradedToBasic16,
+
+    OmittedByPolicy,
+    OmittedNoColorSupport
+};
+
+struct ColorResolutionDiagnostics
+{
+    Style::StyleColorValue authoredColor;
+    ColorSupport supportedTier = ColorSupport::None;
+    std::optional<Color> resolvedColor;
+    ColorAdaptationReason reason = ColorAdaptationReason::OmittedNoColorSupport;
+
+    bool wasDowngraded() const;
+    bool wasOmitted() const;
+    bool wasDirect() const;
+
+    static const char* toString(ColorAdaptationReason reason);
+};

--- a/TUI/Rendering/Styles/ColorResolver.cpp
+++ b/TUI/Rendering/Styles/ColorResolver.cpp
@@ -2,18 +2,46 @@
 
 #include "Rendering/Styles/ColorMapping.h"
 
+namespace
+{
+    ColorResolutionDiagnostics makeOmitted(
+        const Style::StyleColorValue& authoredColor,
+        ColorSupport support,
+        ColorAdaptationReason reason)
+    {
+        ColorResolutionDiagnostics diagnostics;
+        diagnostics.authoredColor = authoredColor;
+        diagnostics.supportedTier = support;
+        diagnostics.reason = reason;
+        diagnostics.resolvedColor.reset();
+        return diagnostics;
+    }
+
+    ColorResolutionDiagnostics makeResolved(
+        const Style::StyleColorValue& authoredColor,
+        ColorSupport support,
+        const Color& resolvedColor,
+        ColorAdaptationReason reason)
+    {
+        ColorResolutionDiagnostics diagnostics;
+        diagnostics.authoredColor = authoredColor;
+        diagnostics.supportedTier = support;
+        diagnostics.resolvedColor = resolvedColor;
+        diagnostics.reason = reason;
+        return diagnostics;
+    }
+}
+
 Color ColorResolver::resolve(
     const Style::StyleColorValue& authoredColor,
     ColorSupport support)
 {
-    if (authoredColor.hasConcreteColor())
-    {
-        return resolveConcreteColor(*authoredColor.concreteColor(), support);
-    }
+    const ColorResolutionDiagnostics diagnostics =
+        resolveWithDiagnostics(authoredColor, support);
 
-    if (authoredColor.hasThemeColor())
+    if (diagnostics.resolvedColor.has_value())
     {
-        return resolveThemeColor(*authoredColor.themeColor(), support);
+        return *diagnostics.resolvedColor;
     }
 
     return Color::Default();
@@ -28,7 +56,10 @@ std::optional<Color> ColorResolver::resolve(
         return std::nullopt;
     }
 
-    return resolve(*authoredColor, support);
+    const ColorResolutionDiagnostics diagnostics =
+        resolveWithDiagnostics(*authoredColor, support);
+
+    return diagnostics.resolvedColor;
 }
 
 Color ColorResolver::resolveConcreteColor(
@@ -61,28 +92,208 @@ Color ColorResolver::resolveThemeColor(
     }
 }
 
+ColorResolutionDiagnostics ColorResolver::resolveWithDiagnostics(
+    const Style::StyleColorValue& authoredColor,
+    ColorSupport support)
+{
+    if (support == ColorSupport::None)
+    {
+        return makeOmitted(
+            authoredColor,
+            support,
+            ColorAdaptationReason::OmittedNoColorSupport);
+    }
+
+    if (authoredColor.hasConcreteColor())
+    {
+        const Color& color = *authoredColor.concreteColor();
+
+        if (color.isBasic16())
+        {
+            return makeResolved(
+                authoredColor,
+                support,
+                ColorMapping::mapToSupport(color, support),
+                ColorAdaptationReason::ConcreteBasicUsedDirect);
+        }
+
+        if (color.isIndexed256())
+        {
+            if (support >= ColorSupport::Indexed256)
+            {
+                return makeResolved(
+                    authoredColor,
+                    support,
+                    ColorMapping::mapToSupport(color, support),
+                    ColorAdaptationReason::ConcreteIndexedUsedDirect);
+            }
+
+            return makeResolved(
+                authoredColor,
+                support,
+                ColorMapping::indexedToBasic(color),
+                ColorAdaptationReason::ConcreteIndexedDowngradedToBasic16);
+        }
+
+        if (color.isRgb())
+        {
+            if (support >= ColorSupport::Rgb24)
+            {
+                return makeResolved(
+                    authoredColor,
+                    support,
+                    color,
+                    ColorAdaptationReason::ConcreteRgbUsedDirect);
+            }
+
+            if (support >= ColorSupport::Indexed256)
+            {
+                return makeResolved(
+                    authoredColor,
+                    support,
+                    ColorMapping::rgbToIndexed(color),
+                    ColorAdaptationReason::ConcreteRgbDowngradedToIndexed256);
+            }
+
+            return makeResolved(
+                authoredColor,
+                support,
+                ColorMapping::rgbToBasic(color),
+                ColorAdaptationReason::ConcreteRgbDowngradedToBasic16);
+        }
+
+        return makeResolved(
+            authoredColor,
+            support,
+            ColorMapping::mapToSupport(color, support),
+            ColorAdaptationReason::ConcreteBasicUsedDirect);
+    }
+
+    if (authoredColor.hasThemeColor())
+    {
+        const ThemeColor& themeColor = *authoredColor.themeColor();
+
+        switch (support)
+        {
+        case ColorSupport::Basic16:
+            if (themeColor.hasRgb())
+            {
+                return makeResolved(
+                    authoredColor,
+                    support,
+                    ColorMapping::rgbToBasic(*themeColor.rgb()),
+                    ColorAdaptationReason::ThemeRgbDowngradedToBasic16);
+            }
+
+            if (themeColor.hasIndexed())
+            {
+                return makeResolved(
+                    authoredColor,
+                    support,
+                    ColorMapping::indexedToBasic(*themeColor.indexed()),
+                    ColorAdaptationReason::ThemeIndexedDowngradedToBasic16);
+            }
+
+            if (themeColor.hasBasic())
+            {
+                return makeResolved(
+                    authoredColor,
+                    support,
+                    *themeColor.basic(),
+                    ColorAdaptationReason::ThemeBasicUsedDirect);
+            }
+
+            break;
+
+        case ColorSupport::Indexed256:
+            if (themeColor.hasRgb())
+            {
+                return makeResolved(
+                    authoredColor,
+                    support,
+                    ColorMapping::rgbToIndexed(*themeColor.rgb()),
+                    ColorAdaptationReason::ThemeRgbDowngradedToIndexed256);
+            }
+
+            if (themeColor.hasIndexed())
+            {
+                return makeResolved(
+                    authoredColor,
+                    support,
+                    *themeColor.indexed(),
+                    ColorAdaptationReason::ThemeIndexedUsedDirect);
+            }
+
+            if (themeColor.hasBasic())
+            {
+                return makeResolved(
+                    authoredColor,
+                    support,
+                    *themeColor.basic(),
+                    ColorAdaptationReason::ThemeBasicUsedDirect);
+            }
+
+            break;
+
+        case ColorSupport::Rgb24:
+            if (themeColor.hasRgb())
+            {
+                return makeResolved(
+                    authoredColor,
+                    support,
+                    *themeColor.rgb(),
+                    ColorAdaptationReason::ThemeRgbUsedDirect);
+            }
+
+            if (themeColor.hasIndexed())
+            {
+                return makeResolved(
+                    authoredColor,
+                    support,
+                    *themeColor.indexed(),
+                    ColorAdaptationReason::ThemeIndexedUsedDirect);
+            }
+
+            if (themeColor.hasBasic())
+            {
+                return makeResolved(
+                    authoredColor,
+                    support,
+                    *themeColor.basic(),
+                    ColorAdaptationReason::ThemeBasicUsedDirect);
+            }
+
+            break;
+
+        case ColorSupport::None:
+        default:
+            break;
+        }
+    }
+
+    return makeOmitted(
+        authoredColor,
+        support,
+        ColorAdaptationReason::OmittedNoColorSupport);
+}
+
+ColorResolutionDiagnostics ColorResolver::omittedByPolicy(
+    const Style::StyleColorValue& authoredColor)
+{
+    return makeOmitted(
+        authoredColor,
+        ColorSupport::None,
+        ColorAdaptationReason::OmittedByPolicy);
+}
+
 Color ColorResolver::resolveThemeColorForNone(const ThemeColor& themeColor)
 {
-    /*
-        No backend color support means authored color intent cannot be presented.
-        Returning Default keeps the result concrete while remaining policy-neutral.
-    */
     (void)themeColor;
     return Color::Default();
 }
 
 Color ColorResolver::resolveThemeColorForBasic16(const ThemeColor& themeColor)
 {
-    /*
-        Required resolution order:
-            RGB -> Indexed -> Basic
-
-        For a Basic16 backend:
-            RGB      -> downgrade to Basic16
-            Indexed  -> downgrade to Basic16
-            Basic    -> direct
-    */
-
     if (themeColor.hasRgb())
     {
         return ColorMapping::rgbToBasic(*themeColor.rgb());
@@ -103,16 +314,6 @@ Color ColorResolver::resolveThemeColorForBasic16(const ThemeColor& themeColor)
 
 Color ColorResolver::resolveThemeColorForIndexed256(const ThemeColor& themeColor)
 {
-    /*
-        Required resolution order:
-            RGB -> Indexed -> Basic
-
-        For an Indexed256 backend:
-            RGB      -> downgrade to Indexed256
-            Indexed  -> direct
-            Basic    -> direct
-    */
-
     if (themeColor.hasRgb())
     {
         return ColorMapping::rgbToIndexed(*themeColor.rgb());
@@ -133,19 +334,6 @@ Color ColorResolver::resolveThemeColorForIndexed256(const ThemeColor& themeColor
 
 Color ColorResolver::resolveThemeColorForRgb24(const ThemeColor& themeColor)
 {
-    /*
-        Required resolution order:
-            RGB -> Indexed -> Basic
-
-        For an Rgb24 backend:
-            RGB      -> direct
-            Indexed  -> direct
-            Basic    -> direct
-
-        Do not invent richer values here. Use the richest authored value that
-        actually exists, but do not up-convert Basic/Indexed into synthetic RGB.
-    */
-
     if (themeColor.hasRgb())
     {
         return *themeColor.rgb();

--- a/TUI/Rendering/Styles/ColorResolver.h
+++ b/TUI/Rendering/Styles/ColorResolver.h
@@ -4,30 +4,17 @@
 
 #include "Rendering/Capabilities/ColorSupport.h"
 #include "Rendering/Styles/Color.h"
+#include "Rendering/Styles/ColorResolutionDiagnostics.h"
 #include "Rendering/Styles/Style.h"
 #include "Rendering/Styles/ThemeColor.h"
 
 class ColorResolver
 {
 public:
-    /*
-        Main entry point for authored color intent.
-
-        Input:
-            - Style::StyleColorValue
-            - renderer-reported ColorSupport
-
-        Output:
-            - concrete Color suitable for the active backend tier
-    */
     static Color resolve(
         const Style::StyleColorValue& authoredColor,
         ColorSupport support);
 
-    /*
-        Convenience overload for optional authored color values.
-        Returns nullopt when the style field was not authored at all.
-    */
     static std::optional<Color> resolve(
         const std::optional<Style::StyleColorValue>& authoredColor,
         ColorSupport support);
@@ -39,6 +26,13 @@ public:
     static Color resolveThemeColor(
         const ThemeColor& themeColor,
         ColorSupport support);
+
+    static ColorResolutionDiagnostics resolveWithDiagnostics(
+        const Style::StyleColorValue& authoredColor,
+        ColorSupport support);
+
+    static ColorResolutionDiagnostics omittedByPolicy(
+        const Style::StyleColorValue& authoredColor);
 
 private:
     static Color resolveThemeColorForNone(const ThemeColor& themeColor);

--- a/TUI/Rendering/Styles/StylePolicy.cpp
+++ b/TUI/Rendering/Styles/StylePolicy.cpp
@@ -42,14 +42,28 @@ ResolvedStyle StylePolicy::resolve(const Style& style) const
     ResolvedStyle result;
     result.presentedStyle = style;
 
-    if (result.presentedStyle.hasForegroundColorValue())
+    if (style.hasForegroundColorValue())
     {
-        const std::optional<Color> resolved =
-            resolveAuthoredColor(result.presentedStyle.foregroundColorValue());
+        const Style::StyleColorValue& authoredColor = *style.foregroundColorValue();
+        const std::optional<ColorSupport> support =
+            selectColorSupportForAuthoredColor(authoredColor);
 
-        if (resolved.has_value())
+        if (support.has_value())
         {
-            result.presentedStyle = result.presentedStyle.withForeground(*resolved);
+            result.foregroundColorDiagnostics =
+                ColorResolver::resolveWithDiagnostics(authoredColor, *support);
+        }
+        else
+        {
+            result.foregroundColorDiagnostics =
+                ColorResolver::omittedByPolicy(authoredColor);
+        }
+
+        if (result.foregroundColorDiagnostics->resolvedColor.has_value())
+        {
+            result.presentedStyle =
+                result.presentedStyle.withForeground(
+                    *result.foregroundColorDiagnostics->resolvedColor);
         }
         else
         {
@@ -57,14 +71,28 @@ ResolvedStyle StylePolicy::resolve(const Style& style) const
         }
     }
 
-    if (result.presentedStyle.hasBackgroundColorValue())
+    if (style.hasBackgroundColorValue())
     {
-        const std::optional<Color> resolved =
-            resolveAuthoredColor(result.presentedStyle.backgroundColorValue());
+        const Style::StyleColorValue& authoredColor = *style.backgroundColorValue();
+        const std::optional<ColorSupport> support =
+            selectColorSupportForAuthoredColor(authoredColor);
 
-        if (resolved.has_value())
+        if (support.has_value())
         {
-            result.presentedStyle = result.presentedStyle.withBackground(*resolved);
+            result.backgroundColorDiagnostics =
+                ColorResolver::resolveWithDiagnostics(authoredColor, *support);
+        }
+        else
+        {
+            result.backgroundColorDiagnostics =
+                ColorResolver::omittedByPolicy(authoredColor);
+        }
+
+        if (result.backgroundColorDiagnostics->resolvedColor.has_value())
+        {
+            result.presentedStyle =
+                result.presentedStyle.withBackground(
+                    *result.backgroundColorDiagnostics->resolvedColor);
         }
         else
         {
@@ -273,25 +301,6 @@ StylePolicy StylePolicy::withFastBlinkMode(BlinkRenderMode mode) const
     return copy;
 }
 
-std::optional<Color> StylePolicy::resolveAuthoredColor(
-    const std::optional<Style::StyleColorValue>& authoredColor) const
-{
-    if (!authoredColor.has_value())
-    {
-        return std::nullopt;
-    }
-
-    const std::optional<ColorSupport> support =
-        selectColorSupportForAuthoredColor(*authoredColor);
-
-    if (!support.has_value())
-    {
-        return std::nullopt;
-    }
-
-    return ColorResolver::resolve(*authoredColor, *support);
-}
-
 std::optional<ColorSupport> StylePolicy::selectColorSupportForAuthoredColor(
     const Style::StyleColorValue& authoredColor) const
 {
@@ -337,13 +346,6 @@ std::optional<ColorSupport> StylePolicy::selectColorSupportForConcreteColor(
 std::optional<ColorSupport> StylePolicy::selectColorSupportForThemeColor(
     const ThemeColor& themeColor) const
 {
-    /*
-        ThemeColor resolution priority must remain:
-            RGB -> Indexed -> Basic
-
-        Policy selection follows that same authored-preference order.
-    */
-
     if (themeColor.hasRgb())
     {
         return supportFromMode(m_trueColorColorMode, ColorSupport::Rgb24);

--- a/TUI/Rendering/Styles/StylePolicy.h
+++ b/TUI/Rendering/Styles/StylePolicy.h
@@ -4,6 +4,7 @@
 
 #include "Rendering/Capabilities/ColorSupport.h"
 #include "Rendering/Styles/Color.h"
+#include "Rendering/Styles/ColorResolutionDiagnostics.h"
 #include "Rendering/Styles/Style.h"
 
 enum class ColorRenderMode
@@ -33,6 +34,9 @@ struct ResolvedStyle
     Style presentedStyle;
     bool emulateSlowBlink = false;
     bool emulateFastBlink = false;
+
+    std::optional<ColorResolutionDiagnostics> foregroundColorDiagnostics;
+    std::optional<ColorResolutionDiagnostics> backgroundColorDiagnostics;
 };
 
 class StylePolicy
@@ -77,9 +81,6 @@ public:
     StylePolicy withFastBlinkMode(BlinkRenderMode mode) const;
 
 private:
-    std::optional<Color> resolveAuthoredColor(
-        const std::optional<Style::StyleColorValue>& authoredColor) const;
-
     std::optional<ColorSupport> selectColorSupportForAuthoredColor(
         const Style::StyleColorValue& authoredColor) const;
 

--- a/TUI/TUI.vcxproj
+++ b/TUI/TUI.vcxproj
@@ -165,6 +165,10 @@
     <ClInclude Include="Rendering\Styles\BannerThemes.h" />
     <ClInclude Include="Rendering\Styles\Color.h" />
     <ClInclude Include="Rendering\Styles\ColorMapping.h" />
+    <ClInclude Include="Rendering\Styles\ColorResolutionDiagnostics.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</ExcludedFromBuild>
+    </ClInclude>
     <ClInclude Include="Rendering\Styles\ColorResolver.h" />
     <ClInclude Include="Rendering\Styles\Style.h" />
     <ClInclude Include="Rendering\Styles\StyleBuilder.h" />
@@ -217,6 +221,10 @@
     <ClCompile Include="Rendering\SgrEmitter.cpp" />
     <ClCompile Include="Rendering\Styles\Color.cpp" />
     <ClCompile Include="Rendering\Styles\ColorMapping.cpp" />
+    <ClCompile Include="Rendering\Styles\ColorResolutionDiagnostics.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="Rendering\Styles\ColorResolver.cpp" />
     <ClCompile Include="Rendering\Styles\Style.cpp" />
     <ClCompile Include="Rendering\Styles\StyleBuilder.cpp" />

--- a/TUI/TUI.vcxproj.filters
+++ b/TUI/TUI.vcxproj.filters
@@ -168,6 +168,15 @@
     <ClInclude Include="Rendering\Capabilities\ColorSupport.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="Rendering\Styles\ColorMapping.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Rendering\Styles\ColorResolver.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Rendering\Styles\ColorResolutionDiagnostics.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Rendering\ScreenBuffer.cpp">
@@ -276,6 +285,15 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="Rendering\Capabilities\RendererCapabilities.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Rendering\Styles\ColorMapping.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Rendering\Styles\ColorResolver.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Rendering\Styles\ColorResolutionDiagnostics.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
The flow is now:
- StylePolicy::resolve() chooses the target ColorSupport for each authored color field
- ColorResolver::resolveWithDiagnostics() resolves the color and returns:
     - the original authored color value
     - the selected support tier
     - the resolved concrete color, if any
     - the exact adaptation reason
- ResolvedStyle carries those foreground/background diagnostics alongside the presented style
- ConsoleRenderer records that structured decision into CapabilityReport
- RenderDiagnosticsWriter prints it in a dedicated Color Adaptation Decisions section

So the report now shows entries like:

- authored=ThemeColor(basic=Basic16(BrightCyan), indexed=Indexed256(51), rgb=Rgb24(95,255,255))
- supported tier=Basic16
- resolved=Basic16(BrightCyan)
- reason=ThemeColor RGB authored value downgraded to Basic16

That gives authors a direct explanation of what happened without asking the renderer to re-interpret the style or re-run downgrade logic.

Closes: #95 