### PR TITLE
TerminalPresentPolicy: High-performance present policy

### DIFF
--- a/TUI/Rendering/Capabilities/CapabilityReport.cpp
+++ b/TUI/Rendering/Capabilities/CapabilityReport.cpp
@@ -108,6 +108,16 @@ const RendererSelectionTrace& CapabilityReport::rendererSelectionTrace() const
     return m_rendererSelectionTrace;
 }
 
+void CapabilityReport::setTerminalPresentPerformance(const TerminalPresentPerformanceSnapshot& performance)
+{
+    m_terminalPresentPerformance = performance;
+}
+
+const TerminalPresentPerformanceSnapshot& CapabilityReport::terminalPresentPerformance() const
+{
+    return m_terminalPresentPerformance;
+}
+
 void CapabilityReport::recordDirect(StyleFeature feature)
 {
     increment(feature, StyleAdaptationKind::Direct);
@@ -237,6 +247,7 @@ void CapabilityReport::clearRuntimeData()
     m_examples.clear();
     m_logicalStateExamples.clear();
     m_colorAdaptationExamples.clear();
+    m_terminalPresentPerformance = TerminalPresentPerformanceSnapshot{};
 }
 
 bool CapabilityReport::hasRuntimeData() const

--- a/TUI/Rendering/Capabilities/CapabilityReport.h
+++ b/TUI/Rendering/Capabilities/CapabilityReport.h
@@ -73,6 +73,29 @@ struct ColorAdaptationExample
     std::optional<Color> resolvedColor;
 };
 
+
+struct TerminalPresentPerformanceSnapshot
+{
+    std::size_t presentCallCount = 0;
+    std::size_t skippedPresentCount = 0;
+    std::size_t fullRedrawCount = 0;
+    std::size_t diffPresentCount = 0;
+    std::size_t forcedFullRedrawCount = 0;
+
+    std::size_t changedCellCount = 0;
+    std::size_t dirtySpanCount = 0;
+    std::size_t cursorMoveCount = 0;
+    std::size_t emittedRunCount = 0;
+
+    std::size_t emittedTextBytes = 0;
+    std::size_t emittedSgrBytes = 0;
+    std::size_t emittedControlBytes = 0;
+    std::size_t emittedTotalBytes = 0;
+
+    std::string lastPresentStrategy = "Unknown";
+    std::string lastPresentReason;
+};
+
 struct BackendStateSnapshot
 {
     std::string startupConfigSource = "startup.ini";
@@ -121,6 +144,9 @@ public:
     const StylePolicy& policy() const;
     const BackendStateSnapshot& backendState() const;
     const RendererSelectionTrace& rendererSelectionTrace() const;
+
+    void setTerminalPresentPerformance(const TerminalPresentPerformanceSnapshot& performance);
+    const TerminalPresentPerformanceSnapshot& terminalPresentPerformance() const;
 
     void recordDirect(StyleFeature feature);
     void recordDowngraded(StyleFeature feature);
@@ -177,6 +203,7 @@ private:
     StylePolicy m_policy{};
     BackendStateSnapshot m_backendState{};
     RendererSelectionTrace m_rendererSelectionTrace{};
+    TerminalPresentPerformanceSnapshot m_terminalPresentPerformance{};
 
     std::vector<StyleAdaptationCounter> m_counters;
     std::vector<StyleAdaptationExample> m_examples;

--- a/TUI/Rendering/Diagnostics/RenderDiagnosticsWriter.cpp
+++ b/TUI/Rendering/Diagnostics/RenderDiagnosticsWriter.cpp
@@ -521,5 +521,29 @@ bool RenderDiagnosticsWriter::write(const RenderDiagnostics& diagnostics)
     out << "- Bright basic color capability describes palette/intensity color presentation, not bold or dim text semantics.\n";
     out << "- Author-facing hints are advisory only and do not change rendering behavior.\n";
 
+    out << "VT Present Performance\n";
+    out << "----------------------\n";
+
+    const auto& vt = report.terminalPresentPerformance();
+
+    out << "Present calls: " << vt.presentCallCount << "\n";
+    out << "Skipped presents: " << vt.skippedPresentCount << "\n";
+    out << "Full redraw presents: " << vt.fullRedrawCount << "\n";
+    out << "Diff presents: " << vt.diffPresentCount << "\n";
+
+    out << "Changed cells: " << vt.changedCellCount << "\n";
+    out << "Dirty spans: " << vt.dirtySpanCount << "\n";
+
+    out << "Cursor moves: " << vt.cursorMoveCount << "\n";
+    out << "Runs: " << vt.emittedRunCount << "\n";
+
+    out << "Text bytes: " << vt.emittedTextBytes << "\n";
+    out << "SGR bytes: " << vt.emittedSgrBytes << "\n";
+    out << "Control bytes: " << vt.emittedControlBytes << "\n";
+    out << "Total bytes: " << vt.emittedTotalBytes << "\n";
+
+    out << "Last present strategy: " << vt.lastPresentStrategy << "\n";
+    out << "Last present reason: " << vt.lastPresentReason << "\n\n";
+
     return true;
 }

--- a/TUI/Rendering/TerminalPresentPolicy.cpp
+++ b/TUI/Rendering/TerminalPresentPolicy.cpp
@@ -1,0 +1,124 @@
+#include "Rendering/TerminalPresentPolicy.h"
+
+namespace
+{
+    constexpr double kHighCoverageThreshold = 0.60;
+    constexpr double kModerateCoverageThreshold = 0.35;
+}
+
+TerminalPresentDecision TerminalPresentPolicy::decide(const TerminalPresentMetrics& metrics) const
+{
+    TerminalPresentDecision decision;
+    decision.minimizeCursorMovement = true;
+
+    if (metrics.firstPresent)
+    {
+        decision.strategy = TerminalPresentStrategy::FullRedraw;
+        decision.clearScreenFirst = true;
+        decision.reason = "First present requires a full redraw.";
+        return decision;
+    }
+
+    if (metrics.sizeMismatch)
+    {
+        decision.strategy = TerminalPresentStrategy::FullRedraw;
+        decision.clearScreenFirst = true;
+        decision.reason = "Frame size changed, so the terminal surface must be redrawn.";
+        return decision;
+    }
+
+    if (metrics.blinkForcedFullPresent)
+    {
+        decision.strategy = TerminalPresentStrategy::FullRedraw;
+        decision.clearScreenFirst = true;
+        decision.reason = "Blink emulation visibility changed and requires a full present.";
+        return decision;
+    }
+
+    if (metrics.changedCells == 0 || metrics.dirtySpanCount == 0)
+    {
+        decision.strategy = TerminalPresentStrategy::DiffBased;
+        decision.clearScreenFirst = false;
+        decision.reason = "No changed cells were detected.";
+        return decision;
+    }
+
+    if (shouldPreferFullRedrawForCoverage(metrics))
+    {
+        decision.strategy = TerminalPresentStrategy::FullRedraw;
+        decision.clearScreenFirst = true;
+        decision.reason = "Changed-cell coverage is high enough that a full redraw is cheaper and simpler.";
+        return decision;
+    }
+
+    if (shouldPreferFullRedrawForFragmentation(metrics))
+    {
+        decision.strategy = TerminalPresentStrategy::FullRedraw;
+        decision.clearScreenFirst = true;
+        decision.reason = "Dirty regions are fragmented enough that diff presentation would be cursor-heavy.";
+        return decision;
+    }
+
+    decision.strategy = TerminalPresentStrategy::DiffBased;
+    decision.clearScreenFirst = false;
+    decision.reason = "Dirty-region coverage is low enough to benefit from diff-based presentation.";
+    return decision;
+}
+
+std::size_t TerminalPresentPolicy::estimateFullRedrawCells(const TerminalPresentMetrics& metrics)
+{
+    return metrics.totalCells;
+}
+
+std::size_t TerminalPresentPolicy::estimateDiffCells(const TerminalPresentMetrics& metrics)
+{
+    return metrics.changedCells;
+}
+
+const char* TerminalPresentPolicy::toString(TerminalPresentStrategy strategy)
+{
+    switch (strategy)
+    {
+    case TerminalPresentStrategy::FullRedraw:
+        return "FullRedraw";
+
+    case TerminalPresentStrategy::DiffBased:
+        return "DiffBased";
+
+    default:
+        return "Unknown";
+    }
+}
+
+bool TerminalPresentPolicy::shouldPreferFullRedrawForCoverage(const TerminalPresentMetrics& metrics) const
+{
+    if (metrics.totalCells == 0)
+    {
+        return false;
+    }
+
+    const double coverage =
+        static_cast<double>(metrics.changedCells) /
+        static_cast<double>(metrics.totalCells);
+
+    return coverage >= kHighCoverageThreshold;
+}
+
+bool TerminalPresentPolicy::shouldPreferFullRedrawForFragmentation(const TerminalPresentMetrics& metrics) const
+{
+    if (metrics.totalCells == 0 || metrics.frameHeight <= 0)
+    {
+        return false;
+    }
+
+    const double coverage =
+        static_cast<double>(metrics.changedCells) /
+        static_cast<double>(metrics.totalCells);
+
+    if (coverage < kModerateCoverageThreshold)
+    {
+        return false;
+    }
+
+    return metrics.dirtySpanCount > static_cast<std::size_t>(metrics.frameHeight);
+}

--- a/TUI/Rendering/TerminalPresentPolicy.h
+++ b/TUI/Rendering/TerminalPresentPolicy.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <cstddef>
+#include <string>
+
+class ScreenBuffer;
+
+enum class TerminalPresentStrategy
+{
+    FullRedraw,
+    DiffBased
+};
+
+struct TerminalPresentMetrics
+{
+    int frameWidth = 0;
+    int frameHeight = 0;
+
+    std::size_t totalCells = 0;
+    std::size_t changedCells = 0;
+    std::size_t dirtySpanCount = 0;
+    std::size_t dirtyRowCount = 0;
+
+    bool firstPresent = false;
+    bool sizeMismatch = false;
+    bool blinkForcedFullPresent = false;
+};
+
+struct TerminalPresentDecision
+{
+    TerminalPresentStrategy strategy = TerminalPresentStrategy::FullRedraw;
+    bool clearScreenFirst = false;
+    bool minimizeCursorMovement = true;
+    std::string reason;
+};
+
+class TerminalPresentPolicy
+{
+public:
+    TerminalPresentDecision decide(const TerminalPresentMetrics& metrics) const;
+
+    static std::size_t estimateFullRedrawCells(const TerminalPresentMetrics& metrics);
+    static std::size_t estimateDiffCells(const TerminalPresentMetrics& metrics);
+
+    static const char* toString(TerminalPresentStrategy strategy);
+
+private:
+    bool shouldPreferFullRedrawForCoverage(const TerminalPresentMetrics& metrics) const;
+    bool shouldPreferFullRedrawForFragmentation(const TerminalPresentMetrics& metrics) const;
+};

--- a/TUI/Rendering/TerminalRenderer.cpp
+++ b/TUI/Rendering/TerminalRenderer.cpp
@@ -12,6 +12,7 @@
 
 #include "Rendering/SgrEmitter.h"
 #include "Rendering/VtFrameEmitter.h"
+#include "Rendering/TerminalPresentPolicy.h"
 #include "Rendering/VtRun.h"
 
 /*
@@ -575,25 +576,71 @@ void TerminalRenderer::present(const ScreenBuffer& frame)
         throw std::runtime_error("TerminalRenderer::present called before initialize().");
     }
 
-    const bool forceFullPresentForBlink = shouldForceFullPresentForBlink(frame);
-
-    if (m_firstPresent ||
-        forceFullPresentForBlink ||
+    TerminalPresentMetrics metrics;
+    metrics.frameWidth = frame.getWidth();
+    metrics.frameHeight = frame.getHeight();
+    metrics.totalCells =
+        static_cast<std::size_t>(frame.getWidth()) *
+        static_cast<std::size_t>(frame.getHeight());
+    metrics.firstPresent = m_firstPresent;
+    metrics.sizeMismatch =
         m_previousFrame.getWidth() != frame.getWidth() ||
-        m_previousFrame.getHeight() != frame.getHeight())
+        m_previousFrame.getHeight() != frame.getHeight();
+    metrics.blinkForcedFullPresent = shouldForceFullPresentForBlink(frame);
+
+    std::vector<DirtySpan> spans;
+    if (!metrics.firstPresent && !metrics.sizeMismatch && !metrics.blinkForcedFullPresent)
     {
-        m_previousFrame.resize(frame.getWidth(), frame.getHeight());
-        m_previousFrame.clear();
+        spans = FrameDiff::diffRows(m_previousFrame, frame);
 
-        writeFullFrame(frame);
+        std::vector<bool> dirtyRows(static_cast<std::size_t>(frame.getHeight()), false);
+        for (const DirtySpan& span : spans)
+        {
+            metrics.changedCells += static_cast<std::size_t>(span.xEnd - span.xStart + 1);
+            metrics.dirtySpanCount += 1;
 
+            if (span.y >= 0 && span.y < frame.getHeight() && !dirtyRows[static_cast<std::size_t>(span.y)])
+            {
+                dirtyRows[static_cast<std::size_t>(span.y)] = true;
+                metrics.dirtyRowCount += 1;
+            }
+        }
+    }
+
+    const TerminalPresentDecision decision = m_presentPolicy.decide(metrics);
+
+    if (decision.strategy == TerminalPresentStrategy::DiffBased &&
+        !metrics.firstPresent &&
+        !metrics.sizeMismatch &&
+        !metrics.blinkForcedFullPresent &&
+        spans.empty())
+    {
+        recordPresentPerformance(decision, metrics, VtFrameEmitterStats{}, true);
         m_previousFrame = frame;
         m_firstPresent = false;
         return;
     }
 
-    writeDirtySpans(frame);
+    if (metrics.firstPresent || metrics.sizeMismatch)
+    {
+        m_previousFrame.resize(frame.getWidth(), frame.getHeight());
+        m_previousFrame.clear();
+    }
+
+    VtFrameEmitterStats emitterStats{};
+    if (decision.strategy == TerminalPresentStrategy::FullRedraw)
+    {
+        emitterStats = writeFullFrame(frame, decision.clearScreenFirst);
+    }
+    else
+    {
+        emitterStats = writeDirtySpans(frame, spans);
+    }
+
+    recordPresentPerformance(decision, metrics, emitterStats, false);
+
     m_previousFrame = frame;
+    m_firstPresent = false;
 }
 
 void TerminalRenderer::resize(int width, int height)
@@ -697,10 +744,10 @@ const RenderDiagnostics& TerminalRenderer::diagnostics() const
     return m_renderDiagnostics;
 }
 
-void TerminalRenderer::writeFullFrame(const ScreenBuffer& frame)
+VtFrameEmitterStats TerminalRenderer::writeFullFrame(const ScreenBuffer& frame, bool clearScreenFirst)
 {
     VtFrameEmitter emitter(m_sgrEmitter);
-    emitter.beginFrame(true);
+    emitter.beginFrame(clearScreenFirst);
 
     for (int y = 0; y < frame.getHeight(); ++y)
     {
@@ -708,15 +755,14 @@ void TerminalRenderer::writeFullFrame(const ScreenBuffer& frame)
     }
 
     writeRaw(emitter.finishFrame(false));
+    return emitter.stats();
 }
 
-void TerminalRenderer::writeDirtySpans(const ScreenBuffer& frame)
+VtFrameEmitterStats TerminalRenderer::writeDirtySpans(const ScreenBuffer& frame, const std::vector<DirtySpan>& spans)
 {
-    const std::vector<DirtySpan> spans = FrameDiff::diffRows(m_previousFrame, frame);
-
     if (spans.empty())
     {
-        return;
+        return VtFrameEmitterStats{};
     }
 
     VtFrameEmitter emitter(m_sgrEmitter);
@@ -728,6 +774,7 @@ void TerminalRenderer::writeDirtySpans(const ScreenBuffer& frame)
     }
 
     writeRaw(emitter.finishFrame(false));
+    return emitter.stats();
 }
 
 void TerminalRenderer::appendSpanRuns(
@@ -997,6 +1044,7 @@ void TerminalRenderer::initializeDiagnosticsState()
     report.setPolicy(m_stylePolicy);
     report.setBackendState(backendState);
     report.setRendererSelectionTrace(m_startupDiagnostics.selectionTrace);
+    report.setTerminalPresentPerformance(TerminalPresentPerformanceSnapshot{});
 }
 
 void TerminalRenderer::flushDiagnosticsReport() const
@@ -1381,6 +1429,67 @@ void TerminalRenderer::recordBlinkFeature(
             buildTextExampleDetail("Blink rendered directly", logicalState, presentedEnabled),
             logicalState);
     }
+}
+
+
+void TerminalRenderer::recordPresentPerformance(
+    const TerminalPresentDecision& decision,
+    const TerminalPresentMetrics& metrics,
+    const VtFrameEmitterStats& emitterStats,
+    bool skippedPresent)
+{
+    if (!m_renderDiagnostics.isEnabled())
+    {
+        return;
+    }
+
+    CapabilityReport& report = m_renderDiagnostics.report();
+    TerminalPresentPerformanceSnapshot performance = report.terminalPresentPerformance();
+
+    performance.presentCallCount += 1;
+
+    const std::size_t recordedChangedCells =
+        (decision.strategy == TerminalPresentStrategy::FullRedraw && !skippedPresent && metrics.changedCells == 0)
+        ? metrics.totalCells
+        : metrics.changedCells;
+
+    const std::size_t recordedDirtySpans =
+        (decision.strategy == TerminalPresentStrategy::FullRedraw && !skippedPresent && metrics.dirtySpanCount == 0)
+        ? static_cast<std::size_t>(metrics.frameHeight > 0 ? metrics.frameHeight : 0)
+        : metrics.dirtySpanCount;
+
+    performance.changedCellCount += recordedChangedCells;
+    performance.dirtySpanCount += recordedDirtySpans;
+
+    if (skippedPresent)
+    {
+        performance.skippedPresentCount += 1;
+    }
+    else if (decision.strategy == TerminalPresentStrategy::FullRedraw)
+    {
+        performance.fullRedrawCount += 1;
+    }
+    else
+    {
+        performance.diffPresentCount += 1;
+    }
+
+    if (metrics.blinkForcedFullPresent && decision.strategy == TerminalPresentStrategy::FullRedraw)
+    {
+        performance.forcedFullRedrawCount += 1;
+    }
+
+    performance.cursorMoveCount += emitterStats.cursorMoveCount;
+    performance.emittedRunCount += emitterStats.runCount;
+    performance.emittedTextBytes += emitterStats.emittedTextBytes;
+    performance.emittedSgrBytes += emitterStats.emittedSgrBytes;
+    performance.emittedControlBytes += emitterStats.emittedControlBytes;
+    performance.emittedTotalBytes += emitterStats.emittedTotalBytes;
+
+    performance.lastPresentStrategy = TerminalPresentPolicy::toString(decision.strategy);
+    performance.lastPresentReason = decision.reason;
+
+    report.setTerminalPresentPerformance(performance);
 }
 
 bool TerminalRenderer::shouldForceFullPresentForBlink(const ScreenBuffer& frame)

--- a/TUI/Rendering/TerminalRenderer.h
+++ b/TUI/Rendering/TerminalRenderer.h
@@ -3,6 +3,7 @@
 #include <string>
 #include <string_view>
 #include <chrono>
+#include <vector>
 
 #include "Rendering/Backends/TerminalCapabilityDetector.h"
 #include "Rendering/Capabilities/RendererCapabilities.h"
@@ -16,6 +17,7 @@
 #include "Rendering/Styles/Style.h"
 #include "Rendering/Styles/StylePolicy.h"
 #include "Rendering/Text/TextTypes.h"
+#include "Rendering/TerminalPresentPolicy.h"
 #include "Rendering/VtFrameEmitter.h"
 #include "Rendering/VtRun.h"
 
@@ -55,8 +57,8 @@ public:
     const RenderDiagnostics& diagnostics() const;
 
 private:
-    void writeFullFrame(const ScreenBuffer& frame);
-    void writeDirtySpans(const ScreenBuffer& frame);
+    VtFrameEmitterStats writeFullFrame(const ScreenBuffer& frame, bool clearScreenFirst);
+    VtFrameEmitterStats writeDirtySpans(const ScreenBuffer& frame, const std::vector<DirtySpan>& spans);
 
     void appendSpanRuns(
         VtFrameEmitter& emitter,
@@ -103,6 +105,11 @@ private:
         bool physicallyRendered);
 
     bool shouldForceFullPresentForBlink(const ScreenBuffer& frame);
+    void recordPresentPerformance(
+        const TerminalPresentDecision& decision,
+        const TerminalPresentMetrics& metrics,
+        const VtFrameEmitterStats& emitterStats,
+        bool skippedPresent);
     void collectBlinkEmulationUsage(
         const ScreenBuffer& frame,
         bool& usesSlowBlinkEmulation,
@@ -125,6 +132,7 @@ private:
     StylePolicy m_stylePolicy{};
     RendererCapabilities m_capabilities{};
     RenderDiagnostics m_renderDiagnostics{};
+    TerminalPresentPolicy m_presentPolicy{};
     StartupDiagnosticsContext m_startupDiagnostics{};
 
     UINT m_originalOutputCodePage = 0;

--- a/TUI/Rendering/VtFrameEmitter.cpp
+++ b/TUI/Rendering/VtFrameEmitter.cpp
@@ -10,10 +10,13 @@ VtFrameEmitter::VtFrameEmitter(SgrEmitter& sgrEmitter)
 void VtFrameEmitter::beginFrame(bool clearScreenFirst)
 {
     m_buffer.clear();
+    m_stats = VtFrameEmitterStats{};
 
     if (clearScreenFirst)
     {
+        const std::size_t before = m_buffer.size();
         m_buffer += "\x1b[2J\x1b[H";
+        m_stats.emittedControlBytes += (m_buffer.size() - before);
         m_cursorX = 0;
         m_cursorY = 0;
         m_cursorKnown = true;
@@ -37,8 +40,14 @@ void VtFrameEmitter::appendRun(const VtRun& run)
         appendCursorMove(run.xStart, run.y);
     }
 
-    m_sgrEmitter.appendTransitionTo(m_buffer, run.presentedStyle);
+    {
+        const std::size_t before = m_buffer.size();
+        m_sgrEmitter.appendTransitionTo(m_buffer, run.presentedStyle);
+        m_stats.emittedSgrBytes += (m_buffer.size() - before);
+    }
     m_buffer += run.utf8Text;
+    m_stats.runCount += 1;
+    m_stats.emittedTextBytes += run.utf8Text.size();
 
     m_cursorX = run.xStart + run.cellWidth;
     m_cursorY = run.y;
@@ -49,17 +58,28 @@ std::string VtFrameEmitter::finishFrame(bool resetStyleAtEnd)
 {
     if (resetStyleAtEnd)
     {
+        const std::size_t before = m_buffer.size();
         m_sgrEmitter.appendReset(m_buffer);
+        m_stats.emittedSgrBytes += (m_buffer.size() - before);
     }
 
+    m_stats.emittedTotalBytes = m_buffer.size();
     return std::move(m_buffer);
+}
+
+const VtFrameEmitterStats& VtFrameEmitter::stats() const
+{
+    return m_stats;
 }
 
 void VtFrameEmitter::appendCursorMove(int x, int y)
 {
+    const std::size_t before = m_buffer.size();
     m_buffer += "\x1b[";
     m_buffer += std::to_string(y + 1);
     m_buffer += ';';
     m_buffer += std::to_string(x + 1);
     m_buffer += 'H';
+    m_stats.cursorMoveCount += 1;
+    m_stats.emittedControlBytes += (m_buffer.size() - before);
 }

--- a/TUI/Rendering/VtFrameEmitter.h
+++ b/TUI/Rendering/VtFrameEmitter.h
@@ -1,9 +1,20 @@
 #pragma once
 
+#include <cstddef>
 #include <string>
 
 #include "Rendering/SgrEmitter.h"
 #include "Rendering/VtRun.h"
+
+struct VtFrameEmitterStats
+{
+    std::size_t cursorMoveCount = 0;
+    std::size_t runCount = 0;
+    std::size_t emittedTextBytes = 0;
+    std::size_t emittedSgrBytes = 0;
+    std::size_t emittedControlBytes = 0;
+    std::size_t emittedTotalBytes = 0;
+};
 
 class VtFrameEmitter
 {
@@ -13,6 +24,7 @@ public:
     void beginFrame(bool clearScreenFirst);
     void appendRun(const VtRun& run);
     std::string finishFrame(bool resetStyleAtEnd = false);
+    const VtFrameEmitterStats& stats() const;
 
 private:
     void appendCursorMove(int x, int y);
@@ -24,4 +36,5 @@ private:
     int m_cursorX = 0;
     int m_cursorY = 0;
     bool m_cursorKnown = false;
+    VtFrameEmitterStats m_stats{};
 };

--- a/TUI/TUI.vcxproj
+++ b/TUI/TUI.vcxproj
@@ -178,6 +178,7 @@
     <ClInclude Include="Rendering\Styles\ThemeColor.h" />
     <ClInclude Include="Rendering\Styles\UIThemes.h" />
     <ClInclude Include="Rendering\Surface.h" />
+    <ClInclude Include="Rendering\TerminalPresentPolicy.h" />
     <ClInclude Include="Rendering\TerminalRenderer.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</ExcludedFromBuild>
@@ -234,6 +235,7 @@
     <ClCompile Include="Rendering\Styles\StylePolicy.cpp" />
     <ClCompile Include="Rendering\Styles\ThemeColor.cpp" />
     <ClCompile Include="Rendering\Surface.cpp" />
+    <ClCompile Include="Rendering\TerminalPresentPolicy.cpp" />
     <ClCompile Include="Rendering\TerminalRenderer.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</ExcludedFromBuild>


### PR DESCRIPTION
Modifies:
- Rendering/ - Capabilities/ - CapabilityReport.h/.cpp - Diagnostics/ - RenderDiagnosticsWriter.cpp - TerminalRenderer.h/.cpp - VtFrameEmitter.h/.cpp
- TUI.vcxproj

Adds:
- Rendering/TerminalPresentPolicy.h/.cpp

Introduces a high-performance terminal present policy that can choose between full redraw and diff-based presentation, minimize cursor movement, and collect performance counters for VT rendering.

This should make animated screens noticeably faster and smoother on the TerminalRenderer path, especially when only part of the screen changes.

Closes: #81 