### PR TITLE
PageComposer: Add non-destructive edge-slicing geometry API

### DIFF
--- a/TUI/Rendering/Composition/PageComposer.cpp
+++ b/TUI/Rendering/Composition/PageComposer.cpp
@@ -359,6 +359,69 @@ namespace Composition
         return makeRect(0, 0, std::max(0, getWidth()), std::max(0, getHeight()));
     }
 
+    Rect PageComposer::peekTop(const Rect& rect, int height) const
+    {
+        const int clampedHeight = std::max(0, std::min(height, rect.size.height));
+        return makeRect(
+            rect.position.x,
+            rect.position.y,
+            rect.size.width,
+            clampedHeight);
+    }
+
+    Rect PageComposer::peekBottom(const Rect& rect, int height) const
+    {
+        const int clampedHeight = std::max(0, std::min(height, rect.size.height));
+        return makeRect(
+            rect.position.x,
+            rect.position.y + (rect.size.height - clampedHeight),
+            rect.size.width,
+            clampedHeight);
+    }
+
+    Rect PageComposer::peekLeft(const Rect& rect, int width) const
+    {
+        const int clampedWidth = std::max(0, std::min(width, rect.size.width));
+        return makeRect(
+            rect.position.x,
+            rect.position.y,
+            clampedWidth,
+            rect.size.height);
+    }
+
+    Rect PageComposer::peekRight(const Rect& rect, int width) const
+    {
+        const int clampedWidth = std::max(0, std::min(width, rect.size.width));
+        return makeRect(
+            rect.position.x + (rect.size.width - clampedWidth),
+            rect.position.y,
+            clampedWidth,
+            rect.size.height);
+    }
+
+    Rect PageComposer::peekTop(std::string_view regionName, int height) const
+    {
+        const NamedRegion* region = getRegion(regionName);
+        return region != nullptr ? peekTop(region->bounds, height) : Rect{};
+    }
+
+    Rect PageComposer::peekBottom(std::string_view regionName, int height) const
+    {
+        const NamedRegion* region = getRegion(regionName);
+        return region != nullptr ? peekBottom(region->bounds, height) : Rect{};
+    }
+
+    Rect PageComposer::peekLeft(std::string_view regionName, int width) const
+    {
+        const NamedRegion* region = getRegion(regionName);
+        return region != nullptr ? peekLeft(region->bounds, width) : Rect{};
+    }
+
+    Rect PageComposer::peekRight(std::string_view regionName, int width) const
+    {
+        const NamedRegion* region = getRegion(regionName);
+        return region != nullptr ? peekRight(region->bounds, width) : Rect{};
+    }
 
     void PageComposer::setAssetLibrary(Assets::AssetLibrary& assetLibrary)
     {

--- a/TUI/Rendering/Composition/PageComposer.h
+++ b/TUI/Rendering/Composition/PageComposer.h
@@ -171,6 +171,16 @@ namespace Composition
 
         Rect getFullScreenRegion() const;
 
+        Rect peekTop(const Rect& rect, int height) const;
+        Rect peekBottom(const Rect& rect, int height) const;
+        Rect peekLeft(const Rect& rect, int width) const;
+        Rect peekRight(const Rect& rect, int width) const;
+
+        Rect peekTop(std::string_view regionName, int height) const;
+        Rect peekBottom(std::string_view regionName, int height) const;
+        Rect peekLeft(std::string_view regionName, int width) const;
+        Rect peekRight(std::string_view regionName, int width) const;
+
         void setAssetLibrary(Assets::AssetLibrary& assetLibrary);
         void detachAssetLibrary();
         bool hasAssetLibrary() const;


### PR DESCRIPTION
Modifies:
- Rendering/Composition/PageComposer.h/.cpp

- Introduced peekTop/Bottom/Left/Right(Rect) helpers for inspecting edge slices of arbitrary Rects
- Added named-region overloads for all peek methods (region lookup + slice)
- Ensured all operations are pure geometry (no region mutation or registration)
- Implemented clamping to keep slices within valid bounds
- Returns empty Rect on missing region lookup for safe usage

Closes: #181 