### PR TITLE
PageComposer: Add non-destructive split geometry API

### DIFF
--- a/TUI/Rendering/Composition/PageComposer.cpp
+++ b/TUI/Rendering/Composition/PageComposer.cpp
@@ -487,6 +487,82 @@ namespace Composition
         return region != nullptr ? remainderLeftOf(region->bounds, consumedWidth) : Rect{};
     }
 
+    std::pair<Rect, Rect> PageComposer::splitTop(const Rect& source, int height) const
+    {
+        return {
+            peekTop(source, height),
+            remainderBelow(source, height)
+        };
+    }
+
+    std::pair<Rect, Rect> PageComposer::splitBottom(const Rect& source, int height) const
+    {
+        return {
+            peekBottom(source, height),
+            remainderAbove(source, height)
+        };
+    }
+
+    std::pair<Rect, Rect> PageComposer::splitLeft(const Rect& source, int width) const
+    {
+        return {
+            peekLeft(source, width),
+            remainderRightOf(source, width)
+        };
+    }
+
+    std::pair<Rect, Rect> PageComposer::splitRight(const Rect& source, int width) const
+    {
+        return {
+            peekRight(source, width),
+            remainderLeftOf(source, width)
+        };
+    }
+
+    std::pair<Rect, Rect> PageComposer::splitTop(std::string_view sourceRegionName, int height) const
+    {
+        const NamedRegion* region = getRegion(sourceRegionName);
+        if (region == nullptr)
+        {
+            return { Rect{}, Rect{} };
+        }
+
+        return splitTop(region->bounds, height);
+    }
+
+    std::pair<Rect, Rect> PageComposer::splitBottom(std::string_view sourceRegionName, int height) const
+    {
+        const NamedRegion* region = getRegion(sourceRegionName);
+        if (region == nullptr)
+        {
+            return { Rect{}, Rect{} };
+        }
+
+        return splitBottom(region->bounds, height);
+    }
+
+    std::pair<Rect, Rect> PageComposer::splitLeft(std::string_view sourceRegionName, int width) const
+    {
+        const NamedRegion* region = getRegion(sourceRegionName);
+        if (region == nullptr)
+        {
+            return { Rect{}, Rect{} };
+        }
+
+        return splitLeft(region->bounds, width);
+    }
+
+    std::pair<Rect, Rect> PageComposer::splitRight(std::string_view sourceRegionName, int width) const
+    {
+        const NamedRegion* region = getRegion(sourceRegionName);
+        if (region == nullptr)
+        {
+            return { Rect{}, Rect{} };
+        }
+
+        return splitRight(region->bounds, width);
+    }
+
     void PageComposer::setAssetLibrary(Assets::AssetLibrary& assetLibrary)
     {
         m_assetLibrary = &assetLibrary;

--- a/TUI/Rendering/Composition/PageComposer.h
+++ b/TUI/Rendering/Composition/PageComposer.h
@@ -191,6 +191,16 @@ namespace Composition
         Rect remainderRightOf(std::string_view sourceRegionName, int consumedWidth) const;
         Rect remainderLeftOf(std::string_view sourceRegionName, int consumedWidth) const;
 
+        std::pair<Rect, Rect> splitTop(const Rect& source, int height) const;
+        std::pair<Rect, Rect> splitBottom(const Rect& source, int height) const;
+        std::pair<Rect, Rect> splitLeft(const Rect& source, int width) const;
+        std::pair<Rect, Rect> splitRight(const Rect& source, int width) const;
+
+        std::pair<Rect, Rect> splitTop(std::string_view sourceRegionName, int height) const;
+        std::pair<Rect, Rect> splitBottom(std::string_view sourceRegionName, int height) const;
+        std::pair<Rect, Rect> splitLeft(std::string_view sourceRegionName, int width) const;
+        std::pair<Rect, Rect> splitRight(std::string_view sourceRegionName, int width) const;
+
         void setAssetLibrary(Assets::AssetLibrary& assetLibrary);
         void detachAssetLibrary();
         bool hasAssetLibrary() const;


### PR DESCRIPTION
Modifies:
 - Rendering/Composition/PageComposer.h/.cpp

- Introduced splitTop/Bottom/Left/Right(Rect) helpers returning { slice, remainder } pairs
- Added full named-region overloads for all split methods (region lookup + split)
- Established stable and explicit pair ordering for predictable layout authoring
- Reused existing edge-slice (peek) and remainder helpers to avoid duplicated geometry logic
- Ensured all operations are pure geometry with no region mutation or registration
- Returns empty Rect pairs on missing region lookup for safe usage

Closes: #183 