### PR TITLE
XpArtLoader: Prepare retained XP system for future editing workflows.

### DIFF
--- a/TUI/Rendering/Objects/XpArtLoader.cpp
+++ b/TUI/Rendering/Objects/XpArtLoader.cpp
@@ -235,6 +235,66 @@ namespace
         return (y * width) + x;
     }
 
+    void refreshLayerDerivedMetadata(XpArtLoader::XpLayer& layer)
+    {
+        layer.metadata.encounteredTransparentBackgroundCells = false;
+        layer.metadata.encounteredVisibleGlyphsOnTransparentBackground = false;
+        layer.metadata.visibilityUsedForFlattening = layer.visible;
+
+        for (const XpArtLoader::XpLayerCell& cell : layer.cells)
+        {
+            if (cell.background == kTransparentBackground)
+            {
+                layer.metadata.encounteredTransparentBackgroundCells = true;
+
+                if (cell.glyph != 0u && cell.glyph != static_cast<std::uint32_t>(U' '))
+                {
+                    layer.metadata.encounteredVisibleGlyphsOnTransparentBackground = true;
+                }
+            }
+        }
+    }
+
+    void refreshDocumentDerivedMetadata(XpArtLoader::XpDocument& document)
+    {
+        document.metadata.canvasWidth = document.width;
+        document.metadata.canvasHeight = document.height;
+        document.metadata.layerCount = static_cast<int>(document.layers.size());
+        document.metadata.parsedFormatVersion = document.formatVersion;
+        document.metadata.retainedPathAvailable = document.isValid();
+
+        for (std::size_t index = 0; index < document.layers.size(); ++index)
+        {
+            XpArtLoader::XpLayer& layer = document.layers[index];
+            layer.metadata.sourceWidth = layer.width;
+            layer.metadata.sourceHeight = layer.height;
+            layer.metadata.matchedCanvasSize =
+                layer.width == document.width && layer.height == document.height;
+            refreshLayerDerivedMetadata(layer);
+        }
+    }
+
+    XpArtLoader::MutationResult makeMutationFailure(
+        XpArtLoader::MutationErrorCode code,
+        const std::string& message)
+    {
+        XpArtLoader::MutationResult result;
+        result.code = code;
+        result.success = false;
+        result.changed = false;
+        result.message = message;
+        return result;
+    }
+
+    XpArtLoader::MutationResult makeMutationSuccess(bool changed)
+    {
+        XpArtLoader::MutationResult result;
+        result.code = XpArtLoader::MutationErrorCode::None;
+        result.success = true;
+        result.changed = changed;
+        return result;
+    }
+
     std::size_t checkedCellCount(int width, int height, bool& ok)
     {
         ok = false;
@@ -1536,6 +1596,22 @@ namespace XpArtLoader
         return &cells[index];
     }
 
+    XpLayerCell* XpLayer::tryGetCell(int x, int y)
+    {
+        if (!inBounds(x, y))
+        {
+            return nullptr;
+        }
+
+        const std::size_t index = static_cast<std::size_t>(layerIndex(x, y, height));
+        if (index >= cells.size())
+        {
+            return nullptr;
+        }
+
+        return &cells[index];
+    }
+
     bool XpDocument::isValid() const
     {
         if (layers.empty() || width <= 0 || height <= 0)
@@ -1557,6 +1633,123 @@ namespace XpArtLoader
     int XpDocument::getLayerCount() const
     {
         return static_cast<int>(layers.size());
+    }
+
+    bool XpDocument::isDirty() const
+    {
+        return dirty;
+    }
+
+    std::uint64_t XpDocument::getMutationRevision() const
+    {
+        return mutationRevision;
+    }
+
+    void XpDocument::clearDirty()
+    {
+        dirty = false;
+    }
+
+    MutationResult XpDocument::setCell(int layerIndexValue, int x, int y, const XpLayerCell& cell)
+    {
+        if (!isValid())
+        {
+            return makeMutationFailure(
+                MutationErrorCode::InvalidDocument,
+                "Cannot mutate an invalid XP document.");
+        }
+
+        if (layerIndexValue < 0 || layerIndexValue >= static_cast<int>(layers.size()))
+        {
+            return makeMutationFailure(
+                MutationErrorCode::LayerIndexOutOfRange,
+                "Layer index was out of range for setCell().");
+        }
+
+        XpLayer& layer = layers[static_cast<std::size_t>(layerIndexValue)];
+        XpLayerCell* existingCell = layer.tryGetCell(x, y);
+        if (existingCell == nullptr)
+        {
+            return makeMutationFailure(
+                MutationErrorCode::CellOutOfBounds,
+                "Cell coordinates were out of bounds for setCell().");
+        }
+
+        const bool changed =
+            existingCell->glyph != cell.glyph ||
+            existingCell->foreground != cell.foreground ||
+            existingCell->background != cell.background;
+
+        if (!changed)
+        {
+            return makeMutationSuccess(false);
+        }
+
+        *existingCell = cell;
+        refreshLayerDerivedMetadata(layer);
+        dirty = true;
+        ++mutationRevision;
+        return makeMutationSuccess(true);
+    }
+
+    MutationResult XpDocument::setLayerVisibility(int layerIndexValue, bool visibleValue)
+    {
+        if (!isValid())
+        {
+            return makeMutationFailure(
+                MutationErrorCode::InvalidDocument,
+                "Cannot mutate an invalid XP document.");
+        }
+
+        if (layerIndexValue < 0 || layerIndexValue >= static_cast<int>(layers.size()))
+        {
+            return makeMutationFailure(
+                MutationErrorCode::LayerIndexOutOfRange,
+                "Layer index was out of range for setLayerVisibility().");
+        }
+
+        XpLayer& layer = layers[static_cast<std::size_t>(layerIndexValue)];
+        if (layer.visible == visibleValue)
+        {
+            return makeMutationSuccess(false);
+        }
+
+        layer.visible = visibleValue;
+        layer.metadata.visibilityUsedForFlattening = visibleValue;
+        dirty = true;
+        ++mutationRevision;
+        return makeMutationSuccess(true);
+    }
+
+    MutationResult XpDocument::reorderLayer(int fromIndex, int toIndex)
+    {
+        if (!isValid())
+        {
+            return makeMutationFailure(
+                MutationErrorCode::InvalidDocument,
+                "Cannot mutate an invalid XP document.");
+        }
+
+        if (fromIndex < 0 || fromIndex >= static_cast<int>(layers.size()) ||
+            toIndex < 0 || toIndex >= static_cast<int>(layers.size()))
+        {
+            return makeMutationFailure(
+                MutationErrorCode::ReorderIndexOutOfRange,
+                "Layer indices were out of range for reorderLayer().");
+        }
+
+        if (fromIndex == toIndex)
+        {
+            return makeMutationSuccess(false);
+        }
+
+        XpLayer movedLayer = layers[static_cast<std::size_t>(fromIndex)];
+        layers.erase(layers.begin() + fromIndex);
+        layers.insert(layers.begin() + toIndex, std::move(movedLayer));
+        refreshDocumentDerivedMetadata(*this);
+        dirty = true;
+        ++mutationRevision;
+        return makeMutationSuccess(true);
     }
 
     bool hasWarning(const LoadResult& result, LoadWarningCode code)
@@ -1744,6 +1937,19 @@ namespace XpArtLoader
         return !sourcePath.empty();
     }
 
+    bool XpFrame::isDirty() const
+    {
+        return document != nullptr && document->isDirty();
+    }
+
+    void XpFrame::clearDirty()
+    {
+        if (document != nullptr)
+        {
+            document->clearDirty();
+        }
+    }
+
     const XpDocument* XpFrame::getDocument() const
     {
         return document.get();
@@ -1845,6 +2051,27 @@ namespace XpArtLoader
     int XpSequence::getFrameCount() const
     {
         return static_cast<int>(frames.size());
+    }
+
+    bool XpSequence::isDirty() const
+    {
+        for (const XpFrame& frame : frames)
+        {
+            if (frame.isDirty())
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    void XpSequence::clearDirty()
+    {
+        for (XpFrame& frame : frames)
+        {
+            frame.clearDirty();
+        }
     }
 
     bool XpSequence::hasUniqueFrameIndices() const

--- a/TUI/Rendering/Objects/XpArtLoader.h
+++ b/TUI/Rendering/Objects/XpArtLoader.h
@@ -46,6 +46,15 @@ namespace XpArtLoader
         UseExplicitVisibleLayerList
     };
 
+    enum class MutationErrorCode
+    {
+        None,
+        InvalidDocument,
+        LayerIndexOutOfRange,
+        CellOutOfBounds,
+        ReorderIndexOutOfRange
+    };
+
     struct SourcePosition
     {
         int x = -1;
@@ -187,6 +196,20 @@ namespace XpArtLoader
         bool isValid() const;
         bool inBounds(int x, int y) const;
         const XpLayerCell* tryGetCell(int x, int y) const;
+        XpLayerCell* tryGetCell(int x, int y);
+    };
+
+    struct MutationResult
+    {
+        MutationErrorCode code = MutationErrorCode::None;
+        bool success = false;
+        bool changed = false;
+        std::string message;
+
+        bool isValid() const
+        {
+            return success && code == MutationErrorCode::None;
+        }
     };
 
     struct XpDocument
@@ -197,9 +220,17 @@ namespace XpArtLoader
         bool usesLegacyLayerCountHeader = false;
         std::vector<XpLayer> layers;
         XpDocumentMetadata metadata;
+        bool dirty = false;
+        std::uint64_t mutationRevision = 0;
 
         bool isValid() const;
         int getLayerCount() const;
+        bool isDirty() const;
+        std::uint64_t getMutationRevision() const;
+        void clearDirty();
+        MutationResult setCell(int layerIndex, int x, int y, const XpLayerCell& cell);
+        MutationResult setLayerVisibility(int layerIndex, bool visible);
+        MutationResult reorderLayer(int fromIndex, int toIndex);
     };
 
     struct XpFrameOverrides
@@ -244,6 +275,8 @@ namespace XpArtLoader
         bool hasDocument() const;
         bool hasLabel() const;
         bool hasSourcePath() const;
+        bool isDirty() const;
+        void clearDirty();
         const XpDocument* getDocument() const;
         XpDocument* getDocument();
 
@@ -267,6 +300,8 @@ namespace XpArtLoader
 
         bool isValid() const;
         int getFrameCount() const;
+        bool isDirty() const;
+        void clearDirty();
         bool hasUniqueFrameIndices() const;
         bool hasContiguousFrameIndicesStartingAtZero() const;
         bool areFramesStoredInFrameIndexOrder() const;

--- a/TUI/Rendering/Objects/XpArtLoaderTests.cpp
+++ b/TUI/Rendering/Objects/XpArtLoaderTests.cpp
@@ -279,6 +279,24 @@ namespace
         }
     }
 
+    void expectMutationSuccess(
+        TestContext& context,
+        const MutationResult& result,
+        bool expectedChanged,
+        const std::string& label)
+    {
+        if (!result.success)
+        {
+            context.fail(label + " expected success but failed: " + result.message);
+            return;
+        }
+
+        if (result.changed != expectedChanged)
+        {
+            context.fail(label + " changed flag mismatch.");
+        }
+    }
+
     void expectRgbForeground(
         TestContext& context,
         const TextObjectCell& cell,
@@ -670,6 +688,139 @@ namespace
         }
     }
 
+    void testMutableCellEditAndDirtyTracking(TestContext& context)
+    {
+        const RgbColor fg = rgb(200, 200, 200);
+        const RgbColor bg = rgb(10, 10, 10);
+        const RgbColor newFg = rgb(10, 240, 60);
+        const RgbColor newBg = rgb(0, 0, 120);
+
+        XpDocument document = makeDocument(1, 1, {
+            makeLayer(1, 1, { makeLayerCell(static_cast<std::uint32_t>(U'A'), fg, bg) })
+            });
+
+        expectFalse(context, document.isDirty(), "document dirty before edit");
+        expectEqualInt(context, static_cast<int>(document.getMutationRevision()), 0, "document mutationRevision before edit");
+
+        MutationResult result = document.setCell(
+            0,
+            0,
+            0,
+            makeLayerCell(static_cast<std::uint32_t>(U'Z'), newFg, newBg));
+
+        expectMutationSuccess(context, result, true, "setCell result");
+        expectTrue(context, document.isDirty(), "document dirty after edit");
+        expectEqualInt(context, static_cast<int>(document.getMutationRevision()), 1, "document mutationRevision after edit");
+
+        LoadOptions options;
+        options.flattenLayers = true;
+
+        const LoadResult loadResult = buildTextObjectFromXpDocument(document, options);
+        expectTrue(context, loadResult.success, "recompose after setCell success");
+
+        const TextObjectCell& cell = requireCell(context, loadResult.object, 0, 0, "mutated cell");
+        expectEqualChar(context, cell.glyph, U'Z', "mutated glyph");
+
+        document.clearDirty();
+        expectFalse(context, document.isDirty(), "document dirty after clearDirty");
+
+        MutationResult noOpResult = document.setCell(
+            0,
+            0,
+            0,
+            makeLayerCell(static_cast<std::uint32_t>(U'Z'), newFg, newBg));
+        expectMutationSuccess(context, noOpResult, false, "setCell no-op result");
+        expectEqualInt(context, static_cast<int>(document.getMutationRevision()), 1, "document mutationRevision after no-op");
+    }
+
+    void testLayerVisibilityToggleAndFrameDirtyPropagation(TestContext& context)
+    {
+        const RgbColor fg = rgb(220, 220, 220);
+        const RgbColor bg = rgb(20, 20, 20);
+
+        XpDocument document = makeDocument(1, 1, {
+            makeLayer(1, 1, { makeLayerCell(static_cast<std::uint32_t>(U'B'), fg, bg) }, true),
+            makeLayer(1, 1, { makeLayerCell(static_cast<std::uint32_t>(U'T'), fg, bg) }, true)
+            });
+
+        XpFrame frame;
+        frame.frameIndex = 0;
+        frame.document = std::make_shared<XpDocument>(document);
+
+        MutationResult visibilityResult = frame.getDocument()->setLayerVisibility(1, false);
+        expectMutationSuccess(context, visibilityResult, true, "setLayerVisibility result");
+        expectTrue(context, frame.isDirty(), "frame dirty after visibility edit");
+
+        const LoadResult loadResult = buildTextObjectFromXpFrame(frame);
+        expectTrue(context, loadResult.success, "recompose after visibility edit success");
+        expectHasWarning(context, loadResult, LoadWarningCode::HiddenLayersSkipped);
+
+        const TextObjectCell& cell = requireCell(context, loadResult.object, 0, 0, "visible toggle cell");
+        expectEqualChar(context, cell.glyph, U'B', "visible toggle glyph");
+
+        frame.clearDirty();
+        expectFalse(context, frame.isDirty(), "frame dirty after clearDirty");
+    }
+
+    void testLayerReorderAndSequenceDirtyPropagation(TestContext& context)
+    {
+        const RgbColor fg = rgb(255, 255, 255);
+        const RgbColor bg = rgb(0, 0, 0);
+
+        XpDocument document = makeDocument(1, 1, {
+            makeLayer(1, 1, { makeLayerCell(static_cast<std::uint32_t>(U'B'), fg, bg) }, true),
+            makeLayer(1, 1, { makeLayerCell(static_cast<std::uint32_t>(U'T'), fg, bg) }, true)
+            });
+
+        XpSequence sequence = buildRetainedSequence(document, 0, "frame0");
+        expectFalse(context, sequence.isDirty(), "sequence dirty before reorder");
+
+        XpFrame* frame = sequence.getDefaultFrame();
+        if (frame == nullptr || frame->getDocument() == nullptr)
+        {
+            context.fail("Default frame should be available for reorder test.");
+            return;
+        }
+
+        MutationResult reorderResult = frame->getDocument()->reorderLayer(1, 0);
+        expectMutationSuccess(context, reorderResult, true, "reorderLayer result");
+        expectTrue(context, sequence.isDirty(), "sequence dirty after reorder");
+        expectEqualInt(context, static_cast<int>(frame->getDocument()->getMutationRevision()), 1, "mutationRevision after reorder");
+
+        const LoadResult loadResult = buildTextObjectFromXpSequence(sequence);
+        expectTrue(context, loadResult.success, "recompose after reorder success");
+
+        const TextObjectCell& cell = requireCell(context, loadResult.object, 0, 0, "reordered cell");
+        expectEqualChar(context, cell.glyph, U'B', "reordered glyph");
+
+        sequence.clearDirty();
+        expectFalse(context, sequence.isDirty(), "sequence dirty after clearDirty");
+    }
+
+    void testMutationFailurePaths(TestContext& context)
+    {
+        const RgbColor fg = rgb(200, 200, 200);
+        const RgbColor bg = rgb(10, 10, 10);
+
+        XpDocument document = makeDocument(1, 1, {
+            makeLayer(1, 1, { makeLayerCell(static_cast<std::uint32_t>(U'A'), fg, bg) })
+            });
+
+        MutationResult badLayerResult = document.setLayerVisibility(5, false);
+        expectFalse(context, badLayerResult.success, "bad layer mutation success");
+        expectFalse(context, badLayerResult.changed, "bad layer mutation changed");
+        expectFalse(context, document.isDirty(), "document dirty after failed layer mutation");
+
+        MutationResult badCellResult = document.setCell(
+            0,
+            5,
+            0,
+            makeLayerCell(static_cast<std::uint32_t>(U'Q'), fg, bg));
+        expectFalse(context, badCellResult.success, "bad cell mutation success");
+        expectFalse(context, badCellResult.changed, "bad cell mutation changed");
+        expectFalse(context, document.isDirty(), "document dirty after failed cell mutation");
+    }
+
 #if TUI_XP_ART_LOADER_TESTS_HAS_ZLIB
     void testCompressedInputFlagsWhenZlibIsAvailable(TestContext& context)
     {
@@ -710,7 +861,11 @@ namespace
             { "BottomToTopLayerOrder", &testBottomToTopLayerOrder },
             { "HiddenLayerSkippedDuringFlattening", &testHiddenLayerSkippedDuringFlattening },
             { "StrictVsNonStrictLayerSizeValidation", &testStrictVsNonStrictLayerSizeValidation },
-            { "LoadFromBytesMetadataAndTrailingBytes", &testLoadFromBytesMetadataAndTrailingBytes }
+            { "LoadFromBytesMetadataAndTrailingBytes", &testLoadFromBytesMetadataAndTrailingBytes },
+            { "MutableCellEditAndDirtyTracking", &testMutableCellEditAndDirtyTracking },
+            { "LayerVisibilityToggleAndFrameDirtyPropagation", &testLayerVisibilityToggleAndFrameDirtyPropagation },
+            { "LayerReorderAndSequenceDirtyPropagation", &testLayerReorderAndSequenceDirtyPropagation },
+            { "MutationFailurePaths", &testMutationFailurePaths }
         };
 
 #if TUI_XP_ART_LOADER_TESTS_HAS_ZLIB


### PR DESCRIPTION
Modifies:
- Rendering/Objects/XpArtLoader.h/.cpp
- Rendering/Objects/XpArtLoaderTests.cpp

Adds a minimal authoring-safe mutation layer directly on the retained XP model: 1) XpDocument
     - setCell(int layerIndex, int x, int y, const XpLayerCell& cell)
     - setLayerVisibility(int layerIndex, bool visible)
     - reorderLayer(int fromIndex, int toIndex)
     - isDirty()
     - clearDirty()
     - getMutationRevision()
2) XpFrame
     - isDirty()
     - clearDirty()
3) XpSequence
     - isDirty()
     - clearDirty()

Also adds a strongly-typed mutation result reporting:
     - MutationErrorCode
     - MutationResult

Behavior:
- Mutations validate document/layer/cell bounds before applying changes.
- No-op mutations return success with changed = false.
- Real changes mark the retained document dirty and increment mutationRevision.
- Layer metadata is refreshed after cell edits and reorder operations.

Existing compositing/conversion code remains the single recomposition path, so - edited retained documents can safely be re-rendered through buildTextObjectFromXpDocument(...), buildTextObjectFromXpFrame(...), and buildTextObjectFromXpSequence(...)

Closes: #140 