### PR TITLE
XpArtLoader: Finalize the conversion path from retained XP sequence d…

### DIFF
--- a/TUI/Rendering/Objects/XpArtLoader.cpp
+++ b/TUI/Rendering/Objects/XpArtLoader.cpp
@@ -427,7 +427,7 @@ namespace
 
     XpArtLoader::XpDocument resolveFrameDocumentForFlattening(
         const XpArtLoader::XpFrame& frame,
-        const XpArtLoader::XpSequenceMetadata* sequenceMetadata)
+        const XpArtLoader::ResolvedXpFrameConversion& conversion)
     {
         const XpArtLoader::XpDocument* document = frame.getDocument();
         if (document == nullptr)
@@ -435,31 +435,42 @@ namespace
             return {};
         }
 
-        XpArtLoader::XpSequenceMetadata emptyMetadata;
-        const XpArtLoader::XpSequenceMetadata& metadata =
-            sequenceMetadata != nullptr ? *sequenceMetadata : emptyMetadata;
-
-        const XpArtLoader::XpVisibleLayerMode visibleLayerMode =
-            frame.resolveVisibleLayerMode(metadata);
-
         return applyVisibleLayerOverride(
             *document,
-            visibleLayerMode,
-            frame.overrides.explicitVisibleLayerIndices);
+            conversion.visibleLayerMode,
+            conversion.explicitVisibleLayerIndices);
     }
 
     XpArtLoader::LoadOptions resolveFrameLoadOptions(
         const XpArtLoader::LoadOptions& options,
-        const XpArtLoader::XpFrame& frame,
-        const XpArtLoader::XpSequenceMetadata* sequenceMetadata)
+        const XpArtLoader::ResolvedXpFrameConversion& conversion)
     {
         XpArtLoader::LoadOptions resolved = options;
+        resolved.compositeMode = conversion.compositeMode;
+        return resolved;
+    }
 
+    XpArtLoader::ResolvedXpFrameConversion resolveFrameConversionInternal(
+        const XpArtLoader::XpFrame& frame,
+        const XpArtLoader::XpSequenceMetadata* sequenceMetadata,
+        const XpArtLoader::XpFrameConversionOptions& options)
+    {
         XpArtLoader::XpSequenceMetadata emptyMetadata;
         const XpArtLoader::XpSequenceMetadata& metadata =
             sequenceMetadata != nullptr ? *sequenceMetadata : emptyMetadata;
 
-        resolved.compositeMode = frame.resolveCompositeMode(metadata);
+        XpArtLoader::ResolvedXpFrameConversion resolved;
+        resolved.durationMilliseconds = frame.resolveDurationMilliseconds(metadata);
+        resolved.compositeMode = options.compositeModeOverride.has_value()
+            ? *options.compositeModeOverride
+            : frame.resolveCompositeMode(metadata);
+        resolved.visibleLayerMode = options.visibleLayerModeOverride.has_value()
+            ? *options.visibleLayerModeOverride
+            : frame.resolveVisibleLayerMode(metadata);
+        resolved.explicitVisibleLayerIndices =
+            !options.explicitVisibleLayerIndicesOverride.empty()
+            ? options.explicitVisibleLayerIndicesOverride
+            : frame.resolveExplicitVisibleLayerIndices(metadata);
         return resolved;
     }
 
@@ -921,15 +932,19 @@ namespace XpArtLoader
         return sequence;
     }
 
-    LoadResult buildTextObject(const ParsedDocument& document, const LoadOptions& options)
+    LoadResult buildTextObjectFromXpDocument(
+        const ParsedDocument& document,
+        const LoadOptions& options)
     {
         const XpDocument retained = buildRetainedDocument(document);
-        LoadResult result = buildTextObject(retained, options);
+        LoadResult result = buildTextObjectFromXpDocument(retained, options);
         result.parsedFormatVersion = document.formatVersion;
         return result;
     }
 
-    LoadResult buildTextObject(const XpDocument& document, const LoadOptions& options)
+    LoadResult buildTextObjectFromXpDocument(
+        const XpDocument& document,
+        const LoadOptions& options)
     {
         LoadResult result;
         result.detectedFileType = FileType::Xp;
@@ -1064,7 +1079,26 @@ namespace XpArtLoader
         return result;
     }
 
-    LoadResult buildTextObject(const XpFrame& frame, const LoadOptions& options)
+    ResolvedXpFrameConversion resolveFrameConversion(
+        const XpFrame& frame,
+        const XpSequenceMetadata* sequenceMetadata,
+        const XpFrameConversionOptions& options)
+    {
+        return resolveFrameConversionInternal(frame, sequenceMetadata, options);
+    }
+
+    LoadResult buildTextObjectFromXpFrame(
+        const XpFrame& frame,
+        const XpFrameConversionOptions& options)
+    {
+        XpSequenceMetadata emptyMetadata;
+        return buildTextObjectFromXpFrame(frame, emptyMetadata, options);
+    }
+
+    LoadResult buildTextObjectFromXpFrame(
+        const XpFrame& frame,
+        const XpSequenceMetadata& sequenceMetadata,
+        const XpFrameConversionOptions& options)
     {
         if (!frame.isValid())
         {
@@ -1075,17 +1109,34 @@ namespace XpArtLoader
             return result;
         }
 
-        const XpDocument resolvedDocument = resolveFrameDocumentForFlattening(frame, nullptr);
-        const LoadOptions resolvedOptions = resolveFrameLoadOptions(options, frame, nullptr);
+        const ResolvedXpFrameConversion conversion =
+            resolveFrameConversion(frame, &sequenceMetadata, options);
 
-        LoadResult result = buildTextObject(resolvedDocument, resolvedOptions);
+        if (!conversion.isValidForDocument(frame.getDocument()))
+        {
+            LoadResult result;
+            result.success = false;
+            result.detectedFileType = FileType::Xp;
+            result.errorMessage = "Resolved XP frame conversion policy is invalid for the retained XP document.";
+            return result;
+        }
+
+        const XpDocument resolvedDocument =
+            resolveFrameDocumentForFlattening(frame, conversion);
+        const LoadOptions resolvedOptions =
+            resolveFrameLoadOptions(options.loadOptions, conversion);
+
+        LoadResult result = buildTextObjectFromXpDocument(resolvedDocument, resolvedOptions);
         result.retainedSequence = buildRetainedSequence(frame);
         result.hasRetainedSequence = result.retainedSequence.isValid();
         result.resolvedFrameCount = result.retainedSequence.getFrameCount();
+        result.compositeModeUsed = conversion.compositeMode;
         return result;
     }
 
-    LoadResult buildTextObject(const XpSequence& sequence, const LoadOptions& options)
+    LoadResult buildTextObjectFromXpSequence(
+        const XpSequence& sequence,
+        const XpFrameConversionOptions& options)
     {
         if (!sequence.isValid())
         {
@@ -1106,16 +1157,38 @@ namespace XpArtLoader
             return result;
         }
 
-        const XpDocument resolvedDocument =
-            resolveFrameDocumentForFlattening(*frame, &sequence.metadata);
-        const LoadOptions resolvedOptions =
-            resolveFrameLoadOptions(options, *frame, &sequence.metadata);
-
-        LoadResult result = buildTextObject(resolvedDocument, resolvedOptions);
+        LoadResult result = buildTextObjectFromXpFrame(
+            *frame,
+            sequence.metadata,
+            options);
         result.retainedSequence = sequence;
         result.hasRetainedSequence = result.retainedSequence.isValid();
         result.resolvedFrameCount = result.retainedSequence.getFrameCount();
         return result;
+    }
+
+    LoadResult buildTextObject(const ParsedDocument& document, const LoadOptions& options)
+    {
+        return buildTextObjectFromXpDocument(document, options);
+    }
+
+    LoadResult buildTextObject(const XpDocument& document, const LoadOptions& options)
+    {
+        return buildTextObjectFromXpDocument(document, options);
+    }
+
+    LoadResult buildTextObject(const XpFrame& frame, const LoadOptions& options)
+    {
+        XpFrameConversionOptions conversionOptions;
+        conversionOptions.loadOptions = options;
+        return buildTextObjectFromXpFrame(frame, conversionOptions);
+    }
+
+    LoadResult buildTextObject(const XpSequence& sequence, const LoadOptions& options)
+    {
+        XpFrameConversionOptions conversionOptions;
+        conversionOptions.loadOptions = options;
+        return buildTextObjectFromXpSequence(sequence, conversionOptions);
     }
 
     LoadResult loadFromBytes(std::string_view bytes, const LoadOptions& options)
@@ -1528,6 +1601,46 @@ namespace XpArtLoader
 
             return true;
         }
+    }
+
+    bool XpFrameConversionOptions::isEmpty() const
+    {
+        return !compositeModeOverride.has_value() &&
+            !visibleLayerModeOverride.has_value() &&
+            explicitVisibleLayerIndicesOverride.empty();
+    }
+
+    bool XpFrameConversionOptions::usesExplicitVisibleLayerListOverride() const
+    {
+        return visibleLayerModeOverride.has_value() &&
+            *visibleLayerModeOverride == XpVisibleLayerMode::UseExplicitVisibleLayerList;
+    }
+
+    bool ResolvedXpFrameConversion::usesExplicitVisibleLayerList() const
+    {
+        return visibleLayerMode == XpVisibleLayerMode::UseExplicitVisibleLayerList;
+    }
+
+    bool ResolvedXpFrameConversion::isValidForDocument(const XpDocument* document) const
+    {
+        if (durationMilliseconds.has_value() && *durationMilliseconds < 0)
+        {
+            return false;
+        }
+
+        if (!explicitVisibleLayerIndices.empty() &&
+            !areVisibleLayerIndicesValid(explicitVisibleLayerIndices, document))
+        {
+            return false;
+        }
+
+        if (usesExplicitVisibleLayerList() &&
+            !areVisibleLayerIndicesValid(explicitVisibleLayerIndices, document))
+        {
+            return false;
+        }
+
+        return true;
     }
 
     bool XpFrameOverrides::isEmpty() const

--- a/TUI/Rendering/Objects/XpArtLoader.h
+++ b/TUI/Rendering/Objects/XpArtLoader.h
@@ -296,6 +296,28 @@ namespace XpArtLoader
         std::optional<Style> baseStyle;
     };
 
+    struct XpFrameConversionOptions
+    {
+        LoadOptions loadOptions;
+        std::optional<XpCompositeMode> compositeModeOverride;
+        std::optional<XpVisibleLayerMode> visibleLayerModeOverride;
+        std::vector<int> explicitVisibleLayerIndicesOverride;
+
+        bool isEmpty() const;
+        bool usesExplicitVisibleLayerListOverride() const;
+    };
+
+    struct ResolvedXpFrameConversion
+    {
+        std::optional<int> durationMilliseconds;
+        XpCompositeMode compositeMode = XpCompositeMode::Phase45BCompatible;
+        XpVisibleLayerMode visibleLayerMode = XpVisibleLayerMode::UseDocumentVisibility;
+        std::vector<int> explicitVisibleLayerIndices;
+
+        bool usesExplicitVisibleLayerList() const;
+        bool isValidForDocument(const XpDocument* document) const;
+    };
+
     struct LoadResult
     {
         TextObject object;
@@ -359,6 +381,32 @@ namespace XpArtLoader
     bool tryLoadFromFile(const std::string& filePath, TextObject& outObject, const Style& style);
 
     LoadResult loadFromBytes(std::string_view bytes, const LoadOptions& options = {});
+
+    ResolvedXpFrameConversion resolveFrameConversion(
+        const XpFrame& frame,
+        const XpSequenceMetadata* sequenceMetadata = nullptr,
+        const XpFrameConversionOptions& options = {});
+
+    LoadResult buildTextObjectFromXpDocument(
+        const ParsedDocument& document,
+        const LoadOptions& options = {});
+
+    LoadResult buildTextObjectFromXpDocument(
+        const XpDocument& document,
+        const LoadOptions& options = {});
+
+    LoadResult buildTextObjectFromXpFrame(
+        const XpFrame& frame,
+        const XpFrameConversionOptions& options = {});
+
+    LoadResult buildTextObjectFromXpFrame(
+        const XpFrame& frame,
+        const XpSequenceMetadata& sequenceMetadata,
+        const XpFrameConversionOptions& options = {});
+
+    LoadResult buildTextObjectFromXpSequence(
+        const XpSequence& sequence,
+        const XpFrameConversionOptions& options = {});
 
     LoadResult buildTextObject(const ParsedDocument& document, const LoadOptions& options = {});
     LoadResult buildTextObject(const XpDocument& document, const LoadOptions& options = {});


### PR DESCRIPTION
…ata into TextObject

Modifies:
- Rendering/Objects/XpArtLoader.h/.cpp

1. Makes frame conversion explicit (no more hidden behavior) Clear APIs:
- buildTextObjectFromXpDocument(...)
- buildTextObjectFromXpFrame(...)
- buildTextObjectFromXpSequence(...)

No more implicit or scattered conversion logic.

2. Properly supports sequence-based animation data
- Each frame is converted with awareness of sequence defaults
- can safely load .xpseq and know every frame resolves consistently

3. Establishes strict, predictable precedence rules
- Caller overrides > Frame overrides > Sequence defaults > Engine fallback
- This removes ambiguity and prevents “why does this frame look different?” bugs

4. Fixes a key correctness gap
- Sequence-level visible layer settings are now actually respected during conversion
- Previously, they could be silently ignored

5. Keeps architecture clean and future-proof
- No logic leaked into renderer, PageComposer, or commands
- No duplicate .xp parsing
- Fully compatible with: - future playback system - asset caching / retrieval - editor tooling

6. Centralizes all conversion policy in one place
- resolveFrameConversion(...) becomes the single source of truth
- Easy to debug, extend, or unit test later

Closes: #132 