### PR TITLE
PageComposer: Add multi-region inset batch helper API

### DIFF
--- a/TUI/Rendering/Composition/PageComposer.cpp
+++ b/TUI/Rendering/Composition/PageComposer.cpp
@@ -1021,6 +1021,57 @@ namespace Composition
         return createInsetRegion(region->bounds, left, top, right, bottom, name);
     }
 
+    bool PageComposer::insetAll(
+        const std::vector<std::string>& sourceNames,
+        int inset,
+        const std::vector<std::string>& destNames)
+    {
+        if (sourceNames.size() != destNames.size())
+        {
+            return false;
+        }
+
+        for (std::size_t i = 0; i < sourceNames.size(); ++i)
+        {
+            if (!createInsetRegion(sourceNames[i], inset, destNames[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    bool PageComposer::insetAll(
+        const std::vector<std::string>& sourceNames,
+        int left,
+        int top,
+        int right,
+        int bottom,
+        const std::vector<std::string>& destNames)
+    {
+        if (sourceNames.size() != destNames.size())
+        {
+            return false;
+        }
+
+        for (std::size_t i = 0; i < sourceNames.size(); ++i)
+        {
+            if (!createInsetRegion(
+                sourceNames[i],
+                left,
+                top,
+                right,
+                bottom,
+                destNames[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
     void PageComposer::setAssetLibrary(Assets::AssetLibrary& assetLibrary)
     {
         m_assetLibrary = &assetLibrary;

--- a/TUI/Rendering/Composition/PageComposer.h
+++ b/TUI/Rendering/Composition/PageComposer.h
@@ -281,6 +281,19 @@ namespace Composition
             int bottom,
             std::string_view name);
 
+        bool insetAll(
+            const std::vector<std::string>& sourceNames,
+            int inset,
+            const std::vector<std::string>& destNames);
+
+        bool insetAll(
+            const std::vector<std::string>& sourceNames,
+            int left,
+            int top,
+            int right,
+            int bottom,
+            const std::vector<std::string>& destNames);
+
         void setAssetLibrary(Assets::AssetLibrary& assetLibrary);
         void detachAssetLibrary();
         bool hasAssetLibrary() const;


### PR DESCRIPTION
Modifies:
- Rendering/Composition/PageComposer.h/.cpp

- Introduced insetAll helpers for batch inset-based region registration
- Supports both uniform inset and per-edge inset variants
- Accepts parallel source and destination name collections for ergonomic multi-region workflows
- Delegates entirely to existing createInsetRegion(...) helpers to avoid duplicating geometry logic
- Validates input size matching and propagates failure on invalid sources or registration errors

Closes: #187 