### PR TITLE
TerminalRenderer: Add VT-native support for text attributes

### DIFF
--- a/TUI/Rendering/Backends/TerminalCapabilityDetector.cpp
+++ b/TUI/Rendering/Backends/TerminalCapabilityDetector.cpp
@@ -70,6 +70,22 @@ namespace
         return loweredHaystack.find(loweredNeedle) != std::wstring::npos;
     }
 
+    bool isWindowsTerminalEnvironment()
+    {
+        return hasEnvironmentVariable(L"WT_SESSION");
+    }
+
+    bool isVsCodeTerminalEnvironment()
+    {
+        const std::wstring termProgram = getEnvironmentVariableString(L"TERM_PROGRAM");
+        return equalsIgnoreCase(termProgram, L"vscode");
+    }
+
+    bool isConEmuEnvironment()
+    {
+        return hasEnvironmentVariable(L"ConEmuPID") || hasEnvironmentVariable(L"ConEmuANSI");
+    }
+
     bool isTrueColorEnvironment()
     {
         const std::wstring colorTerm = getEnvironmentVariableString(L"COLORTERM");
@@ -80,13 +96,12 @@ namespace
             return true;
         }
 
-        if (hasEnvironmentVariable(L"WT_SESSION"))
+        if (isWindowsTerminalEnvironment())
         {
             return true;
         }
 
-        const std::wstring termProgram = getEnvironmentVariableString(L"TERM_PROGRAM");
-        if (equalsIgnoreCase(termProgram, L"vscode"))
+        if (isVsCodeTerminalEnvironment())
         {
             return true;
         }
@@ -102,12 +117,24 @@ namespace
             return true;
         }
 
-        if (hasEnvironmentVariable(L"ConEmuPID") || hasEnvironmentVariable(L"ConEmuANSI"))
+        if (isConEmuEnvironment())
         {
             return true;
         }
 
         return false;
+    }
+
+    bool isXtermLikeEnvironment()
+    {
+        const std::wstring term = getEnvironmentVariableString(L"TERM");
+
+        return containsIgnoreCase(term, L"xterm") ||
+            containsIgnoreCase(term, L"screen") ||
+            containsIgnoreCase(term, L"tmux") ||
+            containsIgnoreCase(term, L"rxvt") ||
+            containsIgnoreCase(term, L"vt100") ||
+            containsIgnoreCase(term, L"vt220");
     }
 
     ColorSupport detectTerminalColorTier()
@@ -125,10 +152,45 @@ namespace
         return ColorSupport::Basic16;
     }
 
+    RendererFeatureSupport detectNativeStrikeSupport()
+    {
+        if (isWindowsTerminalEnvironment() || isVsCodeTerminalEnvironment())
+        {
+            return RendererFeatureSupport::Supported;
+        }
+
+        if (isXtermLikeEnvironment())
+        {
+            return RendererFeatureSupport::Supported;
+        }
+
+        return RendererFeatureSupport::Unsupported;
+    }
+
+    RendererFeatureSupport detectBlinkSupport()
+    {
+        if (isXtermLikeEnvironment())
+        {
+            return RendererFeatureSupport::Supported;
+        }
+
+        return RendererFeatureSupport::Emulated;
+    }
+
     RendererCapabilities buildTerminalCapabilities()
     {
         RendererCapabilities capabilities = RendererCapabilities::VirtualTerminal();
         capabilities.colorTier = detectTerminalColorTier();
+
+        capabilities.bold = RendererFeatureSupport::Supported;
+        capabilities.dim = RendererFeatureSupport::Supported;
+        capabilities.underline = RendererFeatureSupport::Supported;
+        capabilities.reverse = RendererFeatureSupport::Supported;
+        capabilities.invisible = RendererFeatureSupport::Supported;
+        capabilities.strike = detectNativeStrikeSupport();
+        capabilities.slowBlink = detectBlinkSupport();
+        capabilities.fastBlink = detectBlinkSupport();
+
         return capabilities;
     }
 }
@@ -171,4 +233,3 @@ TerminalCapabilityDetectionResult TerminalCapabilityDetector::detectAndConfigure
     result.terminalOutputReady = true;
     return result;
 }
-

--- a/TUI/Rendering/SgrEmitter.cpp
+++ b/TUI/Rendering/SgrEmitter.cpp
@@ -254,6 +254,46 @@ Style SgrEmitter::sanitizeForEmission(const Style& style) const
         sanitized = sanitized.withoutBackground();
     }
 
+    if (sanitized.bold() && !m_capabilities.supportsBoldDirect())
+    {
+        sanitized = sanitized.withBold(false);
+    }
+
+    if (sanitized.dim() && !m_capabilities.supportsDimDirect())
+    {
+        sanitized = sanitized.withDim(false);
+    }
+
+    if (sanitized.underline() && !m_capabilities.supportsUnderlineDirect())
+    {
+        sanitized = sanitized.withUnderline(false);
+    }
+
+    if (sanitized.reverse() && !m_capabilities.supportsReverseDirect())
+    {
+        sanitized = sanitized.withReverse(false);
+    }
+
+    if (sanitized.invisible() && !m_capabilities.supportsInvisibleDirect())
+    {
+        sanitized = sanitized.withInvisible(false);
+    }
+
+    if (sanitized.strike() && !m_capabilities.supportsStrikeDirect())
+    {
+        sanitized = sanitized.withStrike(false);
+    }
+
+    if (sanitized.slowBlink() && !m_capabilities.supportsSlowBlinkDirect())
+    {
+        sanitized = sanitized.withSlowBlink(false);
+    }
+
+    if (sanitized.fastBlink() && !m_capabilities.supportsFastBlinkDirect())
+    {
+        sanitized = sanitized.withFastBlink(false);
+    }
+
     return sanitized;
 }
 

--- a/TUI/Rendering/TerminalRenderer.cpp
+++ b/TUI/Rendering/TerminalRenderer.cpp
@@ -45,10 +45,8 @@ namespace
         case RendererFeatureSupport::Supported:
             return TextAttributeRenderMode::Direct;
 
-        case RendererFeatureSupport::Unknown:
-            return TextAttributeRenderMode::Approximate;
-
         case RendererFeatureSupport::Emulated:
+        case RendererFeatureSupport::Unknown:
         case RendererFeatureSupport::Unsupported:
         default:
             return TextAttributeRenderMode::Omit;
@@ -90,12 +88,10 @@ namespace
         const bool allowSafeFallback = capabilities.usesPreserveStyleSafeFallback();
 
         const bool maySafelyEmulateSlowBlink =
-            capabilities.mayEmulateSlowBlink() ||
-            capabilities.slowBlink == RendererFeatureSupport::Unknown;
+            capabilities.mayEmulateSlowBlink();
 
         const bool maySafelyEmulateFastBlink =
-            capabilities.mayEmulateFastBlink() ||
-            capabilities.fastBlink == RendererFeatureSupport::Unknown;
+            capabilities.mayEmulateFastBlink();
 
         policy = policy.withSlowBlinkMode(
             capabilities.supportsSlowBlinkDirect()

--- a/TUI/Screens/DigitalRainScreen.cpp
+++ b/TUI/Screens/DigitalRainScreen.cpp
@@ -122,7 +122,7 @@ DigitalRainScreen::DigitalRainScreen()
         + style::Bg(black);
 
     m_labelStyle =
-        style::Bold
+        style::Underline
         + style::Fg(Color::FromBasic(Color::Basic::BrightWhite))
         + style::Bg(black);
 
@@ -497,7 +497,8 @@ void DigitalRainScreen::drawOverlay(ScreenBuffer& buffer) const
     const int footerLabelY = m_screenHeight - 3;
     const int footerPreviewY = m_screenHeight - 2;
     
-    buffer.writeString(2, footerLabelY, "Pool:", m_labelStyle);
+    buffer.writeString(2, footerLabelY, "Pool", m_labelStyle);
+    buffer.writeChar(6, footerLabelY, ':', m_headStyle);
     drawPreviewLine(buffer, 8, footerLabelY, std::max(0, m_screenWidth - 10), m_previewOffset);
     
     // Use this footer for console


### PR DESCRIPTION
Modifies:
- Rendering/Backends/TerminalCapabilityDetector.cpp
- Rendering/SgrEmitter.cpp
- Rendering/TerminalRenderer.cpp
- DigitalRainScreen.cpp

TerminalRenderer now has VT-native support for all text attributes:
- bold
- dim
- underline
- reverse
- invisible
- strike
- blink

Policy is adjusted:
- if host support is detected to emit
- if host support is not detected check with Renderer for emulation
- if renderer supports emulation, then emulate
- if all else fails, omit

Closes: #79 