### PR TITLE
AssetLibrary: Adopt minimum assetLibrary to enable caching of asset f…

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3430,7 +3430,7 @@ TUI/
 │   └── Animator.cpp
 │
 ├── Game/
-├── Data/
+│
 ├── Utilities/
 │   ├── Unicode/
 │   │   ├── UnicodeConversions.h
@@ -3438,7 +3438,7 @@ TUI/
 │   │   ├── UnicodeWidth.h
 │   │   ├── UnicodeWidth.cpp
 │   │   ├── UnicodeGrapheme.h
-│   │   ├── UnicodeGrampheme.cpp
+│   │   └── UnicodeGrampheme.cpp
 │   ├── AssetPaths.h
 │   ├── AssetPaths.cpp
 │   ├── StringUtils.h
@@ -3455,7 +3455,10 @@ TUI/
 │   │   └── Bitmap/
 │   ├── Pages/
 │   ├── Screens/
-│   └── Themes/
+│   ├── Themes/
+│   ├── XP/
+│   ├── AssetLibrary.h
+│   └── AssetLibrary.cpp
 │
 ├── Tests/
 │   ├── RenderingTests/

--- a/TUI/Assets/AssetLibrary.cpp
+++ b/TUI/Assets/AssetLibrary.cpp
@@ -1,0 +1,357 @@
+#include "Assets/AssetLibrary.h"
+
+#include <utility>
+
+namespace
+{
+    std::shared_ptr<TextObject> makeSharedTextObject(TextObject object)
+    {
+        return std::make_shared<TextObject>(std::move(object));
+    }
+
+    Data::Assets::LoadTextAssetResult makeFailure(
+        const std::string& requestedPath,
+        const AssetPaths::ResolutionResult& resolution,
+        const std::string& errorMessage)
+    {
+        Data::Assets::LoadTextAssetResult result;
+        result.success = false;
+        result.asset.requestedPath = requestedPath;
+        result.asset.assetType = resolution.assetType;
+        result.asset.resolvedPath = resolution.resolvedPath;
+        result.asset.normalizedPath = resolution.normalizedPath;
+        result.errorMessage = errorMessage;
+        return result;
+    }
+
+    Data::Assets::LoadTextAssetResult makeSuccess(
+        const std::string& requestedPath,
+        const AssetPaths::ResolutionResult& resolution,
+        std::shared_ptr<TextObject> object)
+    {
+        Data::Assets::LoadTextAssetResult result;
+        result.success = true;
+        result.asset.object = std::move(object);
+        result.asset.assetType = resolution.assetType;
+        result.asset.requestedPath = requestedPath;
+        result.asset.resolvedPath = resolution.resolvedPath;
+        result.asset.normalizedPath = resolution.normalizedPath;
+        return result;
+    }
+}
+
+namespace Data::Assets
+{
+    AssetLibrary::AssetLibrary(AssetLibraryOptions options)
+        : m_options(std::move(options))
+    {
+        if (m_options.assetsRoot.empty())
+        {
+            m_options.assetsRoot = AssetPaths::resolveAssetsRoot();
+        }
+    }
+
+    const AssetLibraryOptions& AssetLibrary::getOptions() const
+    {
+        return m_options;
+    }
+
+    void AssetLibrary::setOptions(const AssetLibraryOptions& options)
+    {
+        m_options = options;
+        if (m_options.assetsRoot.empty())
+        {
+            m_options.assetsRoot = AssetPaths::resolveAssetsRoot();
+        }
+    }
+
+    void AssetLibrary::setAssetsRoot(const std::string& assetsRoot)
+    {
+        m_options.assetsRoot = assetsRoot.empty()
+            ? AssetPaths::resolveAssetsRoot()
+            : AssetPaths::normalizePath(assetsRoot);
+    }
+
+    const std::string& AssetLibrary::getAssetsRoot() const
+    {
+        return m_options.assetsRoot;
+    }
+
+    void AssetLibrary::registerAlias(const std::string& assetName, const std::string& assetPath)
+    {
+        if (assetName.empty() || assetPath.empty())
+        {
+            return;
+        }
+
+        m_aliases[assetName] = assetPath;
+    }
+
+    bool AssetLibrary::hasAlias(const std::string& assetName) const
+    {
+        return m_aliases.find(assetName) != m_aliases.end();
+    }
+
+    bool AssetLibrary::removeAlias(const std::string& assetName)
+    {
+        return m_aliases.erase(assetName) > 0;
+    }
+
+    void AssetLibrary::clearAliases()
+    {
+        m_aliases.clear();
+    }
+
+    LoadTextAssetResult AssetLibrary::loadTextAsset(const std::string& assetNameOrPath)
+    {
+        return loadTextAssetInternal(assetNameOrPath, false);
+    }
+
+    LoadTextAssetResult AssetLibrary::reloadTextAsset(const std::string& assetNameOrPath)
+    {
+        return loadTextAssetInternal(assetNameOrPath, true);
+    }
+
+    const std::shared_ptr<TextObject>* AssetLibrary::findCachedTextAsset(const std::string& assetNameOrPath) const
+    {
+        const std::string cacheKey = makeCacheKey(assetNameOrPath);
+        if (cacheKey.empty())
+        {
+            return nullptr;
+        }
+
+        const auto it = m_textAssetCache.find(cacheKey);
+        if (it == m_textAssetCache.end() || !it->second.loadSucceeded)
+        {
+            return nullptr;
+        }
+
+        return &it->second.object;
+    }
+
+    bool AssetLibrary::evictCachedTextAsset(const std::string& assetNameOrPath)
+    {
+        const std::string cacheKey = makeCacheKey(assetNameOrPath);
+        if (cacheKey.empty())
+        {
+            return false;
+        }
+
+        return m_textAssetCache.erase(cacheKey) > 0;
+    }
+
+    void AssetLibrary::clear()
+    {
+        m_textAssetCache.clear();
+    }
+
+    std::size_t AssetLibrary::getCachedTextAssetCount() const
+    {
+        return m_textAssetCache.size();
+    }
+
+    std::size_t AssetLibrary::getAliasCount() const
+    {
+        return m_aliases.size();
+    }
+
+    LoadTextAssetResult AssetLibrary::loadTextAssetInternal(
+        const std::string& assetNameOrPath,
+        const bool forceReload)
+    {
+        const std::string requestedPath = resolveAssetReference(assetNameOrPath);
+        if (requestedPath.empty())
+        {
+            return makeFailure(assetNameOrPath, {}, "Asset name/path is empty.");
+        }
+
+        AssetPaths::ResolutionOptions resolutionOptions;
+        resolutionOptions.assetsRoot = m_options.assetsRoot;
+        resolutionOptions.searchRoots.push_back(m_options.assetsRoot);
+
+        const AssetPaths::ResolutionResult resolution =
+            AssetPaths::resolveAssetPath(requestedPath, resolutionOptions);
+
+        if (!resolution.success)
+        {
+            return makeFailure(requestedPath, resolution, resolution.errorMessage);
+        }
+
+        const std::string cacheKey = resolution.normalizedPath;
+        if (!forceReload)
+        {
+            const auto cacheIt = m_textAssetCache.find(cacheKey);
+            if (cacheIt != m_textAssetCache.end() && cacheIt->second.loadSucceeded)
+            {
+                LoadTextAssetResult result;
+                result.success = true;
+                result.fromCache = true;
+                result.asset.object = cacheIt->second.object;
+                result.asset.assetType = cacheIt->second.assetType;
+                result.asset.requestedPath = cacheIt->second.requestedPath;
+                result.asset.resolvedPath = cacheIt->second.resolvedPath;
+                result.asset.normalizedPath = cacheIt->second.normalizedPath;
+                result.asset.cacheKey = cacheKey;
+                return result;
+            }
+        }
+
+        LoadTextAssetResult result = dispatchLoad(requestedPath, resolution);
+        result.asset.cacheKey = cacheKey;
+
+        if (result.success || m_options.cacheFailures)
+        {
+            CacheEntry& entry = m_textAssetCache[cacheKey];
+            entry.object = result.asset.object;
+            entry.assetType = result.asset.assetType;
+            entry.requestedPath = result.asset.requestedPath;
+            entry.resolvedPath = result.asset.resolvedPath;
+            entry.normalizedPath = result.asset.normalizedPath;
+            entry.loadSucceeded = result.success;
+            entry.errorMessage = result.errorMessage;
+        }
+
+        return result;
+    }
+
+    LoadTextAssetResult AssetLibrary::dispatchLoad(
+        const std::string& requestedPath,
+        const AssetPaths::ResolutionResult& resolution)
+    {
+        switch (resolution.assetType)
+        {
+        case AssetPaths::AssetType::PlainText:
+        {
+            const PlainTextLoader::LoadResult loadResult =
+                PlainTextLoader::loadFromFile(resolution.normalizedPath, m_options.plainTextOptions);
+
+            if (!loadResult.success || !loadResult.object.isLoaded())
+            {
+                return makeFailure(requestedPath, resolution, "Plain text asset load failed.");
+            }
+
+            return makeSuccess(requestedPath, resolution, makeSharedTextObject(loadResult.object));
+        }
+
+        case AssetPaths::AssetType::AnsiArt:
+        {
+            const AnsiLoader::LoadResult loadResult =
+                AnsiLoader::loadFromFile(resolution.normalizedPath, m_options.ansiOptions);
+
+            if (!loadResult.success || !loadResult.object.isLoaded())
+            {
+                return makeFailure(requestedPath, resolution, AnsiLoader::formatLoadError(loadResult));
+            }
+
+            return makeSuccess(requestedPath, resolution, makeSharedTextObject(loadResult.object));
+        }
+
+        case AssetPaths::AssetType::BinaryArt:
+        {
+            const BinaryArtLoader::LoadResult loadResult =
+                BinaryArtLoader::loadFromFile(resolution.normalizedPath, m_options.binaryArtOptions);
+
+            if (!loadResult.success || !loadResult.object.isLoaded())
+            {
+                return makeFailure(requestedPath, resolution, BinaryArtLoader::formatLoadError(loadResult));
+            }
+
+            return makeSuccess(requestedPath, resolution, makeSharedTextObject(loadResult.object));
+        }
+
+        case AssetPaths::AssetType::XpDocument:
+        {
+            const XpArtLoader::LoadResult loadResult =
+                XpArtLoader::loadFromFile(resolution.normalizedPath, m_options.xpLoadOptions);
+
+            if (!loadResult.success || !loadResult.object.isLoaded())
+            {
+                return makeFailure(requestedPath, resolution, XpArtLoader::formatLoadError(loadResult));
+            }
+
+            return makeSuccess(requestedPath, resolution, makeSharedTextObject(loadResult.object));
+        }
+
+        case AssetPaths::AssetType::XpSequence:
+        {
+            XpSequenceAccess::LocalSequenceCache sequenceCache;
+            const XpSequenceAccess::SequenceLoadResult sequenceLoad =
+                XpSequenceAccess::loadSequenceFromFile(
+                    resolution.normalizedPath,
+                    sequenceCache,
+                    m_options.xpSequenceOptions);
+
+            if (!sequenceLoad.success || !sequenceLoad.hasSequence())
+            {
+                return makeFailure(requestedPath, resolution, sequenceLoad.errorMessage);
+            }
+
+            const XpArtLoader::LoadResult buildResult =
+                XpSequenceAccess::buildTextObjectFromDefaultFrame(
+                    sequenceLoad.sequence,
+                    {});
+
+            if (!buildResult.success || !buildResult.object.isLoaded())
+            {
+                return makeFailure(
+                    requestedPath,
+                    resolution,
+                    buildResult.errorMessage.empty()
+                    ? "XP sequence default frame conversion failed."
+                    : buildResult.errorMessage);
+            }
+
+            return makeSuccess(requestedPath, resolution, makeSharedTextObject(buildResult.object));
+        }
+
+        case AssetPaths::AssetType::FontSource:
+            return makeFailure(
+                requestedPath,
+                resolution,
+                "Font source was recognized by extension, but Phase 3.7 does not yet have a central font loader implementation.");
+
+        case AssetPaths::AssetType::BannerSource:
+            return makeFailure(
+                requestedPath,
+                resolution,
+                "Banner source was recognized by extension, but Phase 3.7 does not yet have a central banner loader implementation.");
+
+        case AssetPaths::AssetType::Unknown:
+        default:
+            return makeFailure(requestedPath, resolution, "Unsupported asset type.");
+        }
+    }
+
+    std::string AssetLibrary::resolveAssetReference(const std::string& assetNameOrPath) const
+    {
+        const auto aliasIt = m_aliases.find(assetNameOrPath);
+        if (aliasIt != m_aliases.end())
+        {
+            return aliasIt->second;
+        }
+
+        return assetNameOrPath;
+    }
+
+    std::string AssetLibrary::makeCacheKey(const std::string& assetNameOrPath) const
+    {
+        const std::string requestedPath = resolveAssetReference(assetNameOrPath);
+        if (requestedPath.empty())
+        {
+            return std::string();
+        }
+
+        AssetPaths::ResolutionOptions resolutionOptions;
+        resolutionOptions.assetsRoot = m_options.assetsRoot;
+        resolutionOptions.searchRoots.push_back(m_options.assetsRoot);
+
+        const AssetPaths::ResolutionResult resolution =
+            AssetPaths::resolveAssetPath(requestedPath, resolutionOptions);
+        if (!resolution.success)
+        {
+            return std::string();
+        }
+
+        return resolution.normalizedPath;
+    }
+}

--- a/TUI/Assets/AssetLibrary.h
+++ b/TUI/Assets/AssetLibrary.h
@@ -1,0 +1,103 @@
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <string>
+#include <unordered_map>
+
+#include "Rendering/Objects/AnsiLoader.h"
+#include "Rendering/Objects/BinaryArtLoader.h"
+#include "Rendering/Objects/PlainTextLoader.h"
+#include "Rendering/Objects/TextObject.h"
+#include "Rendering/Objects/XpArtLoader.h"
+#include "Rendering/Objects/XpSequenceAccess.h"
+#include "Utilities/AssetPaths.h"
+
+namespace Data::Assets
+{
+    struct AssetLibraryOptions
+    {
+        std::string assetsRoot;
+        bool cacheFailures = false;
+
+        PlainTextLoader::LoadOptions plainTextOptions;
+        AnsiLoader::LoadOptions ansiOptions;
+        BinaryArtLoader::LoadOptions binaryArtOptions;
+        XpArtLoader::LoadOptions xpLoadOptions;
+        XpSequenceAccess::SequenceLoadOptions xpSequenceOptions;
+    };
+
+    struct LoadedTextAsset
+    {
+        std::shared_ptr<TextObject> object;
+        AssetPaths::AssetType assetType = AssetPaths::AssetType::Unknown;
+        std::string requestedPath;
+        std::string resolvedPath;
+        std::string normalizedPath;
+        std::string cacheKey;
+    };
+
+    struct LoadTextAssetResult
+    {
+        LoadedTextAsset asset;
+        bool success = false;
+        bool fromCache = false;
+        std::string errorMessage;
+
+        bool hasObject() const
+        {
+            return asset.object != nullptr;
+        }
+    };
+
+    class AssetLibrary
+    {
+    public:
+        explicit AssetLibrary(AssetLibraryOptions options = {});
+
+        const AssetLibraryOptions& getOptions() const;
+        void setOptions(const AssetLibraryOptions& options);
+
+        void setAssetsRoot(const std::string& assetsRoot);
+        const std::string& getAssetsRoot() const;
+
+        void registerAlias(const std::string& assetName, const std::string& assetPath);
+        bool hasAlias(const std::string& assetName) const;
+        bool removeAlias(const std::string& assetName);
+        void clearAliases();
+
+        LoadTextAssetResult loadTextAsset(const std::string& assetNameOrPath);
+        LoadTextAssetResult reloadTextAsset(const std::string& assetNameOrPath);
+
+        const std::shared_ptr<TextObject>* findCachedTextAsset(const std::string& assetNameOrPath) const;
+        bool evictCachedTextAsset(const std::string& assetNameOrPath);
+        void clear();
+
+        std::size_t getCachedTextAssetCount() const;
+        std::size_t getAliasCount() const;
+
+    private:
+        struct CacheEntry
+        {
+            std::shared_ptr<TextObject> object;
+            AssetPaths::AssetType assetType = AssetPaths::AssetType::Unknown;
+            std::string requestedPath;
+            std::string resolvedPath;
+            std::string normalizedPath;
+            bool loadSucceeded = false;
+            std::string errorMessage;
+        };
+
+        LoadTextAssetResult loadTextAssetInternal(const std::string& assetNameOrPath, bool forceReload);
+        LoadTextAssetResult dispatchLoad(const std::string& requestedPath, const AssetPaths::ResolutionResult& resolution);
+
+        std::string resolveAssetReference(const std::string& assetNameOrPath) const;
+        std::string makeCacheKey(const std::string& assetNameOrPath) const;
+
+    private:
+        AssetLibraryOptions m_options;
+        std::unordered_map<std::string, std::string> m_aliases;
+        std::unordered_map<std::string, CacheEntry> m_textAssetCache;
+    };
+}

--- a/TUI/TUI.vcxproj
+++ b/TUI/TUI.vcxproj
@@ -137,6 +137,7 @@
     <ClInclude Include="App\StartupConfig.h" />
     <ClInclude Include="App\StartupOptions.h" />
     <ClInclude Include="App\TerminalLauncher.h" />
+    <ClInclude Include="Assets\AssetLibrary.h" />
     <ClInclude Include="Core\Enums.h" />
     <ClInclude Include="Core\Point.h" />
     <ClInclude Include="Core\Rect.h" />
@@ -227,6 +228,7 @@
     <ClInclude Include="Screens\Developer\XpSequenceDiagnosticsScreen.h" />
     <ClInclude Include="ThirdParty\zlib-1.3.1\zconf.h" />
     <ClInclude Include="ThirdParty\zlib-1.3.1\zutil.h" />
+    <ClInclude Include="Utilities\AssetPaths.h" />
     <ClInclude Include="Utilities\Text\TextWrap.h" />
     <ClInclude Include="Utilities\Unicode\GraphemeSegmentation.h" />
     <ClInclude Include="Utilities\Unicode\UnicodeConversion.h" />
@@ -239,6 +241,7 @@
     <ClCompile Include="App\StartupConfig.cpp" />
     <ClCompile Include="App\StartupOptions.cpp" />
     <ClCompile Include="App\TerminalLauncher.cpp" />
+    <ClCompile Include="Assets\AssetLibrary.cpp" />
     <ClCompile Include="main.cpp" />
     <ClCompile Include="Rendering\Backends\ConsoleCapabilityDetector.cpp" />
     <ClCompile Include="Rendering\Backends\RendererCapabiltiyDetector.cpp" />
@@ -318,6 +321,7 @@
     <ClCompile Include="ThirdParty\zlib-1.3.1\inflate.c" />
     <ClCompile Include="ThirdParty\zlib-1.3.1\inftrees.c" />
     <ClCompile Include="ThirdParty\zlib-1.3.1\zutil.c" />
+    <ClCompile Include="Utilities\AssetPaths.cpp" />
     <ClCompile Include="Utilities\Unicode\GraphemeSegmentation.cpp" />
     <ClCompile Include="Utilities\Unicode\UnicodeConversion.cpp" />
     <ClCompile Include="Utilities\Unicode\UnicodeWidth.cpp" />

--- a/TUI/TUI.vcxproj.filters
+++ b/TUI/TUI.vcxproj.filters
@@ -270,6 +270,12 @@
     <ClInclude Include="Rendering\Objects\XpDiagnosticsFormatting.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="Assets\AssetLibrary.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Utilities\AssetPaths.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Rendering\ScreenBuffer.cpp">
@@ -489,6 +495,12 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="Rendering\Objects\XpDiagnosticsFormatting.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Assets\AssetLibrary.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Utilities\AssetPaths.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/TUI/Utilities/AssetPaths.cpp
+++ b/TUI/Utilities/AssetPaths.cpp
@@ -1,0 +1,333 @@
+#include "Utilities/AssetPaths.h"
+
+#include <algorithm>
+#include <cctype>
+#include <filesystem>
+#include <unordered_set>
+
+namespace
+{
+    std::string toLower(std::string value)
+    {
+        std::transform(
+            value.begin(),
+            value.end(),
+            value.begin(),
+            [](unsigned char ch)
+            {
+                return static_cast<char>(std::tolower(ch));
+            });
+        return value;
+    }
+
+    std::string weaklyCanonicalString(const std::filesystem::path& path)
+    {
+        std::error_code error;
+        const std::filesystem::path canonical = std::filesystem::weakly_canonical(path, error);
+        if (!error)
+        {
+            return canonical.generic_string();
+        }
+
+        return path.lexically_normal().generic_string();
+    }
+
+    std::vector<std::filesystem::path> buildCandidatePaths(
+        const std::filesystem::path& input,
+        const AssetPaths::ResolutionOptions& options)
+    {
+        std::vector<std::filesystem::path> candidates;
+        candidates.reserve(8);
+
+        if (input.is_absolute())
+        {
+            if (options.allowAbsolutePaths)
+            {
+                candidates.push_back(input);
+            }
+
+            return candidates;
+        }
+
+        if (!options.assetsRoot.empty())
+        {
+            candidates.push_back(std::filesystem::path(options.assetsRoot) / input);
+        }
+
+        for (const std::string& searchRoot : options.searchRoots)
+        {
+            if (!searchRoot.empty())
+            {
+                candidates.push_back(std::filesystem::path(searchRoot) / input);
+            }
+        }
+
+        candidates.push_back(input);
+        return candidates;
+    }
+}
+
+namespace AssetPaths
+{
+    std::string normalizePath(std::string path)
+    {
+        if (path.empty())
+        {
+            return path;
+        }
+
+        std::replace(path.begin(), path.end(), '\\', '/');
+
+        std::error_code error;
+        const std::filesystem::path filesystemPath(path);
+        const std::filesystem::path normalized = filesystemPath.lexically_normal();
+        if (!error)
+        {
+            return normalized.generic_string();
+        }
+
+        return filesystemPath.generic_string();
+    }
+
+    std::string normalizeExtension(std::string extension)
+    {
+        extension = normalizePath(std::move(extension));
+        if (!extension.empty() && extension.front() == '.')
+        {
+            extension.erase(extension.begin());
+        }
+
+        return toLower(std::move(extension));
+    }
+
+    std::string getExtension(const std::string& path)
+    {
+        return normalizeExtension(std::filesystem::path(path).extension().string());
+    }
+
+    std::string getStem(const std::string& path)
+    {
+        return std::filesystem::path(path).stem().string();
+    }
+
+    bool hasSupportedExtension(const std::string& path)
+    {
+        return detectAssetTypeByExtension(path) != AssetType::Unknown;
+    }
+
+    bool isTextObjectAssetType(AssetType assetType)
+    {
+        switch (assetType)
+        {
+        case AssetType::PlainText:
+        case AssetType::AnsiArt:
+        case AssetType::BinaryArt:
+        case AssetType::XpDocument:
+        case AssetType::XpSequence:
+            return true;
+
+        case AssetType::Unknown:
+        case AssetType::FontSource:
+        case AssetType::BannerSource:
+        default:
+            return false;
+        }
+    }
+
+    AssetType detectAssetTypeByExtension(const std::string& path)
+    {
+        static const std::unordered_set<std::string> plainTextExtensions =
+        {
+            "txt", "asc", "nfo", "diz"
+        };
+
+        static const std::unordered_set<std::string> ansiExtensions =
+        {
+            "ans"
+        };
+
+        static const std::unordered_set<std::string> binaryExtensions =
+        {
+            "bin", "xbin", "adf"
+        };
+
+        static const std::unordered_set<std::string> fontExtensions =
+        {
+            "fon", "fnt"
+        };
+
+        static const std::unordered_set<std::string> bannerExtensions =
+        {
+            "flf", "tlf"
+        };
+
+        const std::string extension = getExtension(path);
+        if (extension.empty())
+        {
+            return AssetType::Unknown;
+        }
+
+        if (plainTextExtensions.count(extension) > 0)
+        {
+            return AssetType::PlainText;
+        }
+
+        if (ansiExtensions.count(extension) > 0)
+        {
+            return AssetType::AnsiArt;
+        }
+
+        if (binaryExtensions.count(extension) > 0)
+        {
+            return AssetType::BinaryArt;
+        }
+
+        if (extension == "xp")
+        {
+            return AssetType::XpDocument;
+        }
+
+        if (extension == "xpseq")
+        {
+            return AssetType::XpSequence;
+        }
+
+        if (fontExtensions.count(extension) > 0)
+        {
+            return AssetType::FontSource;
+        }
+
+        if (bannerExtensions.count(extension) > 0)
+        {
+            return AssetType::BannerSource;
+        }
+
+        return AssetType::Unknown;
+    }
+
+    std::string resolveAssetsRoot()
+    {
+        return resolveAssetsRoot(std::filesystem::current_path().string());
+    }
+
+    std::string resolveAssetsRoot(const std::string& startDirectory)
+    {
+        std::filesystem::path current =
+            startDirectory.empty()
+            ? std::filesystem::current_path()
+            : std::filesystem::path(startDirectory);
+
+        std::error_code error;
+        if (!std::filesystem::exists(current, error))
+        {
+            current = std::filesystem::current_path();
+        }
+
+        current = current.lexically_normal();
+
+        while (!current.empty())
+        {
+            const std::filesystem::path candidate = current / "Assets";
+            if (std::filesystem::exists(candidate, error) && std::filesystem::is_directory(candidate, error))
+            {
+                return weaklyCanonicalString(candidate);
+            }
+
+            const std::filesystem::path parent = current.parent_path();
+            if (parent == current)
+            {
+                break;
+            }
+
+            current = parent;
+        }
+
+        return weaklyCanonicalString(std::filesystem::current_path() / "Assets");
+    }
+
+    ResolutionResult resolveAssetPath(
+        const std::string& assetPath,
+        const ResolutionOptions& options)
+    {
+        ResolutionResult result;
+        result.requestedPath = assetPath;
+        result.assetsRoot = options.assetsRoot.empty()
+            ? resolveAssetsRoot()
+            : normalizePath(options.assetsRoot);
+
+        if (assetPath.empty())
+        {
+            result.errorMessage = "Asset path is empty.";
+            return result;
+        }
+
+        result.assetType = detectAssetTypeByExtension(assetPath);
+        if (result.assetType == AssetType::Unknown)
+        {
+            result.errorMessage = "Asset type could not be determined from extension.";
+            return result;
+        }
+
+        const std::filesystem::path inputPath(normalizePath(assetPath));
+        const std::vector<std::filesystem::path> candidates = buildCandidatePaths(inputPath, options);
+
+        for (const std::filesystem::path& candidate : candidates)
+        {
+            if (candidate.empty())
+            {
+                continue;
+            }
+
+            if (!options.requireExistingPath)
+            {
+                result.success = true;
+                result.resolvedPath = candidate.lexically_normal().generic_string();
+                result.normalizedPath = weaklyCanonicalString(candidate);
+                return result;
+            }
+
+            std::error_code error;
+            if (std::filesystem::exists(candidate, error) && !error)
+            {
+                result.success = true;
+                result.resolvedPath = candidate.lexically_normal().generic_string();
+                result.normalizedPath = weaklyCanonicalString(candidate);
+                return result;
+            }
+        }
+
+        result.errorMessage = "Asset path could not be resolved from the configured asset roots.";
+        return result;
+    }
+
+    const char* toString(AssetType assetType)
+    {
+        switch (assetType)
+        {
+        case AssetType::PlainText:
+            return "PlainText";
+
+        case AssetType::AnsiArt:
+            return "AnsiArt";
+
+        case AssetType::BinaryArt:
+            return "BinaryArt";
+
+        case AssetType::XpDocument:
+            return "XpDocument";
+
+        case AssetType::XpSequence:
+            return "XpSequence";
+
+        case AssetType::FontSource:
+            return "FontSource";
+
+        case AssetType::BannerSource:
+            return "BannerSource";
+
+        case AssetType::Unknown:
+        default:
+            return "Unknown";
+        }
+    }
+}

--- a/TUI/Utilities/AssetPaths.h
+++ b/TUI/Utilities/AssetPaths.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace AssetPaths
+{
+    enum class AssetType
+    {
+        Unknown,
+        PlainText,
+        AnsiArt,
+        BinaryArt,
+        XpDocument,
+        XpSequence,
+        FontSource,
+        BannerSource
+    };
+
+    struct ResolutionOptions
+    {
+        std::string assetsRoot;
+        std::vector<std::string> searchRoots;
+        bool allowAbsolutePaths = true;
+        bool requireExistingPath = true;
+    };
+
+    struct ResolutionResult
+    {
+        bool success = false;
+        AssetType assetType = AssetType::Unknown;
+        std::string requestedPath;
+        std::string resolvedPath;
+        std::string normalizedPath;
+        std::string assetsRoot;
+        std::string errorMessage;
+    };
+
+    std::string normalizePath(std::string path);
+    std::string normalizeExtension(std::string extension);
+    std::string getExtension(const std::string& path);
+    std::string getStem(const std::string& path);
+
+    bool hasSupportedExtension(const std::string& path);
+    bool isTextObjectAssetType(AssetType assetType);
+
+    AssetType detectAssetTypeByExtension(const std::string& path);
+
+    std::string resolveAssetsRoot();
+    std::string resolveAssetsRoot(const std::string& startDirectory);
+
+    ResolutionResult resolveAssetPath(
+        const std::string& assetPath,
+        const ResolutionOptions& options = {});
+
+    const char* toString(AssetType assetType);
+}


### PR DESCRIPTION
…iles

Modifies:
- TUI.vcxproj -TUI.vcxproj.filters

Adds AssetLibrary.h/.cpp and AssetPaths.h/.cpp to project so it will build properly

Modifies:
- ROADMAP.md

Explicitly list in ROADMAP where AssetLibrary is located

Adds:
- Utilities/AssetPaths.h/.cpp

Owns path normalization, Assets/ root discovery, extension-based type detection, and path resolution.

Adds:
- Assets/AssetLibrary.h/.cpp

- Owns loader dispatch and cached engine-owned TextObject instances.

- Cache entries are keyed by normalized resolved path, so repeated requests for the same asset avoid repeated disk work.

- Dispatch is extension-driven and centralized in one place, which keeps screens and future interpreters out of the file-format business.

- The cache stores normalized engine-owned TextObject instances, not raw bytes.

- Library currently supports .txt/.asc/.nfo/.diz, .ans, .bin/.xbin/.adf, .xp, and .xpseq as text-producing assets. For .xpseq, it converts the default frame to TextObject, which keeps current authored-screen usage simple while still fitting the existing XP pipeline.

- Font and banner source extensions are recognized but intentionally return a clear “not implemented here yet” failure so the extension/type system is ready without pretending those loaders already exist.

Closes: #57 