### PR TITLE
XpSequenceDiagnosticsScreen: integrate manifest-first XP sequence dia…

### DIFF
--- a/TUI/Rendering/Objects/XpSequenceInspection.cpp
+++ b/TUI/Rendering/Objects/XpSequenceInspection.cpp
@@ -173,6 +173,14 @@ namespace
 
 namespace XpSequenceInspection
 {
+    bool FrameInspection::hasAnyRetainedOverride() const
+    {
+        return hasDurationOverride ||
+            hasCompositeOverride ||
+            hasVisibleLayerModeOverride ||
+            hasExplicitVisibleLayerOverride;
+    }
+
     InspectionReport inspectSequence(
         const XpArtLoader::XpSequence& sequence,
         const std::string& manifestPath,
@@ -208,12 +216,38 @@ namespace XpSequenceInspection
         report.frames.reserve(sequence.frames.size());
         for (std::size_t ordinal = 0; ordinal < sequence.frames.size(); ++ordinal)
         {
-            report.frames.push_back(
-                buildFrameInspection(
-                    sequence,
-                    manifestPath,
-                    static_cast<int>(ordinal),
-                    sequence.frames[ordinal]));
+            FrameInspection inspection = buildFrameInspection(
+                sequence,
+                manifestPath,
+                static_cast<int>(ordinal),
+                sequence.frames[ordinal]);
+
+            if (inspection.hasDocument)
+            {
+                ++report.framesWithDocuments;
+            }
+
+            if (inspection.hasSourcePath)
+            {
+                ++report.framesWithSourcePaths;
+            }
+
+            if (inspection.hasAnyRetainedOverride())
+            {
+                ++report.framesWithAnyOverrides;
+            }
+
+            if (inspection.hasSourcePath && !inspection.sourceExistsOnDisk)
+            {
+                ++report.framesMissingResolvedSources;
+            }
+
+            if (inspection.sourcePathEscapesManifestDirectory)
+            {
+                ++report.framesEscapingManifestDirectory;
+            }
+
+            report.frames.push_back(std::move(inspection));
         }
 
         if (loadDiagnostics != nullptr)
@@ -252,16 +286,38 @@ namespace XpSequenceInspection
         metadata.defaultFrameDurationMilliseconds =
             sequence.metadata.defaultFrameDurationMilliseconds;
         metadata.defaultFramesPerSecond = sequence.metadata.defaultFramesPerSecond;
+        metadata.defaultCompositeMode = sequence.metadata.defaultCompositeMode;
+        metadata.defaultVisibleLayerMode = sequence.metadata.defaultVisibleLayerMode;
 
         metadata.orderedFrameIndices.reserve(sequence.frames.size());
-        for (const XpArtLoader::XpFrame& frame : sequence.frames)
+        for (std::size_t ordinal = 0; ordinal < sequence.frames.size(); ++ordinal)
         {
+            const XpArtLoader::XpFrame& frame = sequence.frames[ordinal];
             metadata.orderedFrameIndices.push_back(frame.frameIndex);
+            metadata.hasFrameTimingOverrides =
+                metadata.hasFrameTimingOverrides || frame.overrides.durationMilliseconds.has_value();
+            metadata.hasFrameVisibilityOrCompositeOverrides =
+                metadata.hasFrameVisibilityOrCompositeOverrides ||
+                frame.overrides.compositeMode.has_value() ||
+                frame.overrides.visibleLayerMode.has_value() ||
+                frame.overrides.usesExplicitVisibleLayerList();
+            metadata.hasLinkedFrameSources =
+                metadata.hasLinkedFrameSources || frame.hasSourcePath();
+            metadata.hasRetainedFrameDocuments =
+                metadata.hasRetainedFrameDocuments || frame.hasDocument();
         }
 
         if (const XpArtLoader::XpFrame* defaultFrame = sequence.getDefaultFrame())
         {
             metadata.initialFrameIndex = defaultFrame->frameIndex;
+            for (std::size_t ordinal = 0; ordinal < sequence.frames.size(); ++ordinal)
+            {
+                if (&sequence.frames[ordinal] == defaultFrame)
+                {
+                    metadata.initialFrameOrdinal = static_cast<int>(ordinal);
+                    break;
+                }
+            }
         }
 
         return metadata;
@@ -279,6 +335,9 @@ namespace XpSequenceInspection
             << ", uniqueIndices=" << (report.hasUniqueFrameIndices ? "true" : "false")
             << ", contiguous=" << (report.hasContiguousFrameIndicesStartingAtZero ? "true" : "false")
             << ", storedInOrder=" << (report.framesStoredInFrameIndexOrder ? "true" : "false")
+            << ", retainedDocs=" << report.framesWithDocuments << '/' << report.frameCount
+            << ", sourcePaths=" << report.framesWithSourcePaths << '/' << report.frameCount
+            << ", overrideFrames=" << report.framesWithAnyOverrides
             << ", loadDiagnostics=" << report.loadDiagnostics.size()
             << ", validationDiagnostics=" << report.validationDiagnostics.size();
 
@@ -347,6 +406,61 @@ namespace XpSequenceInspection
         return stream.str();
     }
 
+    std::string formatSourceResolutionSummary(const InspectionReport& report)
+    {
+        if (!report.hasSequence)
+        {
+            return "Source resolution: unavailable";
+        }
+
+        std::ostringstream stream;
+        stream << "Source resolution: manifestDir=";
+        if (report.manifestDirectory.empty())
+        {
+            stream << "<none>";
+        }
+        else
+        {
+            stream << report.manifestDirectory;
+        }
+
+        stream << ", linkedFrames=" << report.framesWithSourcePaths
+            << ", retainedFrames=" << report.framesWithDocuments
+            << ", missingResolvedSources=" << report.framesMissingResolvedSources
+            << ", manifestEscapes=" << report.framesEscapingManifestDirectory;
+
+        return stream.str();
+    }
+
+    std::string formatOverrideSummary(const InspectionReport& report)
+    {
+        if (!report.hasSequence)
+        {
+            return "Resolved overrides: unavailable";
+        }
+
+        int durationOverrideCount = 0;
+        int compositeOverrideCount = 0;
+        int visibilityOverrideCount = 0;
+        int explicitLayerOverrideCount = 0;
+
+        for (const FrameInspection& frame : report.frames)
+        {
+            durationOverrideCount += frame.hasDurationOverride ? 1 : 0;
+            compositeOverrideCount += frame.hasCompositeOverride ? 1 : 0;
+            visibilityOverrideCount += frame.hasVisibleLayerModeOverride ? 1 : 0;
+            explicitLayerOverrideCount += frame.hasExplicitVisibleLayerOverride ? 1 : 0;
+        }
+
+        std::ostringstream stream;
+        stream << "Resolved overrides: duration=" << durationOverrideCount
+            << ", composite=" << compositeOverrideCount
+            << ", visibilityMode=" << visibilityOverrideCount
+            << ", explicitVisibleLayers=" << explicitLayerOverrideCount;
+
+        return stream.str();
+    }
+
     std::string formatFrameSummary(const InspectionReport& report, const int ordinal)
     {
         if (ordinal < 0 || ordinal >= static_cast<int>(report.frames.size()))
@@ -391,7 +505,8 @@ namespace XpSequenceInspection
         }
 
         stream << ", composite=" << XpArtLoader::toString(frame.resolvedCompositeMode)
-            << ", visibleLayers=" << XpArtLoader::toString(frame.resolvedVisibleLayerMode);
+            << ", visibleLayers=" << XpArtLoader::toString(frame.resolvedVisibleLayerMode)
+            << ", hasOverrides=" << (frame.hasAnyRetainedOverride() ? "true" : "false");
 
         if (!frame.resolvedExplicitVisibleLayerIndices.empty())
         {
@@ -411,7 +526,8 @@ namespace XpSequenceInspection
         }
 
         std::ostringstream stream;
-        stream << "Playback hook metadata: initialFrameIndex=" << playback.initialFrameIndex
+        stream << "Playback hook metadata: initialFrameOrdinal=" << playback.initialFrameOrdinal
+            << ", initialFrameIndex=" << playback.initialFrameIndex
             << ", frameCount=" << playback.frameCount;
 
         if (playback.loop.has_value())
@@ -429,6 +545,27 @@ namespace XpSequenceInspection
         {
             stream << ", defaultFps=" << *playback.defaultFramesPerSecond;
         }
+
+        if (playback.defaultCompositeMode.has_value())
+        {
+            stream << ", defaultComposite="
+                << XpArtLoader::toString(*playback.defaultCompositeMode);
+        }
+
+        if (playback.defaultVisibleLayerMode.has_value())
+        {
+            stream << ", defaultVisibleLayers="
+                << XpArtLoader::toString(*playback.defaultVisibleLayerMode);
+        }
+
+        stream << ", frameTimingOverrides="
+            << (playback.hasFrameTimingOverrides ? "true" : "false")
+            << ", visibilityOrCompositeOverrides="
+            << (playback.hasFrameVisibilityOrCompositeOverrides ? "true" : "false")
+            << ", linkedFrameSources="
+            << (playback.hasLinkedFrameSources ? "true" : "false")
+            << ", retainedFrameDocuments="
+            << (playback.hasRetainedFrameDocuments ? "true" : "false");
 
         if (!playback.orderedFrameIndices.empty())
         {

--- a/TUI/Rendering/Objects/XpSequenceInspection.h
+++ b/TUI/Rendering/Objects/XpSequenceInspection.h
@@ -48,16 +48,25 @@ namespace XpSequenceInspection
         std::vector<std::string> layerDetails;
         int resolvedVisibleLayerCount = 0;
         int resolvedHiddenLayerCount = 0;
+
+        bool hasAnyRetainedOverride() const;
     };
 
     struct SequencePlaybackMetadata
     {
         bool isInspectable = false;
+        int initialFrameOrdinal = -1;
         int initialFrameIndex = -1;
         int frameCount = 0;
         std::optional<bool> loop;
         std::optional<int> defaultFrameDurationMilliseconds;
         std::optional<int> defaultFramesPerSecond;
+        std::optional<XpArtLoader::XpCompositeMode> defaultCompositeMode;
+        std::optional<XpArtLoader::XpVisibleLayerMode> defaultVisibleLayerMode;
+        bool hasFrameTimingOverrides = false;
+        bool hasFrameVisibilityOrCompositeOverrides = false;
+        bool hasLinkedFrameSources = false;
+        bool hasRetainedFrameDocuments = false;
         std::vector<int> orderedFrameIndices;
     };
 
@@ -84,6 +93,12 @@ namespace XpSequenceInspection
         std::optional<XpArtLoader::XpVisibleLayerMode> defaultVisibleLayerMode;
         std::vector<int> defaultExplicitVisibleLayerIndices;
 
+        int framesWithDocuments = 0;
+        int framesWithSourcePaths = 0;
+        int framesWithAnyOverrides = 0;
+        int framesMissingResolvedSources = 0;
+        int framesEscapingManifestDirectory = 0;
+
         std::vector<FrameInspection> frames;
         std::vector<XpSequenceLoader::Diagnostic> loadDiagnostics;
         std::vector<XpSequenceValidation::Diagnostic> validationDiagnostics;
@@ -106,6 +121,8 @@ namespace XpSequenceInspection
 
     std::string formatInspectionSummary(const InspectionReport& report);
     std::string formatManifestFieldSummary(const InspectionReport& report);
+    std::string formatSourceResolutionSummary(const InspectionReport& report);
+    std::string formatOverrideSummary(const InspectionReport& report);
     std::string formatFrameSummary(const InspectionReport& report, int ordinal);
     std::string formatPlaybackHookSummary(const InspectionReport& report);
 }

--- a/TUI/Screens/Developer/XpSequenceDiagnosticsScreen.cpp
+++ b/TUI/Screens/Developer/XpSequenceDiagnosticsScreen.cpp
@@ -123,12 +123,12 @@ void XpSequenceDiagnosticsScreen::draw(Surface& surface)
     buffer.writeString(screenWidth - 40, 0, "[ manifest-first inspection ]", Themes::Info);
 
     const int halfWidth = screenWidth / 2;
-    drawSummaryPanel(buffer, 1, 2, halfWidth - 1, 9);
-    drawManifestPanel(buffer, halfWidth, 2, screenWidth - halfWidth - 1, 9);
-    drawPlaybackPanel(buffer, 1, 11, halfWidth - 1, 7);
-    drawDiagnosticsPanel(buffer, halfWidth, 11, screenWidth - halfWidth - 1, 7);
-    drawFramesPanel(buffer, 1, 18, halfWidth - 1, screenHeight - 19);
-    drawRetainedDocumentPanel(buffer, halfWidth, 18, screenWidth - halfWidth - 1, screenHeight - 19);
+    drawSummaryPanel(buffer, 1, 2, halfWidth - 1, 10);
+    drawManifestPanel(buffer, halfWidth, 2, screenWidth - halfWidth - 1, 10);
+    drawPlaybackPanel(buffer, 1, 12, halfWidth - 1, 7);
+    drawDiagnosticsPanel(buffer, halfWidth, 12, screenWidth - halfWidth - 1, 7);
+    drawFramesPanel(buffer, 1, 19, halfWidth - 1, screenHeight - 20);
+    drawRetainedDocumentPanel(buffer, halfWidth, 19, screenWidth - halfWidth - 1, screenHeight - 20);
 }
 
 void XpSequenceDiagnosticsScreen::drawSummaryPanel(
@@ -146,6 +146,7 @@ void XpSequenceDiagnosticsScreen::drawSummaryPanel(
     writeClipped(buffer, x + 2, y + 5, width - 4, "Unique indices: " + std::string(m_report.hasUniqueFrameIndices ? "true" : "false"), Themes::Text);
     writeClipped(buffer, x + 2, y + 6, width - 4, "Contiguous from zero: " + std::string(m_report.hasContiguousFrameIndicesStartingAtZero ? "true" : "false"), Themes::Text);
     writeClipped(buffer, x + 2, y + 7, width - 4, "Stored in frame-index order: " + std::string(m_report.framesStoredInFrameIndexOrder ? "true" : "false"), Themes::Text);
+    writeClipped(buffer, x + 2, y + 8, width - 4, XpSequenceInspection::formatOverrideSummary(m_report), Themes::Info);
 }
 
 void XpSequenceDiagnosticsScreen::drawManifestPanel(
@@ -155,22 +156,23 @@ void XpSequenceDiagnosticsScreen::drawManifestPanel(
     const int width,
     const int height) const
 {
-    drawPanel(buffer, x, y, width, height, "Manifest Fields / Defaults");
+    drawPanel(buffer, x, y, width, height, "Manifest Fields / Sources");
 
     writeClipped(buffer, x + 2, y + 1, width - 4, XpSequenceInspection::formatManifestFieldSummary(m_report), Themes::Text);
-    writeClipped(buffer, x + 2, y + 3, width - 4, "Manifest path: " + m_report.manifestPath, Themes::Text);
-    writeClipped(buffer, x + 2, y + 4, width - 4, "Manifest dir:  " + m_report.manifestDirectory, Themes::Text);
+    writeClipped(buffer, x + 2, y + 3, width - 4, XpSequenceInspection::formatSourceResolutionSummary(m_report), Themes::Info);
+    writeClipped(buffer, x + 2, y + 5, width - 4, "Manifest path: " + m_report.manifestPath, Themes::Text);
+    writeClipped(buffer, x + 2, y + 6, width - 4, "Manifest dir:  " + m_report.manifestDirectory, Themes::Text);
     writeClipped(
         buffer,
         x + 2,
-        y + 6,
+        y + 7,
         width - 4,
         "Load diagnostics: " + std::to_string(m_report.loadDiagnostics.size()),
         Themes::Text);
     writeClipped(
         buffer,
         x + 2,
-        y + 7,
+        y + 8,
         width - 4,
         "Validation diagnostics: " + std::to_string(m_report.validationDiagnostics.size()),
         Themes::Text);
@@ -186,8 +188,8 @@ void XpSequenceDiagnosticsScreen::drawPlaybackPanel(
     drawPanel(buffer, x, y, width, height, "Future Playback Hooks");
 
     writeClipped(buffer, x + 2, y + 1, width - 4, XpSequenceInspection::formatPlaybackHookSummary(m_report), Themes::Text);
-    writeClipped(buffer, x + 2, y + 3, width - 4, "This metadata is inspection-only and does not schedule or render frames.", Themes::Info);
-    writeClipped(buffer, x + 2, y + 4, width - 4, "Use it later to seed animation state without changing the existing XP pipeline.", Themes::Info);
+    writeClipped(buffer, x + 2, y + 3, width - 4, "This metadata is inspection-only and does not schedule, interpolate, or render frames.", Themes::Info);
+    writeClipped(buffer, x + 2, y + 4, width - 4, "Use it later to seed animation state while preserving XpSequence -> XpFrame -> TextObject.", Themes::Info);
 }
 
 void XpSequenceDiagnosticsScreen::drawDiagnosticsPanel(
@@ -282,7 +284,8 @@ void XpSequenceDiagnosticsScreen::drawFramesPanel(
             rowY,
             width - 6,
             "resolvedVisibleLayers=" + std::to_string(frame.resolvedVisibleLayerCount)
-            + ", resolvedHiddenLayers=" + std::to_string(frame.resolvedHiddenLayerCount),
+            + ", resolvedHiddenLayers=" + std::to_string(frame.resolvedHiddenLayerCount)
+            + ", hasOverrides=" + std::string(frame.hasAnyRetainedOverride() ? "true" : "false"),
             Themes::Info);
         ++rowY;
     }
@@ -300,7 +303,7 @@ void XpSequenceDiagnosticsScreen::drawRetainedDocumentPanel(
     const int width,
     const int height) const
 {
-    drawPanel(buffer, x, y, width, height, "Retained XP Details (Default Frame)");
+    drawPanel(buffer, x, y, width, height, "Retained XP Details (Initial Frame)");
 
     int rowY = y + 1;
     const int maxRowY = y + height - 2;
@@ -348,6 +351,18 @@ void XpSequenceDiagnosticsScreen::drawRetainedDocumentPanel(
         ++rowY;
     }
 
+    if (rowY <= maxRowY && selectedFrame->hasSourcePath)
+    {
+        writeClipped(
+            buffer,
+            x + 2,
+            rowY,
+            width - 4,
+            "Source: " + selectedFrame->sourcePath + " -> " + selectedFrame->resolvedSourcePath,
+            Themes::Text);
+        ++rowY;
+    }
+
     for (const std::string& layerDetail : selectedFrame->layerDetails)
     {
         if (rowY > maxRowY)
@@ -357,10 +372,5 @@ void XpSequenceDiagnosticsScreen::drawRetainedDocumentPanel(
 
         writeClipped(buffer, x + 2, rowY, width - 4, layerDetail, Themes::Text);
         ++rowY;
-    }
-
-    if (selectedFrame->layerDetails.empty() && rowY <= maxRowY)
-    {
-        writeClipped(buffer, x + 2, rowY, width - 4, "No retained XP layer details are available for the selected frame.", Themes::Warning);
     }
 }


### PR DESCRIPTION
…gnostics.

Modifies:
- Rendering/Objects/XpSequenceInspection.h/.cpp
- Screens/Developer/XpSequenceDiagnosticsScreen.cpp

What this adds:

1) Richer .xpseq inspection summaries for:
- manifest fields
- source resolution
- resolved override usage
- retained-document coverage 2) Expanded inspection-only playback metadata:
- initial frame ordinal
- initial frame index
- default timing/composite/visibility metadata
- whether any frame-level timing or visibility/composite overrides exist
- whether frames are linked by source path vs retained in memory 3) Improved diagnostics screen presentation

Closes: #136 