### PR TITLE
WritePolicy: Establish a renderer independant engine policy

### DIFF
--- a/TUI/Rendering/Composition/DepthPolicy.h
+++ b/TUI/Rendering/Composition/DepthPolicy.h
@@ -1,0 +1,27 @@
+#pragma once
+
+namespace Composition
+{
+    /*
+        DepthPolicy answers:
+
+            "How should this write interact with future depth-aware composition?"
+
+        This tier keeps the enum backend-agnostic and policy-only.
+
+        Semantics:
+        - Ignore:
+            Do not consult or affect depth ordering.
+        - Respect:
+            Participate in normal depth-aware composition.
+        - BehindOnly:
+            Only write when the source is behind existing depth ownership.
+            Exact depth comparison mechanics belong to later implementation tiers.
+    */
+    enum class DepthPolicy
+    {
+        Ignore,
+        Respect,
+        BehindOnly
+    };
+}

--- a/TUI/Rendering/Composition/GlyphPolicy.h
+++ b/TUI/Rendering/Composition/GlyphPolicy.h
@@ -1,0 +1,26 @@
+#pragma once
+
+namespace Composition
+{
+    /*
+        GlyphPolicy answers:
+
+            "If a participating source cell is considered, what glyph-writing
+             intent should the engine apply?"
+
+        Semantics:
+        - None:
+            Never write glyph content from the source.
+        - NonSpaceOnly:
+            Write source glyphs only when the source cell represents a non-space glyph.
+            Source spaces do not replace destination glyphs.
+        - All:
+            Write all eligible source glyphs, including spaces.
+    */
+    enum class GlyphPolicy
+    {
+        None,
+        NonSpaceOnly,
+        All
+    };
+}

--- a/TUI/Rendering/Composition/OverwriteRule.h
+++ b/TUI/Rendering/Composition/OverwriteRule.h
@@ -1,0 +1,31 @@
+#pragma once
+
+namespace Composition
+{
+    /*
+        OverwriteRule answers:
+
+            "When a write is otherwise allowed, under what destination condition
+             may it replace existing destination state?"
+
+        This enum is intentionally explicit so glyph and style replacement behavior
+        can be described without hidden booleans.
+
+        Semantics:
+        - Never:
+            Do not overwrite destination state.
+        - IfTargetEmpty:
+            Overwrite only when the destination is logically empty.
+        - IfTargetNonEmpty:
+            Overwrite only when the destination is logically non-empty.
+        - Always:
+            Always overwrite when the write is otherwise eligible.
+    */
+    enum class OverwriteRule
+    {
+        Never,
+        IfTargetEmpty,
+        IfTargetNonEmpty,
+        Always
+    };
+}

--- a/TUI/Rendering/Composition/SourceMask.h
+++ b/TUI/Rendering/Composition/SourceMask.h
@@ -1,0 +1,26 @@
+#pragma once
+
+namespace Composition
+{
+    /*
+        SourceMask answers:
+
+            "Which source cells are eligible to participate in this write pass?"
+
+        Semantics:
+        - AllCells:
+            All source cells may participate.
+        - GlyphCellsOnly:
+            Only source cells that represent glyph-bearing content may participate.
+            This is the common transparent-overlay style mask.
+        - SpaceCellsOnly:
+            Only source cells that represent space/empty cells may participate.
+            Useful for future erase, punch-through, masking, or negative-space passes.
+    */
+    enum class SourceMask
+    {
+        AllCells,
+        GlyphCellsOnly,
+        SpaceCellsOnly
+    };
+}

--- a/TUI/Rendering/Composition/StylePolicy.h
+++ b/TUI/Rendering/Composition/StylePolicy.h
@@ -1,0 +1,22 @@
+#pragma once
+
+namespace Composition
+{
+    /*
+        StylePolicy answers:
+
+            "If a participating source cell is considered, should source style
+             metadata be applied to the destination?"
+
+        Semantics:
+        - None:
+            Do not write style from the source.
+        - Apply:
+            Apply source style to the destination subject to overwrite rules.
+    */
+    enum class StylePolicy
+    {
+        None,
+        Apply
+    };
+}

--- a/TUI/Rendering/Composition/WritePolicy.cpp
+++ b/TUI/Rendering/Composition/WritePolicy.cpp
@@ -1,0 +1,84 @@
+#include "Rendering/Composition/WritePolicy.h"
+
+namespace Composition
+{
+    WritePolicy WritePolicy::ReplaceAll()
+    {
+        WritePolicy policy;
+        policy.glyphPolicy = GlyphPolicy::All;
+        policy.stylePolicy = StylePolicy::Apply;
+        policy.sourceMask = SourceMask::AllCells;
+        policy.glyphOverwriteRule = OverwriteRule::Always;
+        policy.styleOverwriteRule = OverwriteRule::Always;
+        policy.depthPolicy = DepthPolicy::Ignore;
+        return policy;
+    }
+
+    WritePolicy WritePolicy::TransparentGlyphOverlay()
+    {
+        WritePolicy policy;
+        policy.glyphPolicy = GlyphPolicy::NonSpaceOnly;
+        policy.stylePolicy = StylePolicy::Apply;
+        policy.sourceMask = SourceMask::GlyphCellsOnly;
+        policy.glyphOverwriteRule = OverwriteRule::Always;
+        policy.styleOverwriteRule = OverwriteRule::Always;
+        policy.depthPolicy = DepthPolicy::Ignore;
+        return policy;
+    }
+
+    WritePolicy WritePolicy::StyleOnly()
+    {
+        WritePolicy policy;
+        policy.glyphPolicy = GlyphPolicy::None;
+        policy.stylePolicy = StylePolicy::Apply;
+        policy.sourceMask = SourceMask::AllCells;
+        policy.glyphOverwriteRule = OverwriteRule::Never;
+        policy.styleOverwriteRule = OverwriteRule::Always;
+        policy.depthPolicy = DepthPolicy::Ignore;
+        return policy;
+    }
+
+    WritePolicy WritePolicy::NoWrite()
+    {
+        WritePolicy policy;
+        policy.glyphPolicy = GlyphPolicy::None;
+        policy.stylePolicy = StylePolicy::None;
+        policy.sourceMask = SourceMask::AllCells;
+        policy.glyphOverwriteRule = OverwriteRule::Never;
+        policy.styleOverwriteRule = OverwriteRule::Never;
+        policy.depthPolicy = DepthPolicy::Ignore;
+        return policy;
+    }
+
+    bool WritePolicy::writesGlyphs() const
+    {
+        return glyphPolicy != GlyphPolicy::None &&
+            glyphOverwriteRule != OverwriteRule::Never;
+    }
+
+    bool WritePolicy::writesStyles() const
+    {
+        return stylePolicy == StylePolicy::Apply &&
+            styleOverwriteRule != OverwriteRule::Never;
+    }
+
+    bool WritePolicy::canWriteAnything() const
+    {
+        return writesGlyphs() || writesStyles();
+    }
+
+    bool WritePolicy::operator==(const WritePolicy& other) const
+    {
+        return glyphPolicy == other.glyphPolicy &&
+            stylePolicy == other.stylePolicy &&
+            sourceMask == other.sourceMask &&
+            glyphOverwriteRule == other.glyphOverwriteRule &&
+            styleOverwriteRule == other.styleOverwriteRule &&
+            depthPolicy == other.depthPolicy;
+    }
+
+    bool WritePolicy::operator!=(const WritePolicy& other) const
+    {
+        return !(*this == other);
+    }
+}

--- a/TUI/Rendering/Composition/WritePolicy.h
+++ b/TUI/Rendering/Composition/WritePolicy.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "Rendering/Composition/DepthPolicy.h"
+#include "Rendering/Composition/GlyphPolicy.h"
+#include "Rendering/Composition/OverwriteRule.h"
+#include "Rendering/Composition/SourceMask.h"
+#include "Rendering/Composition/StylePolicy.h"
+
+namespace Composition
+{
+    /*
+        WritePolicy is the core engine-facing composition policy object.
+
+        It fully describes how a write pass should behave without relying on:
+        - hidden mutable writer state
+        - ambiguous legacy mode flags
+        - backend-specific rendering assumptions
+
+        The intent is that future semantic wrappers translate into one of these
+        explicit policies before any actual composition work is performed.
+    */
+    struct WritePolicy
+    {
+        GlyphPolicy glyphPolicy = GlyphPolicy::All;
+        StylePolicy stylePolicy = StylePolicy::Apply;
+        SourceMask sourceMask = SourceMask::AllCells;
+
+        OverwriteRule glyphOverwriteRule = OverwriteRule::Always;
+        OverwriteRule styleOverwriteRule = OverwriteRule::Always;
+
+        DepthPolicy depthPolicy = DepthPolicy::Ignore;
+
+        static WritePolicy ReplaceAll();
+        static WritePolicy TransparentGlyphOverlay();
+        static WritePolicy StyleOnly();
+        static WritePolicy NoWrite();
+
+        bool writesGlyphs() const;
+        bool writesStyles() const;
+        bool canWriteAnything() const;
+
+        bool operator==(const WritePolicy& other) const;
+        bool operator!=(const WritePolicy& other) const;
+    };
+}

--- a/TUI/TUI.vcxproj
+++ b/TUI/TUI.vcxproj
@@ -155,6 +155,12 @@
     <ClInclude Include="Rendering\Capabilities\CapabilityReport.h" />
     <ClInclude Include="Rendering\Capabilities\ColorSupport.h" />
     <ClInclude Include="Rendering\Capabilities\RendererCapabilities.h" />
+    <ClInclude Include="Rendering\Composition\DepthPolicy.h" />
+    <ClInclude Include="Rendering\Composition\GlyphPolicy.h" />
+    <ClInclude Include="Rendering\Composition\OverwriteRule.h" />
+    <ClInclude Include="Rendering\Composition\SourceMask.h" />
+    <ClInclude Include="Rendering\Composition\StylePolicy.h" />
+    <ClInclude Include="Rendering\Composition\WritePolicy.h" />
     <ClInclude Include="Rendering\ConsoleRenderer.h" />
     <ClInclude Include="Rendering\Diagnostics\AuthorRenderHints.h" />
     <ClInclude Include="Rendering\Diagnostics\RenderDiagnostics.h" />
@@ -266,6 +272,7 @@
     <ClCompile Include="Rendering\Backends\TerminalHostInfo.cpp" />
     <ClCompile Include="Rendering\Capabilities\CapabilityReport.cpp" />
     <ClCompile Include="Rendering\Capabilities\RendererCapabilities.cpp" />
+    <ClCompile Include="Rendering\Composition\WritePolicy.cpp" />
     <ClCompile Include="Rendering\ConsoleRenderer.cpp" />
     <ClCompile Include="Rendering\Diagnostics\AuthorRenderHints.cpp" />
     <ClCompile Include="Rendering\Diagnostics\RenderDiagnostics.cpp" />

--- a/TUI/TUI.vcxproj.filters
+++ b/TUI/TUI.vcxproj.filters
@@ -294,6 +294,27 @@
     <ClInclude Include="Rendering\Objects\pFontLoader.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="Rendering\Objects\TextObjectBlitter.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Rendering\Composition\GlyphPolicy.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Rendering\Composition\StylePolicy.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Rendering\Composition\SourceMask.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Rendering\Composition\OverwriteRule.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Rendering\Composition\DepthPolicy.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Rendering\Composition\WritePolicy.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Rendering\ScreenBuffer.cpp">
@@ -561,6 +582,12 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="Rendering\Objects\pFontLoader.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Rendering\Objects\TextObjectBlitter.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Rendering\Composition\WritePolicy.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
Modifies:
- TUI.vcxproj
- TUI.vcxproj.filters

New files so project can build cleanly

Adds:
- Rendering/Composition/ - DepthPolicy.h - GlyphPolicy.h - OverwriteRule.h - SourceMask.h - StylePolicy.h - WritePolicy.h/.cpp

- Cell participation is defined by SourceMask
- Glyph writing intent is defined by GlyphPolicy
- Style writing intent is defined by StylePolicy
- Replacement conditions are defined by explicit OverwriteRule enums
- Depth interaction is defined by DepthPolicy
- One complete write operation is described by a single Composition::WritePolicy

This gives a clean serparation between:
- future author-facing semantic wrappers
- engine-facing explicit policy object

The important foundation choice is that WritePolicy contains all write semantics directly, with no hidden booleans, no mode-switch state, and no renderer coupling.

Closes: #161 