### PR TITLE
Xp System: Future-compatibility foundation.

### DIFF
--- a/TUI/Rendering/Objects/XpArtExporter.cpp
+++ b/TUI/Rendering/Objects/XpArtExporter.cpp
@@ -1532,7 +1532,7 @@ namespace XpArtExporter
         XpDocument& outDocument)
     {
         outDocument = XpDocument{};
-        outDocument.formatVersion = 1;
+        outDocument.formatVersion = XpArtLoader::XpRulesConfig::rexPaintDefaults().defaultFormatVersion;
         outDocument.canvasWidth = object.getWidth();
         outDocument.canvasHeight = object.getHeight();
 
@@ -1620,7 +1620,7 @@ namespace XpArtExporter
             return false;
         }
 
-        outDocument.formatVersion = document.formatVersion > 0 ? document.formatVersion : 1;
+        outDocument.formatVersion = document.formatVersion > 0 ? document.formatVersion : XpArtLoader::XpRulesConfig::rexPaintDefaults().defaultFormatVersion;
         outDocument.canvasWidth = document.width;
         outDocument.canvasHeight = document.height;
 

--- a/TUI/Rendering/Objects/XpArtLoader.cpp
+++ b/TUI/Rendering/Objects/XpArtLoader.cpp
@@ -63,8 +63,6 @@ namespace
         kForegroundRgbBytes +
         kBackgroundRgbBytes;
 
-    const XpArtLoader::RgbColor kTransparentBackground{ 255, 0, 255 };
-    const XpArtLoader::RgbColor kOpaqueBlack{ 0, 0, 0 };
 
     struct CompositedCell
     {
@@ -88,6 +86,20 @@ namespace
         std::vector<CompositedCell> cells;
         FlattenStats stats;
     };
+
+    const XpArtLoader::XpRulesConfig& defaultXpRules()
+    {
+        static const XpArtLoader::XpRulesConfig rules =
+            XpArtLoader::XpRulesConfig::rexPaintDefaults();
+        return rules;
+    }
+
+    const XpArtLoader::XpTransparencyPolicy& defaultTransparencyPolicy()
+    {
+        static const XpArtLoader::XpTransparencyPolicy policy =
+            XpArtLoader::XpTransparencyPolicy::rexPaintDefaults();
+        return policy;
+    }
 
     std::string toLowerCopy(std::string value)
     {
@@ -221,8 +233,7 @@ namespace
 
     bool isTransparentBackground(const XpArtLoader::RgbColor& color, const XpArtLoader::LoadOptions& options)
     {
-        return options.treatMagentaBackgroundAsTransparent &&
-            color == kTransparentBackground;
+        return XpArtLoader::resolveTransparencyPolicy(options).treatsBackgroundAsTransparent(color);
     }
 
     int layerIndex(int x, int y, int height)
@@ -243,7 +254,7 @@ namespace
 
         for (const XpArtLoader::XpLayerCell& cell : layer.cells)
         {
-            if (cell.background == kTransparentBackground)
+            if (defaultTransparencyPolicy().treatsBackgroundAsTransparent(cell.background))
             {
                 layer.metadata.encounteredTransparentBackgroundCells = true;
 
@@ -546,9 +557,9 @@ namespace
         destination.hasForeground = true;
 
         if (!destination.hasBackground &&
-            options.visibleTransparentBaseCellsUseBlackBackground)
+            XpArtLoader::resolveTransparencyPolicy(options).visibleTransparentBaseCellsUseBlackBackground)
         {
-            destination.background = kOpaqueBlack;
+            destination.background = XpArtLoader::resolveXpRules(options).opaqueFallbackBackgroundColor;
             destination.hasBackground = true;
         }
     }
@@ -933,7 +944,7 @@ namespace XpArtLoader
                 retainedCell.background = parsedCell.background;
                 retainedLayer.cells.push_back(retainedCell);
 
-                if (parsedCell.background == kTransparentBackground)
+                if (defaultTransparencyPolicy().treatsBackgroundAsTransparent(parsedCell.background))
                 {
                     retainedLayer.metadata.encounteredTransparentBackgroundCells = true;
 
@@ -1492,9 +1503,124 @@ namespace XpArtLoader
         return FileType::Unknown;
     }
 
+    XpRulesConfig XpRulesConfig::rexPaintDefaults()
+    {
+        XpRulesConfig rules;
+        rules.defaultFormatVersion = 1;
+        rules.transparentBackgroundColor = { 255, 0, 255 };
+        rules.opaqueFallbackBackgroundColor = { 0, 0, 0 };
+        rules.defaultCompositeMode = XpCompositeMode::Phase45BCompatible;
+        return rules;
+    }
+
+    bool XpTransparencyPolicy::treatsBackgroundAsTransparent(const RgbColor& color) const
+    {
+        switch (mode)
+        {
+        case XpTransparencyMode::Disabled:
+            return false;
+
+        case XpTransparencyMode::RexPaintMagentaBackground:
+        case XpTransparencyMode::ExplicitColorKey:
+            return color == transparentBackgroundColor;
+        }
+
+        return false;
+    }
+
+    XpTransparencyPolicy XpTransparencyPolicy::rexPaintDefaults()
+    {
+        XpTransparencyPolicy policy;
+        policy.mode = XpTransparencyMode::RexPaintMagentaBackground;
+        policy.transparentBackgroundColor = XpRulesConfig::rexPaintDefaults().transparentBackgroundColor;
+        policy.visibleTransparentBaseCellsUseBlackBackground = true;
+        return policy;
+    }
+
+    bool XpExtensionFields::empty() const
+    {
+        return fields.empty();
+    }
+
+    bool XpExtensionFields::exceedsBounds() const
+    {
+        return fields.size() > maxFieldCount;
+    }
+
+    const XpExtensionField* XpExtensionFields::find(std::string_view key) const
+    {
+        for (const XpExtensionField& field : fields)
+        {
+            if (field.key == key)
+            {
+                return &field;
+            }
+        }
+
+        return nullptr;
+    }
+
+    bool XpExtensionFields::trySet(std::string key, std::string value)
+    {
+        if (key.empty())
+        {
+            return false;
+        }
+
+        for (XpExtensionField& field : fields)
+        {
+            if (field.key == key)
+            {
+                field.value = std::move(value);
+                return true;
+            }
+        }
+
+        if (fields.size() >= maxFieldCount)
+        {
+            return false;
+        }
+
+        XpExtensionField field;
+        field.key = std::move(key);
+        field.value = std::move(value);
+        fields.push_back(std::move(field));
+        return true;
+    }
+
+    XpRulesConfig resolveXpRules(const LoadOptions& options)
+    {
+        if (options.xpRulesOverride.has_value())
+        {
+            return *options.xpRulesOverride;
+        }
+
+        return XpRulesConfig::rexPaintDefaults();
+    }
+
+    XpTransparencyPolicy resolveTransparencyPolicy(const LoadOptions& options)
+    {
+        XpTransparencyPolicy policy =
+            options.transparencyPolicyOverride.has_value()
+            ? *options.transparencyPolicyOverride
+            : XpTransparencyPolicy::rexPaintDefaults();
+
+        if (!options.transparencyPolicyOverride.has_value())
+        {
+            policy.visibleTransparentBaseCellsUseBlackBackground =
+                options.visibleTransparentBaseCellsUseBlackBackground;
+
+            policy.mode = options.treatMagentaBackgroundAsTransparent
+                ? XpTransparencyMode::RexPaintMagentaBackground
+                : XpTransparencyMode::Disabled;
+        }
+
+        return policy;
+    }
+
     bool CellData::hasTransparentBackground() const
     {
-        return background == kTransparentBackground;
+        return defaultTransparencyPolicy().treatsBackgroundAsTransparent(background);
     }
 
     bool LayerData::isValid() const
@@ -1555,7 +1681,7 @@ namespace XpArtLoader
 
     bool XpLayerCell::hasTransparentBackground() const
     {
-        return background == kTransparentBackground;
+        return defaultTransparencyPolicy().treatsBackgroundAsTransparent(background);
     }
 
     bool XpLayer::isValid() const
@@ -1882,7 +2008,8 @@ namespace XpArtLoader
             defaultExplicitVisibleLayerIndices.empty() &&
             sourceManifestPath.empty() &&
             name.empty() &&
-            sequenceLabel.empty();
+            sequenceLabel.empty() &&
+            extensionFields.empty();
     }
 
     bool XpSequenceMetadata::usesExplicitVisibleLayerList() const

--- a/TUI/Rendering/Objects/XpArtLoader.h
+++ b/TUI/Rendering/Objects/XpArtLoader.h
@@ -98,6 +98,56 @@ namespace XpArtLoader
         }
     };
 
+    enum class XpTransparencyMode
+    {
+        RexPaintMagentaBackground,
+        Disabled,
+        ExplicitColorKey
+    };
+
+    struct XpRulesConfig
+    {
+        int defaultFormatVersion = 1;
+        RgbColor transparentBackgroundColor{ 255, 0, 255 };
+        RgbColor opaqueFallbackBackgroundColor{ 0, 0, 0 };
+        XpCompositeMode defaultCompositeMode = XpCompositeMode::Phase45BCompatible;
+
+        static XpRulesConfig rexPaintDefaults();
+    };
+
+    struct XpTransparencyPolicy
+    {
+        XpTransparencyMode mode = XpTransparencyMode::RexPaintMagentaBackground;
+        RgbColor transparentBackgroundColor{ 255, 0, 255 };
+        bool visibleTransparentBaseCellsUseBlackBackground = true;
+
+        bool treatsBackgroundAsTransparent(const RgbColor& color) const;
+
+        static XpTransparencyPolicy rexPaintDefaults();
+    };
+
+    struct XpExtensionField
+    {
+        std::string key;
+        std::string value;
+
+        bool isValid() const
+        {
+            return !key.empty();
+        }
+    };
+
+    struct XpExtensionFields
+    {
+        std::vector<XpExtensionField> fields;
+        std::size_t maxFieldCount = 16;
+
+        bool empty() const;
+        bool exceedsBounds() const;
+        const XpExtensionField* find(std::string_view key) const;
+        bool trySet(std::string key, std::string value);
+    };
+
     struct CellData
     {
         std::uint32_t glyph = 0;
@@ -158,6 +208,7 @@ namespace XpArtLoader
 
         bool visibilityUsedForFlattening = true;
         XpCompositeMode compositeModeUsed = XpCompositeMode::Phase45BCompatible;
+        XpExtensionFields extensionFields;
     };
 
     struct XpDocumentMetadata
@@ -174,6 +225,7 @@ namespace XpArtLoader
         bool inputWasAlreadyDecompressed = false;
 
         XpCompositeMode compositeModeUsed = XpCompositeMode::Phase45BCompatible;
+        XpExtensionFields extensionFields;
     };
 
     struct XpLayerCell
@@ -257,6 +309,7 @@ namespace XpArtLoader
         std::string sourceManifestPath;
         std::string name;
         std::string sequenceLabel;
+        XpExtensionFields extensionFields;
 
         bool isEmpty() const;
         bool usesExplicitVisibleLayerList() const;
@@ -325,6 +378,9 @@ namespace XpArtLoader
         bool treatMagentaBackgroundAsTransparent = true;
         bool visibleTransparentBaseCellsUseBlackBackground = true;
         bool strictLayerSizeValidation = true;
+
+        std::optional<XpRulesConfig> xpRulesOverride;
+        std::optional<XpTransparencyPolicy> transparencyPolicyOverride;
 
         XpCompositeMode compositeMode = XpCompositeMode::Phase45BCompatible;
 
@@ -461,8 +517,12 @@ namespace XpArtLoader
     std::string formatRetainedLayerSummary(const LoadResult& result, int layerIndex);
     std::string formatRetainedSequenceSummary(const LoadResult& result);
 
+    XpRulesConfig resolveXpRules(const LoadOptions& options);
+    XpTransparencyPolicy resolveTransparencyPolicy(const LoadOptions& options);
+
     const char* toString(FileType fileType);
     const char* toString(LoadWarningCode warningCode);
     const char* toString(XpCompositeMode compositeMode);
     const char* toString(XpVisibleLayerMode visibleLayerMode);
+    const char* toString(XpTransparencyMode transparencyMode);
 }

--- a/TUI/Rendering/Objects/XpArtLoaderTests.cpp
+++ b/TUI/Rendering/Objects/XpArtLoaderTests.cpp
@@ -9,6 +9,7 @@
 
 #include "Rendering/Objects/TextObject.h"
 #include "Rendering/Objects/XpArtLoader.h"
+#include "Rendering/Objects/XpSequenceLoader.h"
 #include "Rendering/Styles/Color.h"
 #include "Rendering/Styles/Style.h"
 
@@ -850,6 +851,79 @@ namespace
     }
 #endif
 
+    void testTransparencyPolicyDefaultsMatchLegacyBehavior(TestContext& context)
+    {
+        LoadOptions options;
+        const XpTransparencyPolicy policy = resolveTransparencyPolicy(options);
+
+        expectTrue(context,
+            policy.mode == XpTransparencyMode::RexPaintMagentaBackground,
+            "default transparency mode");
+        expectTrue(context,
+            policy.treatsBackgroundAsTransparent(rgb(255, 0, 255)),
+            "magenta treated as transparent");
+        expectFalse(context,
+            policy.treatsBackgroundAsTransparent(rgb(0, 0, 0)),
+            "black treated as opaque");
+        expectTrue(context,
+            policy.visibleTransparentBaseCellsUseBlackBackground,
+            "transparent base cells default black background");
+    }
+
+    void testUnknownManifestDirectiveCanBePreserved(TestContext& context)
+    {
+        const std::string manifest = R"(xpseq 1
+future_sequence_flag = "enabled"
+frame {
+  index = 0
+  source = "frame0.xp"
+  future_frame_flag = "beta"
+}
+)";
+
+        XpSequenceLoader::LoadOptions options;
+        options.requireContiguousFrameIndices = false;
+        options.unknownFieldPolicy = XpSequenceLoader::UnknownFieldPolicy::PreserveInMetadata;
+        options.xpLoadOptions.flattenLayers = false;
+
+        const XpSequenceLoader::LoadResult result =
+            XpSequenceLoader::loadFromString(manifest, "in_memory.xpseq", options);
+
+        expectFalse(context, result.success, "preserve unknown manifest load success without frame file");
+
+        const XpArtLoader::XpExtensionField* sequenceField =
+            result.sequence.metadata.extensionFields.find("manifest.sequence.future_sequence_flag");
+        if (sequenceField == nullptr || sequenceField->value != "enabled")
+        {
+            context.fail("Expected preserved sequence-level unknown manifest field.");
+        }
+
+        const XpArtLoader::XpExtensionField* frameField =
+            result.sequence.metadata.extensionFields.find("manifest.frame.0.future_frame_flag");
+        if (frameField == nullptr || frameField->value != "beta")
+        {
+            context.fail("Expected preserved frame-level unknown manifest field.");
+        }
+
+        const XpSequenceLoader::Diagnostic* preservedSequence =
+            XpSequenceLoader::getFirstDiagnosticByCode(
+                result,
+                XpSequenceLoader::DiagnosticCode::UnknownDirectivePreserved);
+        if (preservedSequence == nullptr)
+        {
+            context.fail("Expected UnknownDirectivePreserved diagnostic.");
+        }
+
+        const XpSequenceLoader::Diagnostic* preservedFrame =
+            XpSequenceLoader::getFirstDiagnosticByCode(
+                result,
+                XpSequenceLoader::DiagnosticCode::UnknownFrameDirectivePreserved);
+        if (preservedFrame == nullptr)
+        {
+            context.fail("Expected UnknownFrameDirectivePreserved diagnostic.");
+        }
+    }
+
     std::vector<TestCase> buildTestCases()
     {
         std::vector<TestCase> cases =
@@ -865,7 +939,9 @@ namespace
             { "MutableCellEditAndDirtyTracking", &testMutableCellEditAndDirtyTracking },
             { "LayerVisibilityToggleAndFrameDirtyPropagation", &testLayerVisibilityToggleAndFrameDirtyPropagation },
             { "LayerReorderAndSequenceDirtyPropagation", &testLayerReorderAndSequenceDirtyPropagation },
-            { "MutationFailurePaths", &testMutationFailurePaths }
+            { "MutationFailurePaths", &testMutationFailurePaths },
+            { "TransparencyPolicyDefaultsMatchLegacyBehavior", &testTransparencyPolicyDefaultsMatchLegacyBehavior },
+            { "UnknownManifestDirectiveCanBePreserved", &testUnknownManifestDirectiveCanBePreserved }
         };
 
 #if TUI_XP_ART_LOADER_TESTS_HAS_ZLIB

--- a/TUI/Rendering/Objects/XpSequenceLoader.cpp
+++ b/TUI/Rendering/Objects/XpSequenceLoader.cpp
@@ -388,10 +388,76 @@ namespace
         return !outKey.empty();
     }
 
+    bool handleUnknownField(
+        const std::string& key,
+        const std::string& value,
+        int lineNumber,
+        int frameIndex,
+        bool frameField,
+        const LoadOptions& options,
+        LoadResult& ioResult)
+    {
+        const DiagnosticCode strictCode =
+            frameField ? DiagnosticCode::InvalidFrameDirective : DiagnosticCode::InvalidDirective;
+        const DiagnosticCode ignoredCode =
+            frameField ? DiagnosticCode::UnknownFrameDirectiveIgnored : DiagnosticCode::UnknownDirectiveIgnored;
+        const DiagnosticCode preservedCode =
+            frameField ? DiagnosticCode::UnknownFrameDirectivePreserved : DiagnosticCode::UnknownDirectivePreserved;
+        const std::string fieldLabel = frameField ? "frame field" : "manifest directive";
+        const std::string message = "Unknown " + fieldLabel + ": " + key;
+
+        if (options.unknownFieldPolicy == UnknownFieldPolicy::StrictError)
+        {
+            addDiagnostic(ioResult, strictCode, message, lineNumber, frameIndex);
+            return false;
+        }
+
+        if (options.unknownFieldPolicy == UnknownFieldPolicy::WarnAndIgnore)
+        {
+            addDiagnostic(
+                ioResult,
+                ignoredCode,
+                "Ignoring unknown " + fieldLabel + ": " + key,
+                lineNumber,
+                frameIndex,
+                std::string(),
+                false);
+            return true;
+        }
+
+        std::string extensionKey = frameField
+            ? ("manifest.frame." + std::to_string(frameIndex) + "." + key)
+            : ("manifest.sequence." + key);
+
+        if (!ioResult.sequence.metadata.extensionFields.trySet(extensionKey, value))
+        {
+            addDiagnostic(
+                ioResult,
+                ignoredCode,
+                "Ignoring unknown " + fieldLabel + " because extension storage is full: " + key,
+                lineNumber,
+                frameIndex,
+                std::string(),
+                false);
+            return true;
+        }
+
+        addDiagnostic(
+            ioResult,
+            preservedCode,
+            "Preserved unknown " + fieldLabel + ": " + key,
+            lineNumber,
+            frameIndex,
+            std::string(),
+            false);
+        return true;
+    }
+
     bool parseFrameField(
         const std::string& key,
         const std::string& value,
         int lineNumber,
+        const LoadOptions& options,
         LoadResult& ioResult,
         ParsedFrameLine& ioFrame)
     {
@@ -495,13 +561,14 @@ namespace
             return true;
         }
 
-        addDiagnostic(
-            ioResult,
-            DiagnosticCode::InvalidFrameDirective,
-            "Unknown frame field: " + key,
+        return handleUnknownField(
+            key,
+            value,
             lineNumber,
-            ioFrame.frameIndex);
-        return false;
+            ioFrame.frameIndex,
+            true,
+            options,
+            ioResult);
     }
 
     bool finalizeFrame(
@@ -550,6 +617,7 @@ namespace
     bool parseLegacyFrameLine(
         const std::string& line,
         int lineNumber,
+        const LoadOptions& options,
         LoadResult& ioResult,
         ParsedFrameLine& outFrame)
     {
@@ -587,6 +655,7 @@ namespace
                 trimCopy(token.substr(0, eq)),
                 unquote(trimCopy(token.substr(eq + 1))),
                 lineNumber,
+                options,
                 ioResult,
                 outFrame))
             {
@@ -662,6 +731,7 @@ namespace
         const std::string& key,
         const std::string& value,
         int lineNumber,
+        const LoadOptions& options,
         LoadResult& ioResult)
     {
         XpArtLoader::XpSequenceMetadata& metadata = ioResult.sequence.metadata;
@@ -781,13 +851,14 @@ namespace
             return true;
         }
 
-        addDiagnostic(
-            ioResult,
-            DiagnosticCode::InvalidDirective,
-            "Unknown manifest directive: " + key,
+        return handleUnknownField(
+            key,
+            value,
             lineNumber,
-            -1);
-        return false;
+            -1,
+            false,
+            options,
+            ioResult);
     }
 
     bool tryCanonicalPath(
@@ -939,7 +1010,7 @@ namespace XpSequenceLoader
                     return result;
                 }
 
-                if (!parseFrameField(key, value, lineNumber, result, currentFrame.frame))
+                if (!parseFrameField(key, value, lineNumber, options, result, currentFrame.frame))
                 {
                     result.errorMessage = "Invalid .xpseq frame block.";
                     return result;
@@ -971,7 +1042,7 @@ namespace XpSequenceLoader
             if (startsWith(trimmed, "frame "))
             {
                 ParsedFrameLine frame;
-                if (!parseLegacyFrameLine(trimmed, lineNumber, result, frame))
+                if (!parseLegacyFrameLine(trimmed, lineNumber, options, result, frame))
                 {
                     result.errorMessage = "Invalid .xpseq frame directive.";
                     return result;
@@ -995,7 +1066,7 @@ namespace XpSequenceLoader
                 return result;
             }
 
-            if (!parseSequenceField(key, value, lineNumber, result))
+            if (!parseSequenceField(key, value, lineNumber, options, result))
             {
                 result.errorMessage = "Invalid .xpseq directive.";
                 return result;
@@ -1292,6 +1363,29 @@ namespace XpSequenceLoader
             return "InvalidExplicitVisibleLayerList";
         case DiagnosticCode::XpFrameLoadFailed:
             return "XpFrameLoadFailed";
+        case DiagnosticCode::UnknownDirectiveIgnored:
+            return "UnknownDirectiveIgnored";
+        case DiagnosticCode::UnknownFrameDirectiveIgnored:
+            return "UnknownFrameDirectiveIgnored";
+        case DiagnosticCode::UnknownDirectivePreserved:
+            return "UnknownDirectivePreserved";
+        case DiagnosticCode::UnknownFrameDirectivePreserved:
+            return "UnknownFrameDirectivePreserved";
+        default:
+            return "Unknown";
+        }
+    }
+
+    const char* toString(UnknownFieldPolicy policy)
+    {
+        switch (policy)
+        {
+        case UnknownFieldPolicy::StrictError:
+            return "StrictError";
+        case UnknownFieldPolicy::WarnAndIgnore:
+            return "WarnAndIgnore";
+        case UnknownFieldPolicy::PreserveInMetadata:
+            return "PreserveInMetadata";
         default:
             return "Unknown";
         }

--- a/TUI/Rendering/Objects/XpSequenceLoader.h
+++ b/TUI/Rendering/Objects/XpSequenceLoader.h
@@ -60,7 +60,11 @@ namespace XpSequenceLoader
         InvalidCompositeMode,
         InvalidVisibleLayerMode,
         InvalidExplicitVisibleLayerList,
-        XpFrameLoadFailed
+        XpFrameLoadFailed,
+        UnknownDirectiveIgnored,
+        UnknownFrameDirectiveIgnored,
+        UnknownDirectivePreserved,
+        UnknownFrameDirectivePreserved
     };
 
     struct Diagnostic
@@ -79,11 +83,19 @@ namespace XpSequenceLoader
         }
     };
 
+    enum class UnknownFieldPolicy
+    {
+        StrictError,
+        WarnAndIgnore,
+        PreserveInMetadata
+    };
+
     struct LoadOptions
     {
         XpArtLoader::LoadOptions xpLoadOptions;
         bool requireContiguousFrameIndices = true;
         bool sortFramesByFrameIndex = true;
+        UnknownFieldPolicy unknownFieldPolicy = UnknownFieldPolicy::StrictError;
     };
 
     struct LoadResult
@@ -111,4 +123,5 @@ namespace XpSequenceLoader
     std::string formatLoadSuccess(const LoadResult& result);
 
     const char* toString(DiagnosticCode code);
+    const char* toString(UnknownFieldPolicy policy);
 }


### PR DESCRIPTION
Modifies:
- Rendering/Objects/XpArtExporter.h/.cpp
- Rendering/Objets/XpArtLoader.h/.cpp
- Rendering/Objects/XpSequenceLoader.h/.cpp

The implementation introduces four narrow seams:
1) XpRulesConfig
- Centralizes current XP defaults that were previously implicit or hard-coded,
- especially default format version & default transparent/opaque fallback colors.
- Defaults still match current RexPaint behavior.

2) XpTransparencyPolicy
- Owns transparent-background interpretation instead of scattering the magenta
- rule through loader logic.
- Default mode remains RexPaint-compatible: magenta background is transparent,
- visible transparent base cells still fall back to black when needed.

3) XpExtensionFields
- Adds a bounded key/value container for future metadata/custom attributes.
- Attached to document, layer, and sequence metadata so future fields have a
- controlled place to live without turning the model into a schema engine.

4) UnknownFieldPolicy in .xpseq loading
    - Adds explicit control for unknown manifest fields: - StrictError - WarnAndIgnore - PreserveInMetadata

5) Default remains strict, so existing manifests behave the same unless a caller opts in.

Closes: #141 