### PR TITLE
PageComposer: Add createDesignScreen scaffold helpers

### DIFF
--- a/TUI/Rendering/Composition/PageComposer.cpp
+++ b/TUI/Rendering/Composition/PageComposer.cpp
@@ -492,6 +492,60 @@ namespace Composition
         return createCenteredRegion(containerRegion->bounds, width, height, name);
     }
 
+    bool PageComposer::createDesignScreen(
+        int width,
+        int height,
+        std::string_view outerRegionName,
+        std::string_view innerRegionName)
+    {
+        return createDesignScreen(
+            getFullScreenRegion(),
+            width,
+            height,
+            outerRegionName,
+            innerRegionName);
+    }
+
+    bool PageComposer::createDesignScreen(
+        const Rect& container,
+        int width,
+        int height,
+        std::string_view outerRegionName,
+        std::string_view innerRegionName)
+    {
+        if (!createCenteredRegion(container, width, height, outerRegionName))
+        {
+            return false;
+        }
+
+        if (innerRegionName.empty())
+        {
+            return true;
+        }
+
+        return createInsetRegion(outerRegionName, 1, innerRegionName);
+    }
+
+    bool PageComposer::createDesignScreen(
+        std::string_view containerRegionName,
+        int width,
+        int height,
+        std::string_view outerRegionName,
+        std::string_view innerRegionName)
+    {
+        if (!createCenteredRegion(containerRegionName, width, height, outerRegionName))
+        {
+            return false;
+        }
+
+        if (innerRegionName.empty())
+        {
+            return true;
+        }
+
+        return createInsetRegion(outerRegionName, 1, innerRegionName);
+    }
+
     void PageComposer::fillRegion(const Rect& target, char32_t glyph, const Style& style)
     {
         if (target.size.width <= 0 || target.size.height <= 0)

--- a/TUI/Rendering/Composition/PageComposer.h
+++ b/TUI/Rendering/Composition/PageComposer.h
@@ -154,16 +154,38 @@ namespace Composition
         bool createFullScreenRegion(std::string_view name);
 
         bool createCenteredRegion(int width, int height, std::string_view name);
+
         bool createCenteredRegion(
             const Rect& container,
             int width,
             int height,
             std::string_view name);
+
         bool createCenteredRegion(
             std::string_view containerRegionName,
             int width,
             int height,
             std::string_view name);
+
+        bool createDesignScreen(
+            int width,
+            int height,
+            std::string_view outerRegionName,
+            std::string_view innerRegionName = {});
+
+        bool createDesignScreen(
+            const Rect& container,
+            int width,
+            int height,
+            std::string_view outerRegionName,
+            std::string_view innerRegionName = {});
+
+        bool createDesignScreen(
+            std::string_view containerRegionName,
+            int width,
+            int height,
+            std::string_view outerRegionName,
+            std::string_view innerRegionName = {});
 
         void fillRegion(const Rect& target, char32_t glyph, const Style& style);
         void fillRegion(std::string_view targetRegionName, char32_t glyph, const Style& style);


### PR DESCRIPTION
Modifies:
- Rendering/Composition/PageComposer.h/.cpp

Introduced a small, ergonomic scaffold helper family to simplify common centered layout workflows in PageComposer while fully reusing the existing region and inset APIs.

The new createDesignScreen(...) overloads allow authors to quickly define a centered “design surface” (outer region) with an optional inset “content” (inner region) inside:
- the full screen
- an explicit Rect container
- a named container region

New API:
- createDesignScreen(width, height, outerName, innerName)
- createDesignScreen(containerRect, width, height, outerName, innerName)
- createDesignScreen(containerRegionName, width, height, outerName, innerName)

Behavior:
- Outer region is always created via existing createCenteredRegion(...)
- Inner region is optional and created only when innerName is provided
- Inner region is derived using createInsetRegion(...) with a default inset of 1 cell
- Empty innerName cleanly results in outer-only scaffolding

Design notes:
- Fully composes existing PageComposer primitives; no new layout system introduced
- Follows existing naming, overload, and validation patterns
- Returns bool to match region-registration semantics across the API
- Keeps implementation minimal and consistent with rebuilt architecture

Impact:
- Provides a clean, high-level authoring shortcut for common page layouts
- Reduces boilerplate when defining centered UI compositions
- Maintains full alignment with the Unicode-aware rendering and region system

Closese: #190 