### PR TITLE
PageComposer: Introduce the PageComposer Foundation

### DIFF
--- a/TUI/Rendering/Composition/Alignment.h
+++ b/TUI/Rendering/Composition/Alignment.h
@@ -1,0 +1,24 @@
+#pragma once
+
+namespace Composition
+{
+    enum class HorizontalAlign
+    {
+        Left,
+        Center,
+        Right
+    };
+
+    enum class VerticalAlign
+    {
+        Top,
+        Center,
+        Bottom
+    };
+
+    struct Alignment
+    {
+        HorizontalAlign horizontal = HorizontalAlign::Left;
+        VerticalAlign vertical = VerticalAlign::Top;
+    };
+}

--- a/TUI/Rendering/Composition/PageComposer.cpp
+++ b/TUI/Rendering/Composition/PageComposer.cpp
@@ -1,0 +1,220 @@
+#include "Rendering/Composition/PageComposer.h"
+
+#include <stdexcept>
+
+namespace Composition
+{
+    PageComposer::PageComposer(ScreenBuffer& target)
+        : m_target(&target)
+    {
+    }
+
+    void PageComposer::setTarget(ScreenBuffer& target)
+    {
+        m_target = &target;
+    }
+
+    bool PageComposer::hasTarget() const
+    {
+        return m_target != nullptr;
+    }
+
+    ScreenBuffer* PageComposer::tryGetTarget()
+    {
+        return m_target;
+    }
+
+    const ScreenBuffer* PageComposer::tryGetTarget() const
+    {
+        return m_target;
+    }
+
+    ScreenBuffer& PageComposer::getTarget()
+    {
+        if (m_target == nullptr)
+        {
+            throw std::runtime_error("PageComposer has no target ScreenBuffer.");
+        }
+
+        return *m_target;
+    }
+
+    const ScreenBuffer& PageComposer::getTarget() const
+    {
+        if (m_target == nullptr)
+        {
+            throw std::runtime_error("PageComposer has no target ScreenBuffer.");
+        }
+
+        return *m_target;
+    }
+
+    void PageComposer::clear(const Style& style)
+    {
+        if (m_target == nullptr)
+        {
+            return;
+        }
+
+        m_target->clear(style);
+    }
+
+    void PageComposer::setScreenTemplateLoader(ScreenTemplateLoader loader)
+    {
+        m_screenTemplateLoader = std::move(loader);
+    }
+
+    bool PageComposer::hasScreenTemplateLoader() const
+    {
+        return static_cast<bool>(m_screenTemplateLoader);
+    }
+
+    bool PageComposer::createScreen(std::string_view filename)
+    {
+        if (m_target == nullptr || !m_screenTemplateLoader)
+        {
+            return false;
+        }
+
+        const ScreenTemplateLoadResult loadResult = m_screenTemplateLoader(filename);
+        if (!loadResult.success)
+        {
+            return false;
+        }
+
+        return loadScreen(loadResult.object);
+    }
+
+    bool PageComposer::loadScreen(const TextObject& object)
+    {
+        return loadScreen(object, WritePresets::solidObject(), std::nullopt);
+    }
+
+    bool PageComposer::loadScreen(
+        const TextObject& object,
+        const WritePolicy& writePolicy,
+        const std::optional<Style>& overrideStyle)
+    {
+        if (m_target == nullptr || !object.isLoaded())
+        {
+            return false;
+        }
+
+        object.draw(*m_target, 0, 0, writePolicy, overrideStyle);
+        return true;
+    }
+
+    bool PageComposer::createRegion(
+        int x,
+        int y,
+        int width,
+        int height,
+        std::string_view name)
+    {
+        return m_regions.createRegion(x, y, width, height, name);
+    }
+
+    bool PageComposer::hasRegion(std::string_view name) const
+    {
+        return m_regions.hasRegion(name);
+    }
+
+    const NamedRegion* PageComposer::getRegion(std::string_view name) const
+    {
+        return m_regions.getRegion(name);
+    }
+
+    NamedRegion* PageComposer::getRegion(std::string_view name)
+    {
+        return m_regions.getRegion(name);
+    }
+
+    void PageComposer::clearRegions()
+    {
+        m_regions.clearRegions();
+    }
+
+    Point PageComposer::placeObject(
+        const TextObject& object,
+        int x,
+        int y,
+        const WritePolicy& writePolicy,
+        const std::optional<Style>& overrideStyle)
+    {
+        return drawObjectAt(object, x, y, writePolicy, overrideStyle);
+    }
+
+    PlacementResult PageComposer::placeObject(
+        const TextObject& object,
+        const Rect& region,
+        const Alignment& alignment,
+        const WritePolicy& writePolicy,
+        const std::optional<Style>& overrideStyle,
+        bool clampToRegion)
+    {
+        PlacementRequest request;
+        request.region = region;
+        request.contentSize = measureObject(object);
+        request.alignment = alignment;
+        request.clampToRegion = clampToRegion;
+
+        PlacementResult result = resolvePlacement(request);
+        drawObjectAt(
+            object,
+            result.origin.x,
+            result.origin.y,
+            writePolicy,
+            overrideStyle);
+
+        return result;
+    }
+
+    PlacementResult PageComposer::placeObjectInRegion(
+        const TextObject& object,
+        std::string_view regionName,
+        const Alignment& alignment,
+        const WritePolicy& writePolicy,
+        const std::optional<Style>& overrideStyle,
+        bool clampToRegion)
+    {
+        const NamedRegion* region = m_regions.getRegion(regionName);
+        if (region == nullptr)
+        {
+            PlacementResult result;
+            result.region = makeRect(0, 0, 0, 0);
+            result.contentSize = measureObject(object);
+            result.alignment = alignment;
+            result.origin = Point{};
+            result.clamped = false;
+            return result;
+        }
+
+        return placeObject(
+            object,
+            region->bounds,
+            alignment,
+            writePolicy,
+            overrideStyle,
+            clampToRegion);
+    }
+
+    Point PageComposer::drawObjectAt(
+        const TextObject& object,
+        int x,
+        int y,
+        const WritePolicy& writePolicy,
+        const std::optional<Style>& overrideStyle)
+    {
+        Point origin;
+        origin.x = x;
+        origin.y = y;
+
+        if (m_target == nullptr || !object.isLoaded())
+        {
+            return origin;
+        }
+
+        object.draw(*m_target, x, y, writePolicy, overrideStyle);
+        return origin;
+    }
+}

--- a/TUI/Rendering/Composition/PageComposer.h
+++ b/TUI/Rendering/Composition/PageComposer.h
@@ -1,0 +1,98 @@
+#pragma once
+
+#include <functional>
+#include <optional>
+#include <string>
+#include <string_view>
+
+#include "Rendering/Composition/Placement.h"
+#include "Rendering/Composition/RegionRegistry.h"
+#include "Rendering/Composition/WritePolicy.h"
+#include "Rendering/Composition/WritePresets.h"
+#include "Rendering/Objects/TextObject.h"
+#include "Rendering/ScreenBuffer.h"
+#include "Rendering/Styles/Style.h"
+
+namespace Composition
+{
+    class PageComposer
+    {
+    public:
+        struct ScreenTemplateLoadResult
+        {
+            TextObject object;
+            bool success = false;
+            std::string errorMessage;
+        };
+
+        using ScreenTemplateLoader =
+            std::function<ScreenTemplateLoadResult(std::string_view filename)>;
+
+    public:
+        PageComposer() = default;
+        explicit PageComposer(ScreenBuffer& target);
+
+        void setTarget(ScreenBuffer& target);
+        bool hasTarget() const;
+
+        ScreenBuffer* tryGetTarget();
+        const ScreenBuffer* tryGetTarget() const;
+
+        ScreenBuffer& getTarget();
+        const ScreenBuffer& getTarget() const;
+
+        void clear(const Style& style = Style());
+
+        void setScreenTemplateLoader(ScreenTemplateLoader loader);
+        bool hasScreenTemplateLoader() const;
+
+        bool createScreen(std::string_view filename);
+        bool loadScreen(const TextObject& object);
+        bool loadScreen(
+            const TextObject& object,
+            const WritePolicy& writePolicy,
+            const std::optional<Style>& overrideStyle = std::nullopt);
+
+        bool createRegion(int x, int y, int width, int height, std::string_view name);
+        bool hasRegion(std::string_view name) const;
+        const NamedRegion* getRegion(std::string_view name) const;
+        NamedRegion* getRegion(std::string_view name);
+        void clearRegions();
+
+        Point placeObject(
+            const TextObject& object,
+            int x,
+            int y,
+            const WritePolicy& writePolicy = WritePresets::visibleObject(),
+            const std::optional<Style>& overrideStyle = std::nullopt);
+
+        PlacementResult placeObject(
+            const TextObject& object,
+            const Rect& region,
+            const Alignment& alignment,
+            const WritePolicy& writePolicy = WritePresets::visibleObject(),
+            const std::optional<Style>& overrideStyle = std::nullopt,
+            bool clampToRegion = false);
+
+        PlacementResult placeObjectInRegion(
+            const TextObject& object,
+            std::string_view regionName,
+            const Alignment& alignment,
+            const WritePolicy& writePolicy = WritePresets::visibleObject(),
+            const std::optional<Style>& overrideStyle = std::nullopt,
+            bool clampToRegion = false);
+
+    private:
+        Point drawObjectAt(
+            const TextObject& object,
+            int x,
+            int y,
+            const WritePolicy& writePolicy,
+            const std::optional<Style>& overrideStyle);
+
+    private:
+        ScreenBuffer* m_target = nullptr;
+        RegionRegistry m_regions;
+        ScreenTemplateLoader m_screenTemplateLoader;
+    };
+}

--- a/TUI/Rendering/Composition/Placement.cpp
+++ b/TUI/Rendering/Composition/Placement.cpp
@@ -1,0 +1,141 @@
+#include "Rendering/Composition/Placement.h"
+
+#include <algorithm>
+
+#include "Rendering/Objects/TextObject.h"
+
+namespace
+{
+    int resolveHorizontalOffset(
+        int availableWidth,
+        int contentWidth,
+        Composition::HorizontalAlign horizontalAlign)
+    {
+        switch (horizontalAlign)
+        {
+        case Composition::HorizontalAlign::Center:
+            return (availableWidth - contentWidth) / 2;
+
+        case Composition::HorizontalAlign::Right:
+            return availableWidth - contentWidth;
+
+        case Composition::HorizontalAlign::Left:
+        default:
+            return 0;
+        }
+    }
+
+    int resolveVerticalOffset(
+        int availableHeight,
+        int contentHeight,
+        Composition::VerticalAlign verticalAlign)
+    {
+        switch (verticalAlign)
+        {
+        case Composition::VerticalAlign::Center:
+            return (availableHeight - contentHeight) / 2;
+
+        case Composition::VerticalAlign::Bottom:
+            return availableHeight - contentHeight;
+
+        case Composition::VerticalAlign::Top:
+        default:
+            return 0;
+        }
+    }
+
+    int clampInt(int value, int minValue, int maxValue)
+    {
+        if (minValue > maxValue)
+        {
+            return minValue;
+        }
+
+        return std::max(minValue, std::min(value, maxValue));
+    }
+}
+
+namespace Composition
+{
+    PlacementResult resolvePlacement(const PlacementRequest& request)
+    {
+        PlacementResult result;
+        result.region = request.region;
+        result.contentSize = request.contentSize;
+        result.alignment = request.alignment;
+        result.clamped = false;
+
+        Point origin = resolveAlignedOrigin(
+            request.region,
+            request.contentSize,
+            request.alignment);
+
+        if (request.clampToRegion)
+        {
+            const int minX = request.region.position.x;
+            const int minY = request.region.position.y;
+            const int maxX =
+                request.region.position.x +
+                std::max(0, request.region.size.width - request.contentSize.width);
+            const int maxY =
+                request.region.position.y +
+                std::max(0, request.region.size.height - request.contentSize.height);
+
+            const int clampedX = clampInt(origin.x, minX, maxX);
+            const int clampedY = clampInt(origin.y, minY, maxY);
+
+            result.clamped = (clampedX != origin.x) || (clampedY != origin.y);
+            origin.x = clampedX;
+            origin.y = clampedY;
+        }
+
+        result.origin = origin;
+        return result;
+    }
+
+    Point resolveAlignedOrigin(
+        const Rect& region,
+        const Size& contentSize,
+        HorizontalAlign horizontalAlign,
+        VerticalAlign verticalAlign)
+    {
+        Point origin;
+        origin.x =
+            region.position.x +
+            resolveHorizontalOffset(region.size.width, contentSize.width, horizontalAlign);
+        origin.y =
+            region.position.y +
+            resolveVerticalOffset(region.size.height, contentSize.height, verticalAlign);
+        return origin;
+    }
+
+    Point resolveAlignedOrigin(
+        const Rect& region,
+        const Size& contentSize,
+        const Alignment& alignment)
+    {
+        return resolveAlignedOrigin(
+            region,
+            contentSize,
+            alignment.horizontal,
+            alignment.vertical);
+    }
+
+    Rect makeRect(int x, int y, int width, int height)
+    {
+        Rect rect;
+        rect.position.x = x;
+        rect.position.y = y;
+        rect.size.width = width;
+        rect.size.height = height;
+        return rect;
+    }
+
+    Size measureObject(const TextObject& object)
+    {
+        Size size;
+        size.width = object.getWidth();
+        size.height = object.getHeight();
+        return size;
+    }
+}

--- a/TUI/Rendering/Composition/Placement.h
+++ b/TUI/Rendering/Composition/Placement.h
@@ -1,0 +1,77 @@
+#pragma once
+
+#include <string>
+
+#include "Core/Point.h"
+#include "Core/Rect.h"
+#include "Core/Size.h"
+#include "Rendering/Composition/Alignment.h"
+
+class TextObject;
+
+namespace Composition
+{
+    struct NamedRegion
+    {
+        std::string name;
+        Rect bounds;
+
+        int x() const
+        {
+            return bounds.position.x;
+        }
+
+        int y() const
+        {
+            return bounds.position.y;
+        }
+
+        int width() const
+        {
+            return bounds.size.width;
+        }
+
+        int height() const
+        {
+            return bounds.size.height;
+        }
+
+        bool contains(int px, int py) const
+        {
+            return bounds.contains(px, py);
+        }
+    };
+
+    struct PlacementRequest
+    {
+        Rect region;
+        Size contentSize;
+        Alignment alignment;
+        bool clampToRegion = false;
+    };
+
+    struct PlacementResult
+    {
+        Point origin;
+        Rect region;
+        Size contentSize;
+        Alignment alignment;
+        bool clamped = false;
+    };
+
+    PlacementResult resolvePlacement(const PlacementRequest& request);
+
+    Point resolveAlignedOrigin(
+        const Rect& region,
+        const Size& contentSize,
+        HorizontalAlign horizontalAlign,
+        VerticalAlign verticalAlign);
+
+    Point resolveAlignedOrigin(
+        const Rect& region,
+        const Size& contentSize,
+        const Alignment& alignment);
+
+    Rect makeRect(int x, int y, int width, int height);
+    Size measureObject(const TextObject& object);
+}

--- a/TUI/Rendering/Composition/RegionRegistry.cpp
+++ b/TUI/Rendering/Composition/RegionRegistry.cpp
@@ -1,0 +1,98 @@
+#include "Rendering/Composition/RegionRegistry.h"
+
+namespace Composition
+{
+    bool RegionRegistry::createRegion(
+        int x,
+        int y,
+        int width,
+        int height,
+        std::string_view name)
+    {
+        NamedRegion region;
+        region.name = std::string(name);
+        region.bounds = makeRect(x, y, width, height);
+        return createRegion(region);
+    }
+
+    bool RegionRegistry::createRegion(const NamedRegion& region)
+    {
+        const std::string key = normalizeKey(region.name);
+        if (key.empty())
+        {
+            return false;
+        }
+
+        m_regions[key] = region;
+        return true;
+    }
+
+    bool RegionRegistry::hasRegion(std::string_view name) const
+    {
+        const std::string key = normalizeKey(name);
+        return !key.empty() && m_regions.find(key) != m_regions.end();
+    }
+
+    const NamedRegion* RegionRegistry::getRegion(std::string_view name) const
+    {
+        const std::string key = normalizeKey(name);
+        const auto it = m_regions.find(key);
+        if (it == m_regions.end())
+        {
+            return nullptr;
+        }
+
+        return &it->second;
+    }
+
+    NamedRegion* RegionRegistry::getRegion(std::string_view name)
+    {
+        const std::string key = normalizeKey(name);
+        const auto it = m_regions.find(key);
+        if (it == m_regions.end())
+        {
+            return nullptr;
+        }
+
+        return &it->second;
+    }
+
+    bool RegionRegistry::removeRegion(std::string_view name)
+    {
+        const std::string key = normalizeKey(name);
+        if (key.empty())
+        {
+            return false;
+        }
+
+        return m_regions.erase(key) > 0;
+    }
+
+    void RegionRegistry::clearRegions()
+    {
+        m_regions.clear();
+    }
+
+    std::size_t RegionRegistry::getRegionCount() const
+    {
+        return m_regions.size();
+    }
+
+    std::vector<NamedRegion> RegionRegistry::getAllRegions() const
+    {
+        std::vector<NamedRegion> regions;
+        regions.reserve(m_regions.size());
+
+        for (const auto& entry : m_regions)
+        {
+            regions.push_back(entry.second);
+        }
+
+        return regions;
+    }
+
+    std::string RegionRegistry::normalizeKey(std::string_view name)
+    {
+        return std::string(name);
+    }
+}

--- a/TUI/Rendering/Composition/RegionRegistry.h
+++ b/TUI/Rendering/Composition/RegionRegistry.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+#include "Rendering/Composition/Placement.h"
+
+namespace Composition
+{
+    class RegionRegistry
+    {
+    public:
+        bool createRegion(int x, int y, int width, int height, std::string_view name);
+        bool createRegion(const NamedRegion& region);
+
+        bool hasRegion(std::string_view name) const;
+
+        const NamedRegion* getRegion(std::string_view name) const;
+        NamedRegion* getRegion(std::string_view name);
+
+        bool removeRegion(std::string_view name);
+        void clearRegions();
+
+        std::size_t getRegionCount() const;
+        std::vector<NamedRegion> getAllRegions() const;
+
+    private:
+        static std::string normalizeKey(std::string_view name);
+
+    private:
+        std::unordered_map<std::string, NamedRegion> m_regions;
+    };
+}

--- a/TUI/Screens/PageBuffer.cpp
+++ b/TUI/Screens/PageBuffer.cpp
@@ -1,0 +1,1 @@
+#include "Screens/PageBuffer.h"

--- a/TUI/Screens/PageBuffer.h
+++ b/TUI/Screens/PageBuffer.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include "Rendering/Composition/PageComposer.h"
+
+namespace Page
+{
+    using PageBuffer = Composition::PageComposer;
+}

--- a/TUI/TUI.vcxproj
+++ b/TUI/TUI.vcxproj
@@ -155,10 +155,14 @@
     <ClInclude Include="Rendering\Capabilities\CapabilityReport.h" />
     <ClInclude Include="Rendering\Capabilities\ColorSupport.h" />
     <ClInclude Include="Rendering\Capabilities\RendererCapabilities.h" />
+    <ClInclude Include="Rendering\Composition\Alignment.h" />
     <ClInclude Include="Rendering\Composition\DepthPolicy.h" />
     <ClInclude Include="Rendering\Composition\GlyphPolicy.h" />
     <ClInclude Include="Rendering\Composition\ObjectWriter.h" />
     <ClInclude Include="Rendering\Composition\OverwriteRule.h" />
+    <ClInclude Include="Rendering\Composition\PageComposer.h" />
+    <ClInclude Include="Rendering\Composition\Placement.h" />
+    <ClInclude Include="Rendering\Composition\RegionRegistry.h" />
     <ClInclude Include="Rendering\Composition\SourceMask.h" />
     <ClInclude Include="Rendering\Composition\StylePolicy.h" />
     <ClInclude Include="Rendering\Composition\WritePolicy.h" />
@@ -242,6 +246,7 @@
     <ClInclude Include="Screens\DigitalRainScreen.h" />
     <ClInclude Include="Screens\Donut3DScreen.h" />
     <ClInclude Include="Screens\FireScreen.h" />
+    <ClInclude Include="Screens\PageBuffer.h" />
     <ClInclude Include="Screens\RendererDiagnosticsScreen.h" />
     <ClInclude Include="Screens\Screen.h" />
     <ClInclude Include="Screens\ShowcaseScreen.h" />
@@ -278,6 +283,9 @@
     <ClCompile Include="Rendering\Capabilities\CapabilityReport.cpp" />
     <ClCompile Include="Rendering\Capabilities\RendererCapabilities.cpp" />
     <ClCompile Include="Rendering\Composition\ObjectWriter.cpp" />
+    <ClCompile Include="Rendering\Composition\Placement.cpp" />
+    <ClCompile Include="Rendering\Composition\RegionRegistry.cpp" />
+    <ClCompile Include="Rendering\Composition\PageComposer.cpp" />
     <ClCompile Include="Rendering\Composition\WritePolicy.cpp" />
     <ClCompile Include="Rendering\Composition\WritePolicyBuilder.cpp" />
     <ClCompile Include="Rendering\Composition\WritePolicyUtils.cpp" />
@@ -349,6 +357,7 @@
     </ClCompile>
     <ClCompile Include="Screens\Donut3DScreen.cpp" />
     <ClCompile Include="Screens\FireScreen.cpp" />
+    <ClCompile Include="Screens\PageBuffer.cpp" />
     <ClCompile Include="Screens\RendererDiagnosticsScreen.cpp" />
     <ClCompile Include="Screens\ShowcaseScreen.cpp" />
     <ClCompile Include="Screens\TerminalCapabilitiesScreen.cpp" />

--- a/TUI/TUI.vcxproj.filters
+++ b/TUI/TUI.vcxproj.filters
@@ -321,6 +321,30 @@
     <ClInclude Include="Rendering\Composition\WritePresets.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="Rendering\Composition\WritePolicyBuilder.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Rendering\Composition\WritePolicyUtils.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Rendering\Objects\TextObjectComposer.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Rendering\Composition\Alignment.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Rendering\Composition\Placement.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Rendering\Composition\RegionRegistry.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Rendering\Composition\PageComposer.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Screens\PageBuffer.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Rendering\ScreenBuffer.cpp">
@@ -600,6 +624,27 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="Rendering\Composition\WritePresets.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Rendering\Composition\WritePolicyBuilder.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Rendering\Composition\WritePolicyUtils.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Rendering\Objects\TextObjectComposer.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Rendering\Composition\Placement.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Rendering\Composition\RegionRegistry.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Rendering\Composition\PageComposer.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Screens\PageBuffer.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
Modifies:
- TUI.vcxproj
- TUI.vcxproj.filters

Adds: Rendering/Composition/
     - Alignment.h
     - PageComposer.h/.cpp
     - Placement.h/.cpp
     - RegionRegistry.h./cpp
Screens/
     - PageBuffer.h/.cpp

- Added PageComposer as the high-level author-facing page composition layer above ScreenBuffer
  - Provides clear(style) for page clearing
  - Provides createScreen(...) and loadScreen(...) for template loading at (0,0) without auto-clear
  - Supports injected ScreenTemplateLoader to keep asset loading decoupled from composition

- Implemented RegionRegistry for named layout regions
  - createRegion(x, y, w, h, name)
  - hasRegion(name), getRegion(name), clearRegions()
  - Enables reusable layout zones for page-level composition

- Introduced alignment vocabulary
  - HorizontalAlign: Left, Center, Right
  - VerticalAlign: Top, Center, Bottom
  - Added Alignment struct for unified alignment specification

- Added Placement system for reusable layout math
  - PlacementRequest / PlacementResult types
  - resolvePlacement(...) and resolveAlignedOrigin(...) helpers
  - Centralized alignment and region-based positioning logic
  - Supports optional region clamping behavior

- Added object placement APIs to PageComposer
  - placeObject(x, y)
  - placeObject(region, alignment)
  - placeObjectInRegion(name, alignment)
  - All placement routes through shared placement helpers and existing TextObject draw pipeline

- Preserved backend-agnostic design
  - PageComposer writes into ScreenBuffer but does not extend or pollute it
  - No renderer-specific or asset IO logic embedded in this layer

- Added optional PageBuffer alias for future author-facing naming flexibility

Closes: #166 