### PR TITLE
PageComposer: Add non-destructive remainder geometry API

### DIFF
--- a/TUI/Rendering/Composition/PageComposer.cpp
+++ b/TUI/Rendering/Composition/PageComposer.cpp
@@ -423,6 +423,70 @@ namespace Composition
         return region != nullptr ? peekRight(region->bounds, width) : Rect{};
     }
 
+    Rect PageComposer::remainderBelow(const Rect& source, int consumedHeight) const
+    {
+        const int clampedHeight = std::max(0, std::min(consumedHeight, source.size.height));
+        return makeRect(
+            source.position.x,
+            source.position.y + clampedHeight,
+            source.size.width,
+            source.size.height - clampedHeight);
+    }
+
+    Rect PageComposer::remainderAbove(const Rect& source, int consumedHeight) const
+    {
+        const int clampedHeight = std::max(0, std::min(consumedHeight, source.size.height));
+        return makeRect(
+            source.position.x,
+            source.position.y,
+            source.size.width,
+            source.size.height - clampedHeight);
+    }
+
+    Rect PageComposer::remainderRightOf(const Rect& source, int consumedWidth) const
+    {
+        const int clampedWidth = std::max(0, std::min(consumedWidth, source.size.width));
+        return makeRect(
+            source.position.x + clampedWidth,
+            source.position.y,
+            source.size.width - clampedWidth,
+            source.size.height);
+    }
+
+    Rect PageComposer::remainderLeftOf(const Rect& source, int consumedWidth) const
+    {
+        const int clampedWidth = std::max(0, std::min(consumedWidth, source.size.width));
+        return makeRect(
+            source.position.x,
+            source.position.y,
+            source.size.width - clampedWidth,
+            source.size.height);
+    }
+
+    Rect PageComposer::remainderBelow(std::string_view sourceRegionName, int consumedHeight) const
+    {
+        const NamedRegion* region = getRegion(sourceRegionName);
+        return region != nullptr ? remainderBelow(region->bounds, consumedHeight) : Rect{};
+    }
+
+    Rect PageComposer::remainderAbove(std::string_view sourceRegionName, int consumedHeight) const
+    {
+        const NamedRegion* region = getRegion(sourceRegionName);
+        return region != nullptr ? remainderAbove(region->bounds, consumedHeight) : Rect{};
+    }
+
+    Rect PageComposer::remainderRightOf(std::string_view sourceRegionName, int consumedWidth) const
+    {
+        const NamedRegion* region = getRegion(sourceRegionName);
+        return region != nullptr ? remainderRightOf(region->bounds, consumedWidth) : Rect{};
+    }
+
+    Rect PageComposer::remainderLeftOf(std::string_view sourceRegionName, int consumedWidth) const
+    {
+        const NamedRegion* region = getRegion(sourceRegionName);
+        return region != nullptr ? remainderLeftOf(region->bounds, consumedWidth) : Rect{};
+    }
+
     void PageComposer::setAssetLibrary(Assets::AssetLibrary& assetLibrary)
     {
         m_assetLibrary = &assetLibrary;

--- a/TUI/Rendering/Composition/PageComposer.h
+++ b/TUI/Rendering/Composition/PageComposer.h
@@ -181,6 +181,16 @@ namespace Composition
         Rect peekLeft(std::string_view regionName, int width) const;
         Rect peekRight(std::string_view regionName, int width) const;
 
+        Rect remainderBelow(const Rect& source, int consumedHeight) const;
+        Rect remainderAbove(const Rect& source, int consumedHeight) const;
+        Rect remainderRightOf(const Rect& source, int consumedWidth) const;
+        Rect remainderLeftOf(const Rect& source, int consumedWidth) const;
+
+        Rect remainderBelow(std::string_view sourceRegionName, int consumedHeight) const;
+        Rect remainderAbove(std::string_view sourceRegionName, int consumedHeight) const;
+        Rect remainderRightOf(std::string_view sourceRegionName, int consumedWidth) const;
+        Rect remainderLeftOf(std::string_view sourceRegionName, int consumedWidth) const;
+
         void setAssetLibrary(Assets::AssetLibrary& assetLibrary);
         void detachAssetLibrary();
         bool hasAssetLibrary() const;


### PR DESCRIPTION
Modifies:
- PageComposer.h/.cpp

- Introduced remainderBelow/Above/RightOf/LeftOf(Rect) helpers for computing leftover space after edge consumption
- Added full named-region overloads for all remainder methods (region lookup + derivation)
- Ensured all operations are pure geometry with no region mutation or registration
- Implemented clamping to keep results within valid bounds
- Returns empty Rect on missing region lookup for safe usage

Closes: #182 