### PR TITLE
Phase 3 Clean-up: TextObjectBlitter(), TextObject(), LayeredTextObject()

### DIFF
--- a/TUI/Rendering/Objects/LayeredTextObject.cpp
+++ b/TUI/Rendering/Objects/LayeredTextObject.cpp
@@ -3,69 +3,8 @@
 #include <algorithm>
 #include <utility>
 
+#include "Rendering/Objects/TextObjectBlitter.h"
 #include "Rendering/Objects/TextObjectBuilder.h"
-
-namespace
-{
-    void blitTextObject(
-        TextObjectBuilder& builder,
-        const TextObject& source,
-        const int offsetX,
-        const int offsetY,
-        const std::optional<Style>& overrideStyle)
-    {
-        for (int y = 0; y < source.getHeight(); ++y)
-        {
-            for (int x = 0; x < source.getWidth(); ++x)
-            {
-                const TextObjectCell* cell = source.tryGetCell(x, y);
-                if (cell == nullptr)
-                {
-                    continue;
-                }
-
-                if (cell->kind == CellKind::Empty)
-                {
-                    continue;
-                }
-
-                const int destX = offsetX + x;
-                const int destY = offsetY + y;
-
-                if (!builder.inBounds(destX, destY))
-                {
-                    continue;
-                }
-
-                const std::optional<Style> styleToApply =
-                    overrideStyle.has_value() ? overrideStyle : cell->style;
-
-                switch (cell->kind)
-                {
-                case CellKind::Glyph:
-                    if (cell->width == CellWidth::Two)
-                    {
-                        builder.setWideGlyph(destX, destY, cell->glyph, styleToApply);
-                    }
-                    else
-                    {
-                        builder.setGlyph(destX, destY, cell->glyph, styleToApply);
-                    }
-                    break;
-
-                case CellKind::WideTrailing:
-                case CellKind::CombiningContinuation:
-                    builder.setCell(destX, destY, cell->glyph, cell->kind, cell->width, styleToApply);
-                    break;
-
-                case CellKind::Empty:
-                default:
-                    break;
-                }
-            }
-        }
-    }
-}
 
 namespace Rendering
 {
@@ -288,12 +227,17 @@ namespace Rendering
                 continue;
             }
 
-            blitTextObject(
+            TextObjectBlitter::BlitOptions blitOptions;
+            blitOptions.overrideStyle = options.overrideStyle;
+            blitOptions.skipEmptyCells = true;
+            blitOptions.skipStructuralContinuationCells = false;
+
+            TextObjectBlitter::blitToBuilder(
                 builder,
                 layer->object,
                 layer->offsetX,
                 layer->offsetY,
-                options.overrideStyle);
+                blitOptions);
         }
 
         return builder.build();

--- a/TUI/Rendering/Objects/TextObject.cpp
+++ b/TUI/Rendering/Objects/TextObject.cpp
@@ -1,9 +1,9 @@
 #include "Rendering/Objects/TextObject.h"
 
-#include <fstream>
-#include <iterator>
 #include <stdexcept>
 
+#include "Rendering/Objects/PlainTextLoader.h"
+#include "Rendering/Objects/TextObjectBlitter.h"
 #include "Rendering/Objects/TextObjectExporter.h"
 #include "Utilities/Unicode/UnicodeConversion.h"
 #include "Utilities/Unicode/UnicodeWidth.h"
@@ -24,31 +24,6 @@ namespace
         default:
             return 1;
         }
-    }
-
-    Style resolveDrawStyle(
-        const ScreenBuffer& target,
-        int x,
-        int y,
-        const TextObjectCell& sourceCell,
-        const std::optional<Style>& overrideStyle)
-    {
-        if (overrideStyle.has_value())
-        {
-            return *overrideStyle;
-        }
-
-        if (sourceCell.style.has_value())
-        {
-            return *sourceCell.style;
-        }
-
-        if (target.inBounds(x, y))
-        {
-            return target.getCell(x, y).style;
-        }
-
-        return Style{};
     }
 }
 
@@ -92,19 +67,13 @@ bool TextObject::loadUtf8File(const std::string& filePath)
 {
     clear();
 
-    std::ifstream file(filePath, std::ios::binary);
-    if (!file)
+    const PlainTextLoader::LoadResult loadResult = PlainTextLoader::loadFromFile(filePath);
+    if (!loadResult.success || !loadResult.object.isLoaded())
     {
         return false;
     }
 
-    const std::string bytes{
-        std::istreambuf_iterator<char>(file),
-        std::istreambuf_iterator<char>()
-    };
-
-    *this = fromUtf8(std::string_view(bytes.data(), bytes.size()));
-    m_loaded = true;
+    *this = loadResult.object;
     return true;
 }
 
@@ -112,19 +81,13 @@ bool TextObject::loadUtf8File(const std::string& filePath, const Style& style)
 {
     clear();
 
-    std::ifstream file(filePath, std::ios::binary);
-    if (!file)
+    const PlainTextLoader::LoadResult loadResult = PlainTextLoader::loadFromFile(filePath, style);
+    if (!loadResult.success || !loadResult.object.isLoaded())
     {
         return false;
     }
 
-    const std::string bytes{
-        std::istreambuf_iterator<char>(file),
-        std::istreambuf_iterator<char>()
-    };
-
-    *this = fromUtf8(std::string_view(bytes.data(), bytes.size()), style);
-    m_loaded = true;
+    *this = loadResult.object;
     return true;
 }
 
@@ -224,44 +187,9 @@ void TextObject::draw(ScreenBuffer& target, int x, int y, const Style& overrideS
 
 void TextObject::draw(ScreenBuffer& target, int x, int y, const std::optional<Style>& overrideStyle) const
 {
-    if (!m_loaded || m_width <= 0 || m_height <= 0)
-    {
-        return;
-    }
-
-    for (int row = 0; row < m_height; ++row)
-    {
-        for (int col = 0; col < m_width; ++col)
-        {
-            const int targetX = x + col;
-            const int targetY = y + row;
-
-            if (!target.inBounds(targetX, targetY))
-            {
-                continue;
-            }
-
-            const TextObjectCell& sourceCell = m_cells[static_cast<std::size_t>(index(col, row))];
-
-            if (sourceCell.kind == CellKind::Empty)
-            {
-                continue;
-            }
-
-            if (sourceCell.kind == CellKind::WideTrailing)
-            {
-                continue;
-            }
-
-            if (sourceCell.kind == CellKind::CombiningContinuation)
-            {
-                continue;
-            }
-
-            const Style style = resolveDrawStyle(target, targetX, targetY, sourceCell, overrideStyle);
-            target.writeCodePoint(targetX, targetY, sourceCell.glyph, style);
-        }
-    }
+    TextObjectBlitter::BlitOptions options;
+    options.overrideStyle = overrideStyle;
+    TextObjectBlitter::blitToScreenBuffer(target, *this, x, y, options);
 }
 
 TextObject TextObject::buildFromLines(

--- a/TUI/Rendering/Objects/TextObjectBlitter.cpp
+++ b/TUI/Rendering/Objects/TextObjectBlitter.cpp
@@ -1,0 +1,161 @@
+#include "Rendering/Objects/TextObjectBlitter.h"
+
+namespace
+{
+    Style resolveTargetStyle(
+        const ScreenBuffer& target,
+        int x,
+        int y,
+        const TextObjectCell& sourceCell,
+        const TextObjectBlitter::BlitOptions& options)
+    {
+        if (options.overrideStyle.has_value())
+        {
+            return *options.overrideStyle;
+        }
+
+        if (sourceCell.style.has_value())
+        {
+            return *sourceCell.style;
+        }
+
+        if (target.inBounds(x, y))
+        {
+            return target.getCell(x, y).style;
+        }
+
+        return Style{};
+    }
+
+    bool shouldSkipCell(
+        const TextObjectCell& cell,
+        const TextObjectBlitter::BlitOptions& options)
+    {
+        if (options.skipEmptyCells && cell.kind == CellKind::Empty)
+        {
+            return true;
+        }
+
+        if (options.skipStructuralContinuationCells)
+        {
+            if (cell.kind == CellKind::WideTrailing)
+            {
+                return true;
+            }
+
+            if (cell.kind == CellKind::CombiningContinuation)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    std::optional<Style> resolveBuilderStyle(
+        const TextObjectCell& sourceCell,
+        const TextObjectBlitter::BlitOptions& options)
+    {
+        if (options.overrideStyle.has_value())
+        {
+            return options.overrideStyle;
+        }
+
+        return sourceCell.style;
+    }
+}
+
+namespace TextObjectBlitter
+{
+    void blitToBuilder(
+        TextObjectBuilder& builder,
+        const TextObject& source,
+        int offsetX,
+        int offsetY,
+        const BlitOptions& options)
+    {
+        if (!source.isLoaded() || source.getWidth() <= 0 || source.getHeight() <= 0)
+        {
+            return;
+        }
+
+        for (int y = 0; y < source.getHeight(); ++y)
+        {
+            for (int x = 0; x < source.getWidth(); ++x)
+            {
+                const TextObjectCell* cell = source.tryGetCell(x, y);
+                if (cell == nullptr || shouldSkipCell(*cell, options))
+                {
+                    continue;
+                }
+
+                const int destX = offsetX + x;
+                const int destY = offsetY + y;
+                if (!builder.inBounds(destX, destY))
+                {
+                    continue;
+                }
+
+                const std::optional<Style> styleToApply = resolveBuilderStyle(*cell, options);
+
+                switch (cell->kind)
+                {
+                case CellKind::Glyph:
+                    if (cell->width == CellWidth::Two)
+                    {
+                        builder.setWideGlyph(destX, destY, cell->glyph, styleToApply);
+                    }
+                    else
+                    {
+                        builder.setGlyph(destX, destY, cell->glyph, styleToApply);
+                    }
+                    break;
+
+                case CellKind::WideTrailing:
+                case CellKind::CombiningContinuation:
+                    builder.setCell(destX, destY, cell->glyph, cell->kind, cell->width, styleToApply);
+                    break;
+
+                case CellKind::Empty:
+                default:
+                    break;
+                }
+            }
+        }
+    }
+
+    void blitToScreenBuffer(
+        ScreenBuffer& target,
+        const TextObject& source,
+        int offsetX,
+        int offsetY,
+        const BlitOptions& options)
+    {
+        if (!source.isLoaded() || source.getWidth() <= 0 || source.getHeight() <= 0)
+        {
+            return;
+        }
+
+        for (int y = 0; y < source.getHeight(); ++y)
+        {
+            for (int x = 0; x < source.getWidth(); ++x)
+            {
+                const TextObjectCell* cell = source.tryGetCell(x, y);
+                if (cell == nullptr || shouldSkipCell(*cell, options))
+                {
+                    continue;
+                }
+
+                const int destX = offsetX + x;
+                const int destY = offsetY + y;
+                if (!target.inBounds(destX, destY))
+                {
+                    continue;
+                }
+
+                const Style styleToApply = resolveTargetStyle(target, destX, destY, *cell, options);
+                target.writeCodePoint(destX, destY, cell->glyph, styleToApply);
+            }
+        }
+    }
+}

--- a/TUI/Rendering/Objects/TextObjectBlitter.h
+++ b/TUI/Rendering/Objects/TextObjectBlitter.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <optional>
+
+#include "Rendering/Objects/TextObject.h"
+#include "Rendering/Objects/TextObjectBuilder.h"
+#include "Rendering/ScreenBuffer.h"
+#include "Rendering/Styles/Style.h"
+
+namespace TextObjectBlitter
+{
+    struct BlitOptions
+    {
+        std::optional<Style> overrideStyle;
+        bool skipEmptyCells = true;
+        bool skipStructuralContinuationCells = true;
+    };
+
+    void blitToBuilder(
+        TextObjectBuilder& builder,
+        const TextObject& source,
+        int offsetX,
+        int offsetY,
+        const BlitOptions& options = {});
+
+    void blitToScreenBuffer(
+        ScreenBuffer& target,
+        const TextObject& source,
+        int offsetX,
+        int offsetY,
+        const BlitOptions& options = {});
+}

--- a/TUI/TUI.vcxproj
+++ b/TUI/TUI.vcxproj
@@ -172,6 +172,7 @@
     <ClInclude Include="Rendering\Objects\BinaryArtLoader.h" />
     <ClInclude Include="Rendering\Objects\Cp437Encoding.h" />
     <ClInclude Include="Rendering\Objects\LayeredTextObject.h" />
+    <ClInclude Include="Rendering\Objects\TextObjectBlitter.h" />
     <ClInclude Include="Rendering\Objects\TextObjectFactory.h" />
     <ClInclude Include="Rendering\Objects\pFontLoader.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</ExcludedFromBuild>
@@ -277,6 +278,7 @@
     <ClCompile Include="Rendering\Objects\BinaryArtLoader.cpp" />
     <ClCompile Include="Rendering\Objects\Cp437Encoding.cpp" />
     <ClCompile Include="Rendering\Objects\LayeredTextObject.cpp" />
+    <ClCompile Include="Rendering\Objects\TextObjectBlitter.cpp" />
     <ClCompile Include="Rendering\Objects\TextObjectFactory.cpp" />
     <ClCompile Include="Rendering\Objects\pFontLoader.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</ExcludedFromBuild>


### PR DESCRIPTION
Adds:
- TextObjectBlitter() - Now the single source of truth for both screen drawing and layered flattening

Modifies:
- TUI.vcxproj - Adds Rendering/Objects/TextObjectBlitter.h/.cpp to project so it will build

- TextObject.cpp - Now using TextObjectBitter() for drawing - TextObject::loadUtf8file no longer bypassing PlainTextLoader()

- LayeredTextObjet.cpp - Now using TextObjectBlitter() for layer flattening

Closes #19 