### PR TITLE
WritePolicy: Final integration pass

### DIFF
--- a/TUI/Rendering/Composition/ObjectWriter.cpp
+++ b/TUI/Rendering/Composition/ObjectWriter.cpp
@@ -2,6 +2,7 @@
 
 #include <array>
 
+#include "Rendering/Composition/WritePolicyUtils.h"
 #include "Rendering/Composition/WritePresets.h"
 
 namespace
@@ -12,43 +13,6 @@ namespace
         int y = 0;
         const ScreenCell* cell = nullptr;
     };
-
-    bool isSourceLeadingCell(const TextObjectCell& cell)
-    {
-        return cell.kind == CellKind::Glyph || cell.kind == CellKind::Empty;
-    }
-
-    bool sourceMaskAllows(const TextObjectCell& cell, Composition::SourceMask mask)
-    {
-        switch (mask)
-        {
-        case Composition::SourceMask::GlyphCellsOnly:
-            return cell.kind == CellKind::Glyph;
-
-        case Composition::SourceMask::SpaceCellsOnly:
-            return cell.kind == CellKind::Empty;
-
-        case Composition::SourceMask::AllCells:
-        default:
-            return cell.kind == CellKind::Glyph || cell.kind == CellKind::Empty;
-        }
-    }
-
-    bool glyphPolicyAllows(const TextObjectCell& cell, Composition::GlyphPolicy policy)
-    {
-        switch (policy)
-        {
-        case Composition::GlyphPolicy::None:
-            return false;
-
-        case Composition::GlyphPolicy::NonSpaceOnly:
-            return cell.kind == CellKind::Glyph && cell.glyph != U' ';
-
-        case Composition::GlyphPolicy::All:
-        default:
-            return cell.kind == CellKind::Glyph || cell.kind == CellKind::Empty;
-        }
-    }
 
     const ScreenCell& resolveLogicalDestinationCell(const ScreenBuffer& target, int x, int y)
     {
@@ -281,12 +245,12 @@ namespace Composition
             for (int sourceX = 0; sourceX < source.getWidth(); ++sourceX)
             {
                 const TextObjectCell* sourceCell = source.tryGetCell(sourceX, sourceY);
-                if (sourceCell == nullptr || !isSourceLeadingCell(*sourceCell))
+                if (sourceCell == nullptr || !WritePolicyUtils::isSourceLeadingCell(*sourceCell))
                 {
                     continue;
                 }
 
-                if (!sourceMaskAllows(*sourceCell, policy.sourceMask))
+                if (!WritePolicyUtils::sourceMaskAllows(*sourceCell, policy.sourceMask))
                 {
                     continue;
                 }
@@ -313,7 +277,7 @@ namespace Composition
                 }
 
                 const bool canWriteGlyph =
-                    glyphPolicyAllows(*sourceCell, policy.glyphPolicy) &&
+                    WritePolicyUtils::glyphPolicyAllows(*sourceCell, policy.glyphPolicy) &&
                     overwriteRuleAllows(
                         m_target,
                         destinationX,

--- a/TUI/Rendering/Composition/WritePolicy.cpp
+++ b/TUI/Rendering/Composition/WritePolicy.cpp
@@ -1,41 +1,22 @@
 #include "Rendering/Composition/WritePolicy.h"
 
+#include "Rendering/Composition/WritePresets.h"
+
 namespace Composition
 {
     WritePolicy WritePolicy::ReplaceAll()
     {
-        WritePolicy policy;
-        policy.glyphPolicy = GlyphPolicy::All;
-        policy.stylePolicy = StylePolicy::Apply;
-        policy.sourceMask = SourceMask::AllCells;
-        policy.glyphOverwriteRule = OverwriteRule::Always;
-        policy.styleOverwriteRule = OverwriteRule::Always;
-        policy.depthPolicy = DepthPolicy::Ignore;
-        return policy;
+        return WritePresets::solidObject();
     }
 
     WritePolicy WritePolicy::TransparentGlyphOverlay()
     {
-        WritePolicy policy;
-        policy.glyphPolicy = GlyphPolicy::NonSpaceOnly;
-        policy.stylePolicy = StylePolicy::Apply;
-        policy.sourceMask = SourceMask::GlyphCellsOnly;
-        policy.glyphOverwriteRule = OverwriteRule::Always;
-        policy.styleOverwriteRule = OverwriteRule::Always;
-        policy.depthPolicy = DepthPolicy::Ignore;
-        return policy;
+        return WritePresets::transparentGlyphOverlay();
     }
 
     WritePolicy WritePolicy::StyleOnly()
     {
-        WritePolicy policy;
-        policy.glyphPolicy = GlyphPolicy::None;
-        policy.stylePolicy = StylePolicy::Apply;
-        policy.sourceMask = SourceMask::AllCells;
-        policy.glyphOverwriteRule = OverwriteRule::Never;
-        policy.styleOverwriteRule = OverwriteRule::Always;
-        policy.depthPolicy = DepthPolicy::Ignore;
-        return policy;
+        return WritePresets::styleBlock();
     }
 
     WritePolicy WritePolicy::NoWrite()

--- a/TUI/Rendering/Composition/WritePolicyUtils.cpp
+++ b/TUI/Rendering/Composition/WritePolicyUtils.cpp
@@ -1,0 +1,88 @@
+#include "Rendering/Composition/WritePolicyUtils.h"
+
+namespace Composition::WritePolicyUtils
+{
+    bool isSourceLeadingCell(const TextObjectCell& cell)
+    {
+        return cell.kind == CellKind::Glyph || cell.kind == CellKind::Empty;
+    }
+
+    bool sourceMaskAllows(const TextObjectCell& cell, SourceMask mask)
+    {
+        switch (mask)
+        {
+        case SourceMask::GlyphCellsOnly:
+            return cell.kind == CellKind::Glyph;
+
+        case SourceMask::SpaceCellsOnly:
+            return cell.kind == CellKind::Empty;
+
+        case SourceMask::AllCells:
+        default:
+            return cell.kind == CellKind::Glyph || cell.kind == CellKind::Empty;
+        }
+    }
+
+    bool glyphPolicyAllows(const TextObjectCell& cell, GlyphPolicy policy)
+    {
+        switch (policy)
+        {
+        case GlyphPolicy::None:
+            return false;
+
+        case GlyphPolicy::NonSpaceOnly:
+            return cell.kind == CellKind::Glyph && cell.glyph != U' ';
+
+        case GlyphPolicy::All:
+        default:
+            return cell.kind == CellKind::Glyph || cell.kind == CellKind::Empty;
+        }
+    }
+
+    bool sourceCellCanWriteGlyph(const TextObjectCell& cell, const WritePolicy& policy)
+    {
+        return glyphPolicyAllows(cell, policy.glyphPolicy) &&
+            policy.glyphOverwriteRule != OverwriteRule::Never;
+    }
+
+    bool sourceCellParticipates(const TextObjectCell& cell, const WritePolicy& policy)
+    {
+        if (!isSourceLeadingCell(cell))
+        {
+            return false;
+        }
+
+        if (!sourceMaskAllows(cell, policy.sourceMask))
+        {
+            return false;
+        }
+
+        if (sourceCellCanWriteGlyph(cell, policy))
+        {
+            return true;
+        }
+
+        return policy.stylePolicy == StylePolicy::Apply;
+    }
+
+    bool isBuilderCompatible(const WritePolicy& policy)
+    {
+        if (policy.depthPolicy == DepthPolicy::BehindOnly)
+        {
+            return false;
+        }
+
+        if (policy.glyphOverwriteRule != OverwriteRule::Always)
+        {
+            return false;
+        }
+
+        if (policy.styleOverwriteRule != OverwriteRule::Always &&
+            policy.styleOverwriteRule != OverwriteRule::Never)
+        {
+            return false;
+        }
+
+        return policy.glyphPolicy != GlyphPolicy::None;
+    }
+}

--- a/TUI/Rendering/Composition/WritePolicyUtils.h
+++ b/TUI/Rendering/Composition/WritePolicyUtils.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "Rendering/Composition/WritePolicy.h"
+#include "Rendering/Objects/TextObject.h"
+
+namespace Composition::WritePolicyUtils
+{
+    bool isSourceLeadingCell(const TextObjectCell& cell);
+    bool sourceMaskAllows(const TextObjectCell& cell, SourceMask mask);
+    bool glyphPolicyAllows(const TextObjectCell& cell, GlyphPolicy policy);
+
+    bool sourceCellParticipates(const TextObjectCell& cell, const WritePolicy& policy);
+    bool sourceCellCanWriteGlyph(const TextObjectCell& cell, const WritePolicy& policy);
+
+    bool isBuilderCompatible(const WritePolicy& policy);
+}

--- a/TUI/Rendering/Composition/WritePresets.cpp
+++ b/TUI/Rendering/Composition/WritePresets.cpp
@@ -26,6 +26,18 @@ namespace Composition::WritePresets
         return policy;
     }
 
+    WritePolicy transparentGlyphOverlay(DepthPolicy depthPolicy)
+    {
+        WritePolicy policy;
+        policy.glyphPolicy = GlyphPolicy::NonSpaceOnly;
+        policy.stylePolicy = StylePolicy::Apply;
+        policy.sourceMask = SourceMask::GlyphCellsOnly;
+        policy.glyphOverwriteRule = OverwriteRule::Always;
+        policy.styleOverwriteRule = OverwriteRule::Always;
+        policy.depthPolicy = depthPolicy;
+        return policy;
+    }
+
     WritePolicy glyphsOnly(DepthPolicy depthPolicy)
     {
         WritePolicy policy;

--- a/TUI/Rendering/Composition/WritePresets.h
+++ b/TUI/Rendering/Composition/WritePresets.h
@@ -7,6 +7,7 @@ namespace Composition::WritePresets
 {
     WritePolicy solidObject(DepthPolicy depthPolicy = DepthPolicy::Ignore);
     WritePolicy visibleObject(DepthPolicy depthPolicy = DepthPolicy::Ignore);
+    WritePolicy transparentGlyphOverlay(DepthPolicy depthPolicy = DepthPolicy::Ignore);
     WritePolicy glyphsOnly(DepthPolicy depthPolicy = DepthPolicy::Ignore);
     WritePolicy styleMask(DepthPolicy depthPolicy = DepthPolicy::Ignore);
     WritePolicy styleBlock(DepthPolicy depthPolicy = DepthPolicy::Ignore);

--- a/TUI/Rendering/Objects/LayeredTextObject.cpp
+++ b/TUI/Rendering/Objects/LayeredTextObject.cpp
@@ -261,7 +261,7 @@ namespace Rendering
 
             TextObjectBlitter::BlitOptions blitOptions;
             blitOptions.overrideStyle = options.overrideStyle;
-            blitOptions.skipEmptyCells = true;
+            blitOptions.writePolicy = options.writePolicy;
             blitOptions.skipStructuralContinuationCells = false;
 
             TextObjectBlitter::blitToBuilder(
@@ -275,4 +275,3 @@ namespace Rendering
         return builder.build();
     }
 }
-

--- a/TUI/Rendering/Objects/LayeredTextObject.h
+++ b/TUI/Rendering/Objects/LayeredTextObject.h
@@ -5,6 +5,7 @@
 #include <string_view>
 #include <vector>
 
+#include "Rendering/Composition/WritePresets.h"
 #include "Rendering/Objects/TextObject.h"
 #include "Rendering/Styles/Style.h"
 
@@ -38,6 +39,7 @@ namespace Rendering
         {
             bool visibleOnly = true;
             std::optional<Style> overrideStyle;
+            Composition::WritePolicy writePolicy = Composition::WritePresets::visibleObject();
         };
 
     public:
@@ -95,4 +97,3 @@ namespace Rendering
         std::vector<TextObjectLayer> m_layers;
     };
 }
-

--- a/TUI/Rendering/Objects/TextObject.cpp
+++ b/TUI/Rendering/Objects/TextObject.cpp
@@ -3,6 +3,7 @@
 #include <stdexcept>
 
 #include "Rendering/Composition/ObjectWriter.h"
+#include "Rendering/Composition/WritePresets.h"
 #include "Rendering/Objects/PlainTextLoader.h"
 #include "Rendering/Objects/TextObjectBlitter.h"
 #include "Rendering/Objects/TextObjectExporter.h"
@@ -136,18 +137,43 @@ const TextObjectCell* TextObject::tryGetCell(int x, int y) const
 
 void TextObject::draw(ScreenBuffer& target, int x, int y) const
 {
-    draw(target, x, y, std::nullopt);
+    draw(target, x, y, Composition::WritePresets::visibleObject(), std::nullopt);
 }
 
 void TextObject::draw(ScreenBuffer& target, int x, int y, const Style& overrideStyle) const
 {
-    draw(target, x, y, std::optional<Style>(overrideStyle));
+    draw(target, x, y, Composition::WritePresets::visibleObject(), std::optional<Style>(overrideStyle));
 }
 
 void TextObject::draw(ScreenBuffer& target, int x, int y, const std::optional<Style>& overrideStyle) const
 {
+    draw(target, x, y, Composition::WritePresets::visibleObject(), overrideStyle);
+}
+
+void TextObject::draw(ScreenBuffer& target, int x, int y, const Composition::WritePolicy& writePolicy) const
+{
+    draw(target, x, y, writePolicy, std::nullopt);
+}
+
+void TextObject::draw(
+    ScreenBuffer& target,
+    int x,
+    int y,
+    const Composition::WritePolicy& writePolicy,
+    const Style& overrideStyle) const
+{
+    draw(target, x, y, writePolicy, std::optional<Style>(overrideStyle));
+}
+
+void TextObject::draw(
+    ScreenBuffer& target,
+    int x,
+    int y,
+    const Composition::WritePolicy& writePolicy,
+    const std::optional<Style>& overrideStyle) const
+{
     Composition::ObjectWriter writer(target, x, y);
-    writer.writeVisibleObject(*this, overrideStyle);
+    writer.writeObject(*this, writePolicy, overrideStyle);
 }
 
 TextObject TextObject::buildFromLines(

--- a/TUI/Rendering/Objects/TextObject.h
+++ b/TUI/Rendering/Objects/TextObject.h
@@ -5,6 +5,7 @@
 #include <string_view>
 #include <vector>
 
+#include "Rendering/Composition/WritePolicy.h"
 #include "Rendering/ScreenBuffer.h"
 #include "Rendering/Styles/Style.h"
 #include "Rendering/Text/TextTypes.h"
@@ -93,6 +94,19 @@ public:
     void draw(ScreenBuffer& target, int x, int y) const;
     void draw(ScreenBuffer& target, int x, int y, const Style& overrideStyle) const;
     void draw(ScreenBuffer& target, int x, int y, const std::optional<Style>& overrideStyle) const;
+    void draw(ScreenBuffer& target, int x, int y, const Composition::WritePolicy& writePolicy) const;
+    void draw(
+        ScreenBuffer& target,
+        int x,
+        int y,
+        const Composition::WritePolicy& writePolicy,
+        const Style& overrideStyle) const;
+    void draw(
+        ScreenBuffer& target,
+        int x,
+        int y,
+        const Composition::WritePolicy& writePolicy,
+        const std::optional<Style>& overrideStyle) const;
 
 private:
     static TextObject buildFromLines(
@@ -117,4 +131,3 @@ private:
     bool m_hasAnyCellStyles = false;
     std::vector<TextObjectCell> m_cells;
 };
-

--- a/TUI/Rendering/Objects/TextObjectBlitter.cpp
+++ b/TUI/Rendering/Objects/TextObjectBlitter.cpp
@@ -1,5 +1,9 @@
-#include "Rendering/Composition/ObjectWriter.h"
 #include "Rendering/Objects/TextObjectBlitter.h"
+
+#include <cassert>
+
+#include "Rendering/Composition/ObjectWriter.h"
+#include "Rendering/Composition/WritePolicyUtils.h"
 
 namespace
 {
@@ -7,11 +11,6 @@ namespace
         const TextObjectCell& cell,
         const TextObjectBlitter::BlitOptions& options)
     {
-        if (options.skipEmptyCells && cell.kind == CellKind::Empty)
-        {
-            return true;
-        }
-
         if (options.skipStructuralContinuationCells)
         {
             if (cell.kind == CellKind::WideTrailing)
@@ -55,12 +54,31 @@ namespace TextObjectBlitter
             return;
         }
 
+        assert(
+            Composition::WritePolicyUtils::isBuilderCompatible(options.writePolicy) &&
+            "TextObjectBlitter::blitToBuilder only supports glyph-writing overwrite policies.");
+
+        if (!Composition::WritePolicyUtils::isBuilderCompatible(options.writePolicy))
+        {
+            return;
+        }
+
         for (int y = 0; y < source.getHeight(); ++y)
         {
             for (int x = 0; x < source.getWidth(); ++x)
             {
                 const TextObjectCell* cell = source.tryGetCell(x, y);
                 if (cell == nullptr || shouldSkipCell(*cell, options))
+                {
+                    continue;
+                }
+
+                if (!Composition::WritePolicyUtils::sourceCellCanWriteGlyph(*cell, options.writePolicy))
+                {
+                    continue;
+                }
+
+                if (!Composition::WritePolicyUtils::sourceMaskAllows(*cell, options.writePolicy.sourceMask))
                 {
                     continue;
                 }
@@ -89,10 +107,16 @@ namespace TextObjectBlitter
 
                 case CellKind::WideTrailing:
                 case CellKind::CombiningContinuation:
-                    builder.setCell(destX, destY, cell->glyph, cell->kind, cell->width, styleToApply);
+                    if (!options.skipStructuralContinuationCells)
+                    {
+                        builder.setCell(destX, destY, cell->glyph, cell->kind, cell->width, styleToApply);
+                    }
                     break;
 
                 case CellKind::Empty:
+                    builder.setEmpty(destX, destY, styleToApply);
+                    break;
+
                 default:
                     break;
                 }
@@ -108,13 +132,6 @@ namespace TextObjectBlitter
         const BlitOptions& options)
     {
         Composition::ObjectWriter writer(target, offsetX, offsetY);
-
-        if (options.skipEmptyCells)
-        {
-            writer.writeVisibleObject(source, options.overrideStyle);
-            return;
-        }
-
-        writer.writeSolidObject(source, options.overrideStyle);
+        writer.writeObject(source, options.writePolicy, options.overrideStyle);
     }
 }

--- a/TUI/Rendering/Objects/TextObjectBlitter.h
+++ b/TUI/Rendering/Objects/TextObjectBlitter.h
@@ -2,6 +2,7 @@
 
 #include <optional>
 
+#include "Rendering/Composition/WritePresets.h"
 #include "Rendering/Objects/TextObject.h"
 #include "Rendering/Objects/TextObjectBuilder.h"
 #include "Rendering/ScreenBuffer.h"
@@ -12,7 +13,7 @@ namespace TextObjectBlitter
     struct BlitOptions
     {
         std::optional<Style> overrideStyle;
-        bool skipEmptyCells = true;
+        Composition::WritePolicy writePolicy = Composition::WritePresets::visibleObject();
         bool skipStructuralContinuationCells = true;
     };
 

--- a/TUI/TUI.vcxproj
+++ b/TUI/TUI.vcxproj
@@ -162,6 +162,7 @@
     <ClInclude Include="Rendering\Composition\SourceMask.h" />
     <ClInclude Include="Rendering\Composition\StylePolicy.h" />
     <ClInclude Include="Rendering\Composition\WritePolicy.h" />
+    <ClInclude Include="Rendering\Composition\WritePolicyUtils.h" />
     <ClInclude Include="Rendering\Composition\WritePresets.h" />
     <ClInclude Include="Rendering\ConsoleRenderer.h" />
     <ClInclude Include="Rendering\Diagnostics\AuthorRenderHints.h" />
@@ -276,6 +277,7 @@
     <ClCompile Include="Rendering\Capabilities\RendererCapabilities.cpp" />
     <ClCompile Include="Rendering\Composition\ObjectWriter.cpp" />
     <ClCompile Include="Rendering\Composition\WritePolicy.cpp" />
+    <ClCompile Include="Rendering\Composition\WritePolicyUtils.cpp" />
     <ClCompile Include="Rendering\Composition\WritePresets.cpp" />
     <ClCompile Include="Rendering\ConsoleRenderer.cpp" />
     <ClCompile Include="Rendering\Diagnostics\AuthorRenderHints.cpp" />


### PR DESCRIPTION
Modifies:
- TUI.vcxproj
- Rendering/ - Composition/ - ObjectWriter.cpp - WritePolcy.cpp - WritePresets.h/.cpp - Objects/ - LayeredTextObject.h/.cpp - TextObject.h/.cpp - TextObjectBlitter.h/.cpp

Adds:
- Rendering/Composition/WritePolicyUtils.h/.cpp

- Refactored all legacy write-mode paths to route through WritePolicy
- Removed boolean-based composition flags (e.g. skipEmptyCells) in favor of explicit policy
- Centralized composition execution in ObjectWriter::writeObject(...)
- Aligned TextObject, TextObjectBlitter, and LayeredTextObject flattening with policy-driven writes
- Added WritePolicyUtils for shared source-cell evaluation logic
- Consolidated preset behavior into WritePresets to eliminate duplication
- Introduced explicit policy-based draw(...) overloads on TextObject
- Added validation guard for builder-incompatible policies

Result:
- Single, unified compositing path across the codebase
- No hidden write semantics or duplicated logic
- Renderer-independent composition model
- Clean extension seams for future layering, masking, and depth systems

Closes: #160 
Closes: #164 