### PR TITLE
WritePresets: Author-facing WritePolicy presets

### DIFF
--- a/TUI/Rendering/Composition/ObjectWriter.cpp
+++ b/TUI/Rendering/Composition/ObjectWriter.cpp
@@ -2,6 +2,8 @@
 
 #include <array>
 
+#include "Rendering/Composition/WritePresets.h"
+
 namespace
 {
     struct LogicalCellRef
@@ -210,6 +212,15 @@ namespace
 
         return sourceCell.style;
     }
+
+    void writeWithPreset(
+        Composition::ObjectWriter& writer,
+        const TextObject& source,
+        const std::optional<Style>& sourceStyleOverride,
+        const Composition::WritePolicy& policy)
+    {
+        writer.writeObject(source, policy, sourceStyleOverride);
+    }
 }
 
 namespace Composition
@@ -345,5 +356,120 @@ namespace Composition
                 m_target.setCellStyle(destinationX, destinationY, *resolvedSourceStyle);
             }
         }
+    }
+
+    void ObjectWriter::writeSolidObject(
+        const TextObject& source,
+        DepthPolicy depthPolicy)
+    {
+        writeSolidObject(source, std::nullopt, depthPolicy);
+    }
+
+    void ObjectWriter::writeSolidObject(
+        const TextObject& source,
+        const Style& sourceStyleOverride,
+        DepthPolicy depthPolicy)
+    {
+        writeSolidObject(source, std::optional<Style>(sourceStyleOverride), depthPolicy);
+    }
+
+    void ObjectWriter::writeSolidObject(
+        const TextObject& source,
+        const std::optional<Style>& sourceStyleOverride,
+        DepthPolicy depthPolicy)
+    {
+        writeWithPreset(*this, source, sourceStyleOverride, WritePresets::solidObject(depthPolicy));
+    }
+
+    void ObjectWriter::writeVisibleObject(
+        const TextObject& source,
+        DepthPolicy depthPolicy)
+    {
+        writeVisibleObject(source, std::nullopt, depthPolicy);
+    }
+
+    void ObjectWriter::writeVisibleObject(
+        const TextObject& source,
+        const Style& sourceStyleOverride,
+        DepthPolicy depthPolicy)
+    {
+        writeVisibleObject(source, std::optional<Style>(sourceStyleOverride), depthPolicy);
+    }
+
+    void ObjectWriter::writeVisibleObject(
+        const TextObject& source,
+        const std::optional<Style>& sourceStyleOverride,
+        DepthPolicy depthPolicy)
+    {
+        writeWithPreset(*this, source, sourceStyleOverride, WritePresets::visibleObject(depthPolicy));
+    }
+
+    void ObjectWriter::writeGlyphsOnly(
+        const TextObject& source,
+        DepthPolicy depthPolicy)
+    {
+        writeGlyphsOnly(source, std::nullopt, depthPolicy);
+    }
+
+    void ObjectWriter::writeGlyphsOnly(
+        const TextObject& source,
+        const Style& sourceStyleOverride,
+        DepthPolicy depthPolicy)
+    {
+        writeGlyphsOnly(source, std::optional<Style>(sourceStyleOverride), depthPolicy);
+    }
+
+    void ObjectWriter::writeGlyphsOnly(
+        const TextObject& source,
+        const std::optional<Style>& sourceStyleOverride,
+        DepthPolicy depthPolicy)
+    {
+        writeWithPreset(*this, source, sourceStyleOverride, WritePresets::glyphsOnly(depthPolicy));
+    }
+
+    void ObjectWriter::writeStyleMask(
+        const TextObject& source,
+        DepthPolicy depthPolicy)
+    {
+        writeStyleMask(source, std::nullopt, depthPolicy);
+    }
+
+    void ObjectWriter::writeStyleMask(
+        const TextObject& source,
+        const Style& sourceStyleOverride,
+        DepthPolicy depthPolicy)
+    {
+        writeStyleMask(source, std::optional<Style>(sourceStyleOverride), depthPolicy);
+    }
+
+    void ObjectWriter::writeStyleMask(
+        const TextObject& source,
+        const std::optional<Style>& sourceStyleOverride,
+        DepthPolicy depthPolicy)
+    {
+        writeWithPreset(*this, source, sourceStyleOverride, WritePresets::styleMask(depthPolicy));
+    }
+
+    void ObjectWriter::writeStyleBlock(
+        const TextObject& source,
+        DepthPolicy depthPolicy)
+    {
+        writeStyleBlock(source, std::nullopt, depthPolicy);
+    }
+
+    void ObjectWriter::writeStyleBlock(
+        const TextObject& source,
+        const Style& sourceStyleOverride,
+        DepthPolicy depthPolicy)
+    {
+        writeStyleBlock(source, std::optional<Style>(sourceStyleOverride), depthPolicy);
+    }
+
+    void ObjectWriter::writeStyleBlock(
+        const TextObject& source,
+        const std::optional<Style>& sourceStyleOverride,
+        DepthPolicy depthPolicy)
+    {
+        writeWithPreset(*this, source, sourceStyleOverride, WritePresets::styleBlock(depthPolicy));
     }
 }

--- a/TUI/Rendering/Composition/ObjectWriter.h
+++ b/TUI/Rendering/Composition/ObjectWriter.h
@@ -3,6 +3,7 @@
 #include <optional>
 
 #include "Rendering/Composition/WritePolicy.h"
+#include "Rendering/Composition/WritePresets.h"
 #include "Rendering/Objects/TextObject.h"
 #include "Rendering/ScreenBuffer.h"
 #include "Rendering/Styles/Style.h"
@@ -24,6 +25,66 @@ namespace Composition
             const TextObject& source,
             const WritePolicy& policy,
             const std::optional<Style>& sourceStyleOverride);
+
+        void writeSolidObject(
+            const TextObject& source,
+            DepthPolicy depthPolicy = DepthPolicy::Ignore);
+        void writeSolidObject(
+            const TextObject& source,
+            const Style& sourceStyleOverride,
+            DepthPolicy depthPolicy = DepthPolicy::Ignore);
+        void writeSolidObject(
+            const TextObject& source,
+            const std::optional<Style>& sourceStyleOverride,
+            DepthPolicy depthPolicy = DepthPolicy::Ignore);
+
+        void writeVisibleObject(
+            const TextObject& source,
+            DepthPolicy depthPolicy = DepthPolicy::Ignore);
+        void writeVisibleObject(
+            const TextObject& source,
+            const Style& sourceStyleOverride,
+            DepthPolicy depthPolicy = DepthPolicy::Ignore);
+        void writeVisibleObject(
+            const TextObject& source,
+            const std::optional<Style>& sourceStyleOverride,
+            DepthPolicy depthPolicy = DepthPolicy::Ignore);
+
+        void writeGlyphsOnly(
+            const TextObject& source,
+            DepthPolicy depthPolicy = DepthPolicy::Ignore);
+        void writeGlyphsOnly(
+            const TextObject& source,
+            const Style& sourceStyleOverride,
+            DepthPolicy depthPolicy = DepthPolicy::Ignore);
+        void writeGlyphsOnly(
+            const TextObject& source,
+            const std::optional<Style>& sourceStyleOverride,
+            DepthPolicy depthPolicy = DepthPolicy::Ignore);
+
+        void writeStyleMask(
+            const TextObject& source,
+            DepthPolicy depthPolicy = DepthPolicy::Ignore);
+        void writeStyleMask(
+            const TextObject& source,
+            const Style& sourceStyleOverride,
+            DepthPolicy depthPolicy = DepthPolicy::Ignore);
+        void writeStyleMask(
+            const TextObject& source,
+            const std::optional<Style>& sourceStyleOverride,
+            DepthPolicy depthPolicy = DepthPolicy::Ignore);
+
+        void writeStyleBlock(
+            const TextObject& source,
+            DepthPolicy depthPolicy = DepthPolicy::Ignore);
+        void writeStyleBlock(
+            const TextObject& source,
+            const Style& sourceStyleOverride,
+            DepthPolicy depthPolicy = DepthPolicy::Ignore);
+        void writeStyleBlock(
+            const TextObject& source,
+            const std::optional<Style>& sourceStyleOverride,
+            DepthPolicy depthPolicy = DepthPolicy::Ignore);
 
     private:
         void writeObjectInternal(

--- a/TUI/Rendering/Composition/WritePresets.cpp
+++ b/TUI/Rendering/Composition/WritePresets.cpp
@@ -1,0 +1,64 @@
+#include "Rendering/Composition/WritePresets.h"
+
+namespace Composition::WritePresets
+{
+    WritePolicy solidObject(DepthPolicy depthPolicy)
+    {
+        WritePolicy policy;
+        policy.glyphPolicy = GlyphPolicy::All;
+        policy.stylePolicy = StylePolicy::Apply;
+        policy.sourceMask = SourceMask::AllCells;
+        policy.glyphOverwriteRule = OverwriteRule::Always;
+        policy.styleOverwriteRule = OverwriteRule::Always;
+        policy.depthPolicy = depthPolicy;
+        return policy;
+    }
+
+    WritePolicy visibleObject(DepthPolicy depthPolicy)
+    {
+        WritePolicy policy;
+        policy.glyphPolicy = GlyphPolicy::All;
+        policy.stylePolicy = StylePolicy::Apply;
+        policy.sourceMask = SourceMask::GlyphCellsOnly;
+        policy.glyphOverwriteRule = OverwriteRule::Always;
+        policy.styleOverwriteRule = OverwriteRule::Always;
+        policy.depthPolicy = depthPolicy;
+        return policy;
+    }
+
+    WritePolicy glyphsOnly(DepthPolicy depthPolicy)
+    {
+        WritePolicy policy;
+        policy.glyphPolicy = GlyphPolicy::All;
+        policy.stylePolicy = StylePolicy::None;
+        policy.sourceMask = SourceMask::GlyphCellsOnly;
+        policy.glyphOverwriteRule = OverwriteRule::Always;
+        policy.styleOverwriteRule = OverwriteRule::Never;
+        policy.depthPolicy = depthPolicy;
+        return policy;
+    }
+
+    WritePolicy styleMask(DepthPolicy depthPolicy)
+    {
+        WritePolicy policy;
+        policy.glyphPolicy = GlyphPolicy::None;
+        policy.stylePolicy = StylePolicy::Apply;
+        policy.sourceMask = SourceMask::GlyphCellsOnly;
+        policy.glyphOverwriteRule = OverwriteRule::Never;
+        policy.styleOverwriteRule = OverwriteRule::Always;
+        policy.depthPolicy = depthPolicy;
+        return policy;
+    }
+
+    WritePolicy styleBlock(DepthPolicy depthPolicy)
+    {
+        WritePolicy policy;
+        policy.glyphPolicy = GlyphPolicy::None;
+        policy.stylePolicy = StylePolicy::Apply;
+        policy.sourceMask = SourceMask::AllCells;
+        policy.glyphOverwriteRule = OverwriteRule::Never;
+        policy.styleOverwriteRule = OverwriteRule::Always;
+        policy.depthPolicy = depthPolicy;
+        return policy;
+    }
+}

--- a/TUI/Rendering/Composition/WritePresets.h
+++ b/TUI/Rendering/Composition/WritePresets.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "Rendering/Composition/DepthPolicy.h"
+#include "Rendering/Composition/WritePolicy.h"
+
+namespace Composition::WritePresets
+{
+    WritePolicy solidObject(DepthPolicy depthPolicy = DepthPolicy::Ignore);
+    WritePolicy visibleObject(DepthPolicy depthPolicy = DepthPolicy::Ignore);
+    WritePolicy glyphsOnly(DepthPolicy depthPolicy = DepthPolicy::Ignore);
+    WritePolicy styleMask(DepthPolicy depthPolicy = DepthPolicy::Ignore);
+    WritePolicy styleBlock(DepthPolicy depthPolicy = DepthPolicy::Ignore);
+}

--- a/TUI/Rendering/Objects/TextObject.cpp
+++ b/TUI/Rendering/Objects/TextObject.cpp
@@ -146,16 +146,8 @@ void TextObject::draw(ScreenBuffer& target, int x, int y, const Style& overrideS
 
 void TextObject::draw(ScreenBuffer& target, int x, int y, const std::optional<Style>& overrideStyle) const
 {
-    Composition::WritePolicy policy;
-    policy.glyphPolicy = Composition::GlyphPolicy::All;
-    policy.stylePolicy = Composition::StylePolicy::Apply;
-    policy.sourceMask = Composition::SourceMask::GlyphCellsOnly;
-    policy.glyphOverwriteRule = Composition::OverwriteRule::Always;
-    policy.styleOverwriteRule = Composition::OverwriteRule::Always;
-    policy.depthPolicy = Composition::DepthPolicy::Ignore;
-
     Composition::ObjectWriter writer(target, x, y);
-    writer.writeObject(*this, policy, overrideStyle);
+    writer.writeVisibleObject(*this, overrideStyle);
 }
 
 TextObject TextObject::buildFromLines(

--- a/TUI/Rendering/Objects/TextObjectBlitter.cpp
+++ b/TUI/Rendering/Objects/TextObjectBlitter.cpp
@@ -107,17 +107,14 @@ namespace TextObjectBlitter
         int offsetY,
         const BlitOptions& options)
     {
-        Composition::WritePolicy policy;
-        policy.glyphPolicy = Composition::GlyphPolicy::All;
-        policy.stylePolicy = Composition::StylePolicy::Apply;
-        policy.sourceMask = options.skipEmptyCells
-            ? Composition::SourceMask::GlyphCellsOnly
-            : Composition::SourceMask::AllCells;
-        policy.glyphOverwriteRule = Composition::OverwriteRule::Always;
-        policy.styleOverwriteRule = Composition::OverwriteRule::Always;
-        policy.depthPolicy = Composition::DepthPolicy::Ignore;
-
         Composition::ObjectWriter writer(target, offsetX, offsetY);
-        writer.writeObject(source, policy, options.overrideStyle);
+
+        if (options.skipEmptyCells)
+        {
+            writer.writeVisibleObject(source, options.overrideStyle);
+            return;
+        }
+
+        writer.writeSolidObject(source, options.overrideStyle);
     }
 }

--- a/TUI/TUI.vcxproj
+++ b/TUI/TUI.vcxproj
@@ -162,6 +162,7 @@
     <ClInclude Include="Rendering\Composition\SourceMask.h" />
     <ClInclude Include="Rendering\Composition\StylePolicy.h" />
     <ClInclude Include="Rendering\Composition\WritePolicy.h" />
+    <ClInclude Include="Rendering\Composition\WritePresets.h" />
     <ClInclude Include="Rendering\ConsoleRenderer.h" />
     <ClInclude Include="Rendering\Diagnostics\AuthorRenderHints.h" />
     <ClInclude Include="Rendering\Diagnostics\RenderDiagnostics.h" />
@@ -275,6 +276,7 @@
     <ClCompile Include="Rendering\Capabilities\RendererCapabilities.cpp" />
     <ClCompile Include="Rendering\Composition\ObjectWriter.cpp" />
     <ClCompile Include="Rendering\Composition\WritePolicy.cpp" />
+    <ClCompile Include="Rendering\Composition\WritePresets.cpp" />
     <ClCompile Include="Rendering\ConsoleRenderer.cpp" />
     <ClCompile Include="Rendering\Diagnostics\AuthorRenderHints.cpp" />
     <ClCompile Include="Rendering\Diagnostics\RenderDiagnostics.cpp" />

--- a/TUI/TUI.vcxproj.filters
+++ b/TUI/TUI.vcxproj.filters
@@ -315,6 +315,12 @@
     <ClInclude Include="Rendering\Composition\WritePolicy.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="Rendering\Composition\ObjectWriter.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Rendering\Composition\WritePresets.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Rendering\ScreenBuffer.cpp">
@@ -588,6 +594,12 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="Rendering\Composition\WritePolicy.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Rendering\Composition\ObjectWriter.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Rendering\Composition\WritePresets.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
Modifies:
- TUI.vcxproj
- TUI.vcxproj.filters
- Rendering/Objects/TextObject.cpp
- Rendering/Objects/TextObjectBlitter.cpp
- Rendering/Composition/ObjectWriter.h/.cpp

Adds:
- Rendering/Composition/WritePresets.h/.cpp

- add semantic ObjectWriter convenience wrappers that map directly to the single writeObject(..., WritePolicy) engine path
- keep depth-aware variants as thin wrapper-only overloads with no duplicate compositing logic
- preserve direct custom WritePolicy usage for advanced callers
- route TextObject::draw(...) through writeVisibleObject(...) so default object drawing uses the new semantic API
- update TextObjectBlitter screen-buffer blits to use semantic solid/visible wrapper calls instead of manual special-case behavior
- keep ANSI-style author ergonomics while enforcing one explicit compositing engine underneath
- reduce ambiguous/manual write call patterns and make common object-write intent clearer at call sites

Closes: #163 