### PR TITLE
PageComposer: Object placement API

### DIFF
--- a/TUI/Rendering/Composition/Alignment.h
+++ b/TUI/Rendering/Composition/Alignment.h
@@ -21,4 +21,52 @@ namespace Composition
         HorizontalAlign horizontal = HorizontalAlign::Left;
         VerticalAlign vertical = VerticalAlign::Top;
     };
+
+    namespace Align
+    {
+        inline constexpr Alignment topLeft()
+        {
+            return { HorizontalAlign::Left, VerticalAlign::Top };
+        }
+
+        inline constexpr Alignment topCenter()
+        {
+            return { HorizontalAlign::Center, VerticalAlign::Top };
+        }
+
+        inline constexpr Alignment topRight()
+        {
+            return { HorizontalAlign::Right, VerticalAlign::Top };
+        }
+
+        inline constexpr Alignment centerLeft()
+        {
+            return { HorizontalAlign::Left, VerticalAlign::Center };
+        }
+
+        inline constexpr Alignment center()
+        {
+            return { HorizontalAlign::Center, VerticalAlign::Center };
+        }
+
+        inline constexpr Alignment centerRight()
+        {
+            return { HorizontalAlign::Right, VerticalAlign::Center };
+        }
+
+        inline constexpr Alignment bottomLeft()
+        {
+            return { HorizontalAlign::Left, VerticalAlign::Bottom };
+        }
+
+        inline constexpr Alignment bottomCenter()
+        {
+            return { HorizontalAlign::Center, VerticalAlign::Bottom };
+        }
+
+        inline constexpr Alignment bottomRight()
+        {
+            return { HorizontalAlign::Right, VerticalAlign::Bottom };
+        }
+    }
 }

--- a/TUI/Rendering/Composition/PageComposer.cpp
+++ b/TUI/Rendering/Composition/PageComposer.cpp
@@ -190,7 +190,12 @@ namespace Composition
         m_regions.clearRegions();
     }
 
-    Point PageComposer::placeObject(
+    Rect PageComposer::getFullScreenRegion() const
+    {
+        return makeRect(0, 0, std::max(0, getWidth()), std::max(0, getHeight()));
+    }
+
+    Point PageComposer::writeObject(
         const TextObject& object,
         int x,
         int y,
@@ -200,7 +205,52 @@ namespace Composition
         return drawObjectAt(object, x, y, writePolicy, overrideStyle);
     }
 
-    PlacementResult PageComposer::placeObject(
+    Point PageComposer::writeSolidObject(
+        const TextObject& object,
+        int x,
+        int y,
+        const std::optional<Style>& overrideStyle)
+    {
+        return writeObject(object, x, y, WritePresets::solidObject(), overrideStyle);
+    }
+
+    Point PageComposer::writeVisibleObject(
+        const TextObject& object,
+        int x,
+        int y,
+        const std::optional<Style>& overrideStyle)
+    {
+        return writeObject(object, x, y, WritePresets::visibleObject(), overrideStyle);
+    }
+
+    Point PageComposer::writeGlyphsOnly(
+        const TextObject& object,
+        int x,
+        int y,
+        const std::optional<Style>& overrideStyle)
+    {
+        return writeObject(object, x, y, WritePresets::glyphsOnly(), overrideStyle);
+    }
+
+    Point PageComposer::writeStyleMask(
+        const TextObject& object,
+        int x,
+        int y,
+        const std::optional<Style>& overrideStyle)
+    {
+        return writeObject(object, x, y, WritePresets::styleMask(), overrideStyle);
+    }
+
+    Point PageComposer::writeStyleBlock(
+        const TextObject& object,
+        int x,
+        int y,
+        const std::optional<Style>& overrideStyle)
+    {
+        return writeObject(object, x, y, WritePresets::styleBlock(), overrideStyle);
+    }
+
+    PlacementResult PageComposer::writeObject(
         const TextObject& object,
         const Rect& region,
         const Alignment& alignment,
@@ -225,7 +275,87 @@ namespace Composition
         return result;
     }
 
-    PlacementResult PageComposer::placeObjectInRegion(
+    PlacementResult PageComposer::writeSolidObject(
+        const TextObject& object,
+        const Rect& region,
+        const Alignment& alignment,
+        const std::optional<Style>& overrideStyle,
+        bool clampToRegion)
+    {
+        return writeObject(
+            object,
+            region,
+            alignment,
+            WritePresets::solidObject(),
+            overrideStyle,
+            clampToRegion);
+    }
+
+    PlacementResult PageComposer::writeVisibleObject(
+        const TextObject& object,
+        const Rect& region,
+        const Alignment& alignment,
+        const std::optional<Style>& overrideStyle,
+        bool clampToRegion)
+    {
+        return writeObject(
+            object,
+            region,
+            alignment,
+            WritePresets::visibleObject(),
+            overrideStyle,
+            clampToRegion);
+    }
+
+    PlacementResult PageComposer::writeGlyphsOnly(
+        const TextObject& object,
+        const Rect& region,
+        const Alignment& alignment,
+        const std::optional<Style>& overrideStyle,
+        bool clampToRegion)
+    {
+        return writeObject(
+            object,
+            region,
+            alignment,
+            WritePresets::glyphsOnly(),
+            overrideStyle,
+            clampToRegion);
+    }
+
+    PlacementResult PageComposer::writeStyleMask(
+        const TextObject& object,
+        const Rect& region,
+        const Alignment& alignment,
+        const std::optional<Style>& overrideStyle,
+        bool clampToRegion)
+    {
+        return writeObject(
+            object,
+            region,
+            alignment,
+            WritePresets::styleMask(),
+            overrideStyle,
+            clampToRegion);
+    }
+
+    PlacementResult PageComposer::writeStyleBlock(
+        const TextObject& object,
+        const Rect& region,
+        const Alignment& alignment,
+        const std::optional<Style>& overrideStyle,
+        bool clampToRegion)
+    {
+        return writeObject(
+            object,
+            region,
+            alignment,
+            WritePresets::styleBlock(),
+            overrideStyle,
+            clampToRegion);
+    }
+
+    PlacementResult PageComposer::writeObjectInRegion(
         const TextObject& object,
         std::string_view regionName,
         const Alignment& alignment,
@@ -236,18 +366,222 @@ namespace Composition
         const NamedRegion* region = m_regions.getRegion(regionName);
         if (region == nullptr)
         {
-            PlacementResult result;
-            result.region = makeRect(0, 0, 0, 0);
-            result.contentSize = measureObject(object);
-            result.alignment = alignment;
-            result.origin = Point{};
-            result.clamped = false;
-            return result;
+            return makeUnresolvedPlacementResult(object, alignment);
         }
 
-        return placeObject(
+        return writeObject(
             object,
             region->bounds,
+            alignment,
+            writePolicy,
+            overrideStyle,
+            clampToRegion);
+    }
+
+    PlacementResult PageComposer::writeSolidObjectInRegion(
+        const TextObject& object,
+        std::string_view regionName,
+        const Alignment& alignment,
+        const std::optional<Style>& overrideStyle,
+        bool clampToRegion)
+    {
+        return writeObjectInRegion(
+            object,
+            regionName,
+            alignment,
+            WritePresets::solidObject(),
+            overrideStyle,
+            clampToRegion);
+    }
+
+    PlacementResult PageComposer::writeVisibleObjectInRegion(
+        const TextObject& object,
+        std::string_view regionName,
+        const Alignment& alignment,
+        const std::optional<Style>& overrideStyle,
+        bool clampToRegion)
+    {
+        return writeObjectInRegion(
+            object,
+            regionName,
+            alignment,
+            WritePresets::visibleObject(),
+            overrideStyle,
+            clampToRegion);
+    }
+
+    PlacementResult PageComposer::writeGlyphsOnlyInRegion(
+        const TextObject& object,
+        std::string_view regionName,
+        const Alignment& alignment,
+        const std::optional<Style>& overrideStyle,
+        bool clampToRegion)
+    {
+        return writeObjectInRegion(
+            object,
+            regionName,
+            alignment,
+            WritePresets::glyphsOnly(),
+            overrideStyle,
+            clampToRegion);
+    }
+
+    PlacementResult PageComposer::writeStyleMaskInRegion(
+        const TextObject& object,
+        std::string_view regionName,
+        const Alignment& alignment,
+        const std::optional<Style>& overrideStyle,
+        bool clampToRegion)
+    {
+        return writeObjectInRegion(
+            object,
+            regionName,
+            alignment,
+            WritePresets::styleMask(),
+            overrideStyle,
+            clampToRegion);
+    }
+
+    PlacementResult PageComposer::writeStyleBlockInRegion(
+        const TextObject& object,
+        std::string_view regionName,
+        const Alignment& alignment,
+        const std::optional<Style>& overrideStyle,
+        bool clampToRegion)
+    {
+        return writeObjectInRegion(
+            object,
+            regionName,
+            alignment,
+            WritePresets::styleBlock(),
+            overrideStyle,
+            clampToRegion);
+    }
+
+    PlacementResult PageComposer::writeObjectAligned(
+        const TextObject& object,
+        const Alignment& alignment,
+        const WritePolicy& writePolicy,
+        const std::optional<Style>& overrideStyle,
+        bool clampToRegion)
+    {
+        return writeObject(
+            object,
+            getFullScreenRegion(),
+            alignment,
+            writePolicy,
+            overrideStyle,
+            clampToRegion);
+    }
+
+    PlacementResult PageComposer::writeSolidObjectAligned(
+        const TextObject& object,
+        const Alignment& alignment,
+        const std::optional<Style>& overrideStyle,
+        bool clampToRegion)
+    {
+        return writeObjectAligned(
+            object,
+            alignment,
+            WritePresets::solidObject(),
+            overrideStyle,
+            clampToRegion);
+    }
+
+    PlacementResult PageComposer::writeVisibleObjectAligned(
+        const TextObject& object,
+        const Alignment& alignment,
+        const std::optional<Style>& overrideStyle,
+        bool clampToRegion)
+    {
+        return writeObjectAligned(
+            object,
+            alignment,
+            WritePresets::visibleObject(),
+            overrideStyle,
+            clampToRegion);
+    }
+
+    PlacementResult PageComposer::writeGlyphsOnlyAligned(
+        const TextObject& object,
+        const Alignment& alignment,
+        const std::optional<Style>& overrideStyle,
+        bool clampToRegion)
+    {
+        return writeObjectAligned(
+            object,
+            alignment,
+            WritePresets::glyphsOnly(),
+            overrideStyle,
+            clampToRegion);
+    }
+
+    PlacementResult PageComposer::writeStyleMaskAligned(
+        const TextObject& object,
+        const Alignment& alignment,
+        const std::optional<Style>& overrideStyle,
+        bool clampToRegion)
+    {
+        return writeObjectAligned(
+            object,
+            alignment,
+            WritePresets::styleMask(),
+            overrideStyle,
+            clampToRegion);
+    }
+
+    PlacementResult PageComposer::writeStyleBlockAligned(
+        const TextObject& object,
+        const Alignment& alignment,
+        const std::optional<Style>& overrideStyle,
+        bool clampToRegion)
+    {
+        return writeObjectAligned(
+            object,
+            alignment,
+            WritePresets::styleBlock(),
+            overrideStyle,
+            clampToRegion);
+    }
+
+    Point PageComposer::placeObject(
+        const TextObject& object,
+        int x,
+        int y,
+        const WritePolicy& writePolicy,
+        const std::optional<Style>& overrideStyle)
+    {
+        return writeObject(object, x, y, writePolicy, overrideStyle);
+    }
+
+    PlacementResult PageComposer::placeObject(
+        const TextObject& object,
+        const Rect& region,
+        const Alignment& alignment,
+        const WritePolicy& writePolicy,
+        const std::optional<Style>& overrideStyle,
+        bool clampToRegion)
+    {
+        return writeObject(
+            object,
+            region,
+            alignment,
+            writePolicy,
+            overrideStyle,
+            clampToRegion);
+    }
+
+    PlacementResult PageComposer::placeObjectInRegion(
+        const TextObject& object,
+        std::string_view regionName,
+        const Alignment& alignment,
+        const WritePolicy& writePolicy,
+        const std::optional<Style>& overrideStyle,
+        bool clampToRegion)
+    {
+        return writeObjectInRegion(
+            object,
+            regionName,
             alignment,
             writePolicy,
             overrideStyle,
@@ -370,6 +704,19 @@ namespace Composition
         object.draw(m_composedBuffer, x, y, writePolicy, overrideStyle);
         synchronizeTarget();
         return origin;
+    }
+
+    PlacementResult PageComposer::makeUnresolvedPlacementResult(
+        const TextObject& object,
+        const Alignment& alignment)
+    {
+        PlacementResult result;
+        result.origin = Point{};
+        result.region = makeRect(0, 0, 0, 0);
+        result.contentSize = measureObject(object);
+        result.alignment = alignment;
+        result.clamped = false;
+        return result;
     }
 
     void PageComposer::writeSegmentedLine(

--- a/TUI/Rendering/Composition/PageComposer.h
+++ b/TUI/Rendering/Composition/PageComposer.h
@@ -4,6 +4,7 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <vector>
 
 #include "Rendering/Composition/Placement.h"
 #include "Rendering/Composition/RegionRegistry.h"
@@ -68,6 +69,169 @@ namespace Composition
         NamedRegion* getRegion(std::string_view name);
         void clearRegions();
 
+        Rect getFullScreenRegion() const;
+
+        Point writeObject(
+            const TextObject& object,
+            int x,
+            int y,
+            const WritePolicy& writePolicy,
+            const std::optional<Style>& overrideStyle = std::nullopt);
+
+        Point writeSolidObject(
+            const TextObject& object,
+            int x,
+            int y,
+            const std::optional<Style>& overrideStyle = std::nullopt);
+
+        Point writeVisibleObject(
+            const TextObject& object,
+            int x,
+            int y,
+            const std::optional<Style>& overrideStyle = std::nullopt);
+
+        Point writeGlyphsOnly(
+            const TextObject& object,
+            int x,
+            int y,
+            const std::optional<Style>& overrideStyle = std::nullopt);
+
+        Point writeStyleMask(
+            const TextObject& object,
+            int x,
+            int y,
+            const std::optional<Style>& overrideStyle = std::nullopt);
+
+        Point writeStyleBlock(
+            const TextObject& object,
+            int x,
+            int y,
+            const std::optional<Style>& overrideStyle = std::nullopt);
+
+        PlacementResult writeObject(
+            const TextObject& object,
+            const Rect& region,
+            const Alignment& alignment,
+            const WritePolicy& writePolicy,
+            const std::optional<Style>& overrideStyle = std::nullopt,
+            bool clampToRegion = false);
+
+        PlacementResult writeSolidObject(
+            const TextObject& object,
+            const Rect& region,
+            const Alignment& alignment,
+            const std::optional<Style>& overrideStyle = std::nullopt,
+            bool clampToRegion = false);
+
+        PlacementResult writeVisibleObject(
+            const TextObject& object,
+            const Rect& region,
+            const Alignment& alignment,
+            const std::optional<Style>& overrideStyle = std::nullopt,
+            bool clampToRegion = false);
+
+        PlacementResult writeGlyphsOnly(
+            const TextObject& object,
+            const Rect& region,
+            const Alignment& alignment,
+            const std::optional<Style>& overrideStyle = std::nullopt,
+            bool clampToRegion = false);
+
+        PlacementResult writeStyleMask(
+            const TextObject& object,
+            const Rect& region,
+            const Alignment& alignment,
+            const std::optional<Style>& overrideStyle = std::nullopt,
+            bool clampToRegion = false);
+
+        PlacementResult writeStyleBlock(
+            const TextObject& object,
+            const Rect& region,
+            const Alignment& alignment,
+            const std::optional<Style>& overrideStyle = std::nullopt,
+            bool clampToRegion = false);
+
+        PlacementResult writeObjectInRegion(
+            const TextObject& object,
+            std::string_view regionName,
+            const Alignment& alignment,
+            const WritePolicy& writePolicy,
+            const std::optional<Style>& overrideStyle = std::nullopt,
+            bool clampToRegion = false);
+
+        PlacementResult writeSolidObjectInRegion(
+            const TextObject& object,
+            std::string_view regionName,
+            const Alignment& alignment,
+            const std::optional<Style>& overrideStyle = std::nullopt,
+            bool clampToRegion = false);
+
+        PlacementResult writeVisibleObjectInRegion(
+            const TextObject& object,
+            std::string_view regionName,
+            const Alignment& alignment,
+            const std::optional<Style>& overrideStyle = std::nullopt,
+            bool clampToRegion = false);
+
+        PlacementResult writeGlyphsOnlyInRegion(
+            const TextObject& object,
+            std::string_view regionName,
+            const Alignment& alignment,
+            const std::optional<Style>& overrideStyle = std::nullopt,
+            bool clampToRegion = false);
+
+        PlacementResult writeStyleMaskInRegion(
+            const TextObject& object,
+            std::string_view regionName,
+            const Alignment& alignment,
+            const std::optional<Style>& overrideStyle = std::nullopt,
+            bool clampToRegion = false);
+
+        PlacementResult writeStyleBlockInRegion(
+            const TextObject& object,
+            std::string_view regionName,
+            const Alignment& alignment,
+            const std::optional<Style>& overrideStyle = std::nullopt,
+            bool clampToRegion = false);
+
+        PlacementResult writeObjectAligned(
+            const TextObject& object,
+            const Alignment& alignment,
+            const WritePolicy& writePolicy,
+            const std::optional<Style>& overrideStyle = std::nullopt,
+            bool clampToRegion = false);
+
+        PlacementResult writeSolidObjectAligned(
+            const TextObject& object,
+            const Alignment& alignment,
+            const std::optional<Style>& overrideStyle = std::nullopt,
+            bool clampToRegion = false);
+
+        PlacementResult writeVisibleObjectAligned(
+            const TextObject& object,
+            const Alignment& alignment,
+            const std::optional<Style>& overrideStyle = std::nullopt,
+            bool clampToRegion = false);
+
+        PlacementResult writeGlyphsOnlyAligned(
+            const TextObject& object,
+            const Alignment& alignment,
+            const std::optional<Style>& overrideStyle = std::nullopt,
+            bool clampToRegion = false);
+
+        PlacementResult writeStyleMaskAligned(
+            const TextObject& object,
+            const Alignment& alignment,
+            const std::optional<Style>& overrideStyle = std::nullopt,
+            bool clampToRegion = false);
+
+        PlacementResult writeStyleBlockAligned(
+            const TextObject& object,
+            const Alignment& alignment,
+            const std::optional<Style>& overrideStyle = std::nullopt,
+            bool clampToRegion = false);
+
+        // Backward-compatible placement aliases
         Point placeObject(
             const TextObject& object,
             int x,
@@ -126,6 +290,10 @@ namespace Composition
             int y,
             const WritePolicy& writePolicy,
             const std::optional<Style>& overrideStyle);
+
+        static PlacementResult makeUnresolvedPlacementResult(
+            const TextObject& object,
+            const Alignment& alignment);
 
         void writeSegmentedLine(
             int x,


### PR DESCRIPTION
Modifies:
- Rendering/Composition/ - Alignment.h - PageComposer.h/.cpp

- Added full author-facing object placement layer to PageComposer supporting:
  - Explicit coordinate placement (x, y)
  - Region-based placement (named regions + Alignment)
  - Full-screen aligned placement (implicit root region)

- Introduced Alignment system:
  - HorizontalAlign / VerticalAlign enums
  - Alignment struct
  - Align::* convenience helpers (topLeft, center, bottomRight, etc.)

- Integrated placement pipeline:
  - PlacementRequest / PlacementResult used to resolve origin from region + alignment
  - Single unified placement resolution path reused across all APIs

- Implemented WritePolicy-driven object writing helpers:
  - writeObject(..., WritePolicy)
  - writeSolidObject(...)      -> WritePresets::solidObject()
  - writeVisibleObject(...)    -> WritePresets::visibleObject()
  - writeGlyphsOnly(...)       -> WritePresets::glyphsOnly()
  - writeStyleMask(...)        -> WritePresets::styleMask()
  - writeStyleBlock(...)       -> WritePresets::styleBlock()

- Added overload groups for:
  - Coordinate placement
  - Rect-based placement (region + alignment)
  - Named region placement
  - Full-screen aligned placement

- Ensured ALL placement paths delegate to a single composition path:
  - drawObjectAt(...) -> TextObject::draw(...) using WritePolicy
  - No duplication of composition logic outside WritePolicy/ObjectWriter

- Added region-aware helpers:
  - writeObjectInRegion(...)
  - write*ObjectInRegion(...) convenience wrappers
  - Safe fallback behavior for missing regions (unresolved PlacementResult)

- Added full-screen placement helpers:
  - writeObjectAligned(...)
  - write*ObjectAligned(...) convenience wrappers
  - Uses implicit full-screen Rect from current composed buffer

- Preserved deterministic composition order:
  - No implicit layering or hidden state
  - All writes occur immediately in call order

- Maintained backward-compatible aliases:
  - placeObject(...) variants mapped to new writeObject(...) APIs

- Strengthened separation of responsibilities:
  - PageComposer = placement + authoring layer
  - WritePolicy/ObjectWriter = composition semantics
  - No new composition logic introduced in PageComposer

- No changes to:
  - Asset loading
  - Animation systems
  - Rendering backend
  - TextObject internals

Result:
PageComposer is now the primary ergonomic object placement surface for TUI pages, enabling clean, declarative layout without direct ScreenBuffer writes while fully preserving the unified WritePolicy compositing model.

Closes: #168 