### PR TITLE
PageComposer: Refactor PageComposer wrapped-text layout to use canoni…

### DIFF
--- a/TUI/Rendering/Composition/PageComposer.cpp
+++ b/TUI/Rendering/Composition/PageComposer.cpp
@@ -17,25 +17,23 @@ namespace
     {
         return ch == U'\n' || ch == U'\r';
     }
+}
 
-    bool isWrapWhitespace(char32_t ch)
+namespace Composition
+{
+    bool PageComposer::isWrapWhitespaceText(std::u32string_view text)
     {
-        return ch == U' ' ||
-            ch == U'\t' ||
-            ch == U'\v' ||
-            ch == U'\f';
-    }
-
-    bool isWhitespaceCluster(const TextCluster& cluster)
-    {
-        if (cluster.codePoints.empty())
+        if (text.empty())
         {
             return false;
         }
 
-        for (char32_t codePoint : cluster.codePoints)
+        for (char32_t ch : text)
         {
-            if (!isWrapWhitespace(codePoint))
+            if (ch != U' ' &&
+                ch != U'\t' &&
+                ch != U'\v' &&
+                ch != U'\f')
             {
                 return false;
             }
@@ -44,46 +42,25 @@ namespace
         return true;
     }
 
-    int measureClusterDisplayWidth(const std::vector<TextCluster>& clusters)
+    std::u32string PageComposer::trimTrailingWrapWhitespace(std::u32string_view text)
     {
-        int width = 0;
+        std::size_t end = text.size();
 
-        for (const TextCluster& cluster : clusters)
+        while (end > 0)
         {
-            width += std::max(0, cluster.displayWidth);
-        }
-
-        return width;
-    }
-
-    std::u32string joinClusterRange(
-        const std::vector<TextCluster>& clusters,
-        std::size_t startIndex,
-        std::size_t endIndexExclusive,
-        bool trimTrailingWhitespace)
-    {
-        std::size_t effectiveEnd = endIndexExclusive;
-
-        if (trimTrailingWhitespace)
-        {
-            while (effectiveEnd > startIndex &&
-                isWhitespaceCluster(clusters[effectiveEnd - 1]))
+            if (!isWrapWhitespaceText(std::u32string_view(text.data() + end - 1, 1)))
             {
-                --effectiveEnd;
+                break;
             }
+
+            --end;
         }
 
-        std::u32string result;
-        for (std::size_t i = startIndex; i < effectiveEnd; ++i)
-        {
-            result += clusters[i].codePoints;
-        }
-
-        return result;
+        return std::u32string(text.substr(0, end));
     }
 
-    std::vector<std::u32string> wrapSingleSegmentedLine(
-        const std::vector<TextCluster>& clusters,
+    std::vector<std::u32string> PageComposer::wrapSingleLineToLines(
+        std::u32string_view text,
         int maxWidth)
     {
         std::vector<std::u32string> lines;
@@ -93,18 +70,40 @@ namespace
             return lines;
         }
 
+        const std::vector<TextCluster> clusters = GraphemeSegmentation::segment(text);
+
         if (clusters.empty())
         {
             lines.push_back(U"");
             return lines;
         }
 
+        auto buildClusterRange =
+            [&](std::size_t startIndex,
+                std::size_t endIndexExclusive,
+                bool trimTrailingWhitespace) -> std::u32string
+            {
+                std::u32string result;
+
+                for (std::size_t i = startIndex; i < endIndexExclusive; ++i)
+                {
+                    result += clusters[i].codePoints;
+                }
+
+                if (trimTrailingWhitespace)
+                {
+                    result = trimTrailingWrapWhitespace(result);
+                }
+
+                return result;
+            };
+
         std::size_t lineStart = 0;
 
         while (lineStart < clusters.size())
         {
             while (lineStart < clusters.size() &&
-                isWhitespaceCluster(clusters[lineStart]))
+                isWrapWhitespaceText(clusters[lineStart].codePoints))
             {
                 ++lineStart;
             }
@@ -121,8 +120,9 @@ namespace
 
             while (index < clusters.size())
             {
-                const int clusterWidth = std::max(0, clusters[index].displayWidth);
-                const bool breakableWhitespace = isWhitespaceCluster(clusters[index]);
+                const int clusterWidth = std::max(0, static_cast<int>(clusters[index].displayWidth));
+                const bool breakableWhitespace =
+                    isWrapWhitespaceText(clusters[index].codePoints);
 
                 if (currentWidth > 0 &&
                     (currentWidth + clusterWidth) > maxWidth)
@@ -142,8 +142,7 @@ namespace
 
             if (index >= clusters.size())
             {
-                lines.push_back(joinClusterRange(
-                    clusters,
+                lines.push_back(buildClusterRange(
                     lineStart,
                     clusters.size(),
                     true));
@@ -152,8 +151,7 @@ namespace
 
             if (currentWidth == 0)
             {
-                lines.push_back(joinClusterRange(
-                    clusters,
+                lines.push_back(buildClusterRange(
                     lineStart,
                     lineStart + 1,
                     false));
@@ -164,8 +162,7 @@ namespace
             if (lastBreak != static_cast<std::size_t>(-1) &&
                 lastBreak >= lineStart)
             {
-                lines.push_back(joinClusterRange(
-                    clusters,
+                lines.push_back(buildClusterRange(
                     lineStart,
                     lastBreak,
                     true));
@@ -173,8 +170,7 @@ namespace
                 continue;
             }
 
-            lines.push_back(joinClusterRange(
-                clusters,
+            lines.push_back(buildClusterRange(
                 lineStart,
                 index,
                 true));
@@ -188,10 +184,7 @@ namespace
 
         return lines;
     }
-}
 
-namespace Composition
-{
     PageComposer::PageComposer(ScreenBuffer& target)
         : m_target(&target)
         , m_composedBuffer(target)
@@ -2329,6 +2322,109 @@ namespace Composition
         return drawObjectAt(object, x, y, writePolicy, overrideStyle);
     }
 
+    PlacementResult PageComposer::writeObject(
+        const TextObject& object,
+        std::string_view regionName,
+        const Alignment& alignment,
+        const WritePolicy& writePolicy,
+        const std::optional<Style>& overrideStyle,
+        bool clampToRegion)
+    {
+        return writeObjectInRegion(
+            object,
+            regionName,
+            alignment,
+            writePolicy,
+            overrideStyle,
+            clampToRegion);
+    }
+
+    PlacementResult PageComposer::writeObjectInFullScreen(
+        const TextObject& object,
+        const Alignment& alignment,
+        const WritePolicy& writePolicy,
+        const std::optional<Style>& overrideStyle,
+        bool clampToRegion)
+    {
+        return writeObject(
+            object,
+            getFullScreenRegion(),
+            alignment,
+            writePolicy,
+            overrideStyle,
+            clampToRegion);
+    }
+
+    PlacementResult PageComposer::writeSolidObjectInFullScreen(
+        const TextObject& object,
+        const Alignment& alignment,
+        const std::optional<Style>& overrideStyle,
+        bool clampToRegion)
+    {
+        return writeObjectInFullScreen(
+            object,
+            alignment,
+            WritePresets::solidObject(),
+            overrideStyle,
+            clampToRegion);
+    }
+
+    PlacementResult PageComposer::writeVisibleObjectInFullScreen(
+        const TextObject& object,
+        const Alignment& alignment,
+        const std::optional<Style>& overrideStyle,
+        bool clampToRegion)
+    {
+        return writeObjectInFullScreen(
+            object,
+            alignment,
+            WritePresets::visibleObject(),
+            overrideStyle,
+            clampToRegion);
+    }
+
+    PlacementResult PageComposer::writeGlyphsOnlyInFullScreen(
+        const TextObject& object,
+        const Alignment& alignment,
+        const std::optional<Style>& overrideStyle,
+        bool clampToRegion)
+    {
+        return writeObjectInFullScreen(
+            object,
+            alignment,
+            WritePresets::glyphsOnly(),
+            overrideStyle,
+            clampToRegion);
+    }
+
+    PlacementResult PageComposer::writeStyleMaskInFullScreen(
+        const TextObject& object,
+        const Alignment& alignment,
+        const std::optional<Style>& overrideStyle,
+        bool clampToRegion)
+    {
+        return writeObjectInFullScreen(
+            object,
+            alignment,
+            WritePresets::styleMask(),
+            overrideStyle,
+            clampToRegion);
+    }
+
+    PlacementResult PageComposer::writeStyleBlockInFullScreen(
+        const TextObject& object,
+        const Alignment& alignment,
+        const std::optional<Style>& overrideStyle,
+        bool clampToRegion)
+    {
+        return writeObjectInFullScreen(
+            object,
+            alignment,
+            WritePresets::styleBlock(),
+            overrideStyle,
+            clampToRegion);
+    }
+
     Point PageComposer::writeSolidObject(
         const TextObject& object,
         int x,
@@ -2443,7 +2539,7 @@ namespace Composition
                 placement.clampToRegion);
 
         case PlacementSpec::Mode::FullScreenAligned:
-            return writeObjectAligned(
+            return writeObjectInFullScreen(
                 object,
                 placement.alignment,
                 writePolicy,
@@ -2634,146 +2730,6 @@ namespace Composition
             regionName,
             alignment,
             WritePresets::styleBlock(),
-            overrideStyle,
-            clampToRegion);
-    }
-
-    PlacementResult PageComposer::writeObjectAligned(
-        const TextObject& object,
-        const Alignment& alignment,
-        const WritePolicy& writePolicy,
-        const std::optional<Style>& overrideStyle,
-        bool clampToRegion)
-    {
-        return writeObject(
-            object,
-            getFullScreenRegion(),
-            alignment,
-            writePolicy,
-            overrideStyle,
-            clampToRegion);
-    }
-
-    PlacementResult PageComposer::writeSolidObjectAligned(
-        const TextObject& object,
-        const Alignment& alignment,
-        const std::optional<Style>& overrideStyle,
-        bool clampToRegion)
-    {
-        return writeObjectAligned(
-            object,
-            alignment,
-            WritePresets::solidObject(),
-            overrideStyle,
-            clampToRegion);
-    }
-
-    PlacementResult PageComposer::writeVisibleObjectAligned(
-        const TextObject& object,
-        const Alignment& alignment,
-        const std::optional<Style>& overrideStyle,
-        bool clampToRegion)
-    {
-        return writeObjectAligned(
-            object,
-            alignment,
-            WritePresets::visibleObject(),
-            overrideStyle,
-            clampToRegion);
-    }
-
-    PlacementResult PageComposer::writeGlyphsOnlyAligned(
-        const TextObject& object,
-        const Alignment& alignment,
-        const std::optional<Style>& overrideStyle,
-        bool clampToRegion)
-    {
-        return writeObjectAligned(
-            object,
-            alignment,
-            WritePresets::glyphsOnly(),
-            overrideStyle,
-            clampToRegion);
-    }
-
-    PlacementResult PageComposer::writeStyleMaskAligned(
-        const TextObject& object,
-        const Alignment& alignment,
-        const std::optional<Style>& overrideStyle,
-        bool clampToRegion)
-    {
-        return writeObjectAligned(
-            object,
-            alignment,
-            WritePresets::styleMask(),
-            overrideStyle,
-            clampToRegion);
-    }
-
-    PlacementResult PageComposer::writeStyleBlockAligned(
-        const TextObject& object,
-        const Alignment& alignment,
-        const std::optional<Style>& overrideStyle,
-        bool clampToRegion)
-    {
-        return writeObjectAligned(
-            object,
-            alignment,
-            WritePresets::styleBlock(),
-            overrideStyle,
-            clampToRegion);
-    }
-
-    Point PageComposer::placeObject(
-        const TextObject& object,
-        int x,
-        int y,
-        const WritePolicy& writePolicy,
-        const std::optional<Style>& overrideStyle)
-    {
-        return writeObject(object, x, y, writePolicy, overrideStyle);
-    }
-
-    PlacementResult PageComposer::placeObject(
-        const TextObject& object,
-        const Rect& region,
-        const Alignment& alignment,
-        const WritePolicy& writePolicy,
-        const std::optional<Style>& overrideStyle,
-        bool clampToRegion)
-    {
-        return writeObject(
-            object,
-            region,
-            alignment,
-            writePolicy,
-            overrideStyle,
-            clampToRegion);
-    }
-
-
-    PlacementResult PageComposer::placeObject(
-        const TextObject& object,
-        const PlacementSpec& placement,
-        const WritePolicy& writePolicy,
-        const std::optional<Style>& overrideStyle)
-    {
-        return writeObject(object, placement, writePolicy, overrideStyle);
-    }
-
-    PlacementResult PageComposer::placeObjectInRegion(
-        const TextObject& object,
-        std::string_view regionName,
-        const Alignment& alignment,
-        const WritePolicy& writePolicy,
-        const std::optional<Style>& overrideStyle,
-        bool clampToRegion)
-    {
-        return writeObjectInRegion(
-            object,
-            regionName,
-            alignment,
-            writePolicy,
             overrideStyle,
             clampToRegion);
     }
@@ -3435,7 +3391,15 @@ namespace Composition
 
     int PageComposer::measureDisplayWidth(std::u32string_view text)
     {
-        return measureClusterDisplayWidth(GraphemeSegmentation::segment(text));
+        int width = 0;
+        const std::vector<TextCluster> clusters = GraphemeSegmentation::segment(text);
+
+        for (const TextCluster& cluster : clusters)
+        {
+            width += std::max(0, static_cast<int>(cluster.displayWidth));
+        }
+
+        return width;
     }
 
     Size PageComposer::measureTextBlockDisplay(const std::vector<std::u32string>& lines)
@@ -3467,11 +3431,8 @@ namespace Composition
 
         for (const std::u32string& sourceLine : sourceLines)
         {
-            const std::vector<TextCluster> clusters =
-                GraphemeSegmentation::segment(sourceLine);
-
             std::vector<std::u32string> paragraphLines =
-                wrapSingleSegmentedLine(clusters, maxWidth);
+                wrapSingleLineToLines(sourceLine, maxWidth);
 
             if (paragraphLines.empty())
             {

--- a/TUI/Rendering/Composition/PageComposer.h
+++ b/TUI/Rendering/Composition/PageComposer.h
@@ -616,9 +616,24 @@ namespace Composition
 
         PlacementResult writeObject(
             const TextObject& object,
+            std::string_view regionName,
+            const Alignment& alignment,
+            const WritePolicy& writePolicy,
+            const std::optional<Style>& overrideStyle = std::nullopt,
+            bool clampToRegion = false);
+
+        PlacementResult writeObject(
+            const TextObject& object,
             const PlacementSpec& placement,
             const WritePolicy& writePolicy,
             const std::optional<Style>& overrideStyle = std::nullopt);
+
+        PlacementResult writeObjectInFullScreen(
+            const TextObject& object,
+            const Alignment& alignment,
+            const WritePolicy& writePolicy,
+            const std::optional<Style>& overrideStyle = std::nullopt,
+            bool clampToRegion = false);
 
         PlacementResult writeSolidObject(
             const TextObject& object,
@@ -698,69 +713,33 @@ namespace Composition
             const std::optional<Style>& overrideStyle = std::nullopt,
             bool clampToRegion = false);
 
-        PlacementResult writeObjectAligned(
-            const TextObject& object,
-            const Alignment& alignment,
-            const WritePolicy& writePolicy,
-            const std::optional<Style>& overrideStyle = std::nullopt,
-            bool clampToRegion = false);
-
-        PlacementResult writeSolidObjectAligned(
+        PlacementResult writeSolidObjectInFullScreen(
             const TextObject& object,
             const Alignment& alignment,
             const std::optional<Style>& overrideStyle = std::nullopt,
             bool clampToRegion = false);
 
-        PlacementResult writeVisibleObjectAligned(
+        PlacementResult writeVisibleObjectInFullScreen(
             const TextObject& object,
             const Alignment& alignment,
             const std::optional<Style>& overrideStyle = std::nullopt,
             bool clampToRegion = false);
 
-        PlacementResult writeGlyphsOnlyAligned(
+        PlacementResult writeGlyphsOnlyInFullScreen(
             const TextObject& object,
             const Alignment& alignment,
             const std::optional<Style>& overrideStyle = std::nullopt,
             bool clampToRegion = false);
 
-        PlacementResult writeStyleMaskAligned(
+        PlacementResult writeStyleMaskInFullScreen(
             const TextObject& object,
             const Alignment& alignment,
             const std::optional<Style>& overrideStyle = std::nullopt,
             bool clampToRegion = false);
 
-        PlacementResult writeStyleBlockAligned(
+        PlacementResult writeStyleBlockInFullScreen(
             const TextObject& object,
             const Alignment& alignment,
-            const std::optional<Style>& overrideStyle = std::nullopt,
-            bool clampToRegion = false);
-
-        Point placeObject(
-            const TextObject& object,
-            int x,
-            int y,
-            const WritePolicy& writePolicy = WritePresets::visibleObject(),
-            const std::optional<Style>& overrideStyle = std::nullopt);
-
-        PlacementResult placeObject(
-            const TextObject& object,
-            const Rect& region,
-            const Alignment& alignment,
-            const WritePolicy& writePolicy = WritePresets::visibleObject(),
-            const std::optional<Style>& overrideStyle = std::nullopt,
-            bool clampToRegion = false);
-
-        PlacementResult placeObject(
-            const TextObject& object,
-            const PlacementSpec& placement,
-            const WritePolicy& writePolicy = WritePresets::visibleObject(),
-            const std::optional<Style>& overrideStyle = std::nullopt);
-
-        PlacementResult placeObjectInRegion(
-            const TextObject& object,
-            std::string_view regionName,
-            const Alignment& alignment,
-            const WritePolicy& writePolicy = WritePresets::visibleObject(),
             const std::optional<Style>& overrideStyle = std::nullopt,
             bool clampToRegion = false);
 
@@ -792,166 +771,174 @@ namespace Composition
             std::string_view utf8Block,
             const std::optional<Style>& styleOverride = std::nullopt);
 
-    private:
-        Point drawObjectAt(
-            const TextObject& object,
-            int x,
-            int y,
-            const WritePolicy& writePolicy,
-            const std::optional<Style>& overrideStyle);
+private:
+    Point drawObjectAt(
+        const TextObject& object,
+        int x,
+        int y,
+        const WritePolicy& writePolicy,
+        const std::optional<Style>& overrideStyle);
 
-        static PlacementResult makeUnresolvedPlacementResult(
-            const TextObject& object,
-            const Alignment& alignment);
+    static PlacementResult makeUnresolvedPlacementResult(
+        const TextObject& object,
+        const Alignment& alignment);
 
-        SourcePlacementResult placeResolvedSource(
-            const ResolvedObjectSource& resolvedSource,
-            int x,
-            int y,
-            const WritePolicy& writePolicy,
-            const std::optional<Style>& overrideStyle);
+    SourcePlacementResult placeResolvedSource(
+        const ResolvedObjectSource& resolvedSource,
+        int x,
+        int y,
+        const WritePolicy& writePolicy,
+        const std::optional<Style>& overrideStyle);
 
-        SourcePlacementResult placeResolvedSource(
-            const ResolvedObjectSource& resolvedSource,
-            const Rect& region,
-            const Alignment& alignment,
-            const WritePolicy& writePolicy,
-            const std::optional<Style>& overrideStyle,
-            bool clampToRegion);
+    SourcePlacementResult placeResolvedSource(
+        const ResolvedObjectSource& resolvedSource,
+        const Rect& region,
+        const Alignment& alignment,
+        const WritePolicy& writePolicy,
+        const std::optional<Style>& overrideStyle,
+        bool clampToRegion);
 
-        static SourcePlacementResult makeFailedSourcePlacement(
-            const ResolvedObjectSource& resolvedSource,
-            const Alignment* alignment = nullptr);
+    static SourcePlacementResult makeFailedSourcePlacement(
+        const ResolvedObjectSource& resolvedSource,
+        const Alignment* alignment = nullptr);
 
-        void writeSegmentedLine(
-            int x,
-            int y,
-            std::u32string_view line,
-            const std::optional<Style>& styleOverride);
+    void writeSegmentedLine(
+        int x,
+        int y,
+        std::u32string_view line,
+        const std::optional<Style>& styleOverride);
 
-        static std::u32string extractFirstLine(std::u32string_view text);
-        static std::vector<std::u32string> splitLines(std::u32string_view text);
+    static std::u32string extractFirstLine(std::u32string_view text);
+    static std::vector<std::u32string> splitLines(std::u32string_view text);
 
-        void writeAlignedText(
-            const Rect& target,
-            const Alignment& alignment,
-            std::string_view text,
-            const Style& style);
+    void writeAlignedText(
+        const Rect& target,
+        const Alignment& alignment,
+        std::string_view text,
+        const Style& style);
 
-        void writeAlignedText(
-            std::string_view targetRegionName,
-            const Alignment& alignment,
-            std::string_view text,
-            const Style& style);
+    void writeAlignedText(
+        std::string_view targetRegionName,
+        const Alignment& alignment,
+        std::string_view text,
+        const Style& style);
 
-        void writeAlignedTextInFullScreen(
-            const Alignment& alignment,
-            std::string_view text,
-            const Style& style);
+    void writeAlignedTextInFullScreen(
+        const Alignment& alignment,
+        std::string_view text,
+        const Style& style);
 
-        void writeAlignedTextBlock(
-            const Rect& target,
-            const Alignment& alignment,
-            std::string_view textBlock,
-            const Style& style);
+    void writeAlignedTextBlock(
+        const Rect& target,
+        const Alignment& alignment,
+        std::string_view textBlock,
+        const Style& style);
 
-        void writeAlignedTextBlock(
-            std::string_view targetRegionName,
-            const Alignment& alignment,
-            std::string_view textBlock,
-            const Style& style);
+    void writeAlignedTextBlock(
+        std::string_view targetRegionName,
+        const Alignment& alignment,
+        std::string_view textBlock,
+        const Style& style);
 
-        void writeAlignedTextBlockInFullScreen(
-            const Alignment& alignment,
-            std::string_view textBlock,
-            const Style& style);
+    void writeAlignedTextBlockInFullScreen(
+        const Alignment& alignment,
+        std::string_view textBlock,
+        const Style& style);
 
-        void writeWrappedText(
-            const Rect& target,
-            const Alignment& alignment,
-            std::string_view text,
-            const Style& style);
+    void writeWrappedText(
+        const Rect& target,
+        const Alignment& alignment,
+        std::string_view text,
+        const Style& style);
 
-        void writeWrappedText(
-            std::string_view targetRegionName,
-            const Alignment& alignment,
-            std::string_view text,
-            const Style& style);
+    void writeWrappedText(
+        std::string_view targetRegionName,
+        const Alignment& alignment,
+        std::string_view text,
+        const Style& style);
 
-        void writeWrappedTextInFullScreen(
-            const Alignment& alignment,
-            std::string_view text,
-            const Style& style);
+    void writeWrappedTextInFullScreen(
+        const Alignment& alignment,
+        std::string_view text,
+        const Style& style);
 
-        void writeAlignedTextUtf32(
-            const Rect& target,
-            const Alignment& alignment,
-            std::u32string_view text,
-            const std::optional<Style>& styleOverride);
+    void writeAlignedTextUtf32(
+        const Rect& target,
+        const Alignment& alignment,
+        std::u32string_view text,
+        const std::optional<Style>& styleOverride);
 
-        void writeAlignedTextBlockUtf32(
-            const Rect& target,
-            const Alignment& alignment,
-            std::u32string_view textBlock,
-            const std::optional<Style>& styleOverride,
-            std::string_view operationName);
+    void writeAlignedTextBlockUtf32(
+        const Rect& target,
+        const Alignment& alignment,
+        std::u32string_view textBlock,
+        const std::optional<Style>& styleOverride,
+        std::string_view operationName);
 
-        void writeWrappedTextUtf32(
-            const Rect& target,
-            const Alignment& alignment,
-            std::u32string_view text,
-            const std::optional<Style>& styleOverride);
+    void writeWrappedTextUtf32(
+        const Rect& target,
+        const Alignment& alignment,
+        std::u32string_view text,
+        const std::optional<Style>& styleOverride);
 
-        static int measureDisplayWidth(std::u32string_view text);
-        static Size measureTextBlockDisplay(const std::vector<std::u32string>& lines);
-       
-        static std::vector<std::u32string> wrapTextToLines(
-            std::u32string_view text,
-            int maxWidth);
+    static bool isWrapWhitespaceText(std::u32string_view text);
 
-        int resolveActiveFrameIndex() const;
+    static std::u32string trimTrailingWrapWhitespace(std::u32string_view text);
 
-        void recordOperation(
-            PageCompositionDiagnostics::OperationKind operation,
-            std::string_view operationName,
-            const Rect* requestedRegion = nullptr,
-            const Rect* resolvedRegion = nullptr,
-            const Point* origin = nullptr,
-            const Size* contentSize = nullptr,
-            const Alignment* alignment = nullptr,
-            const WritePolicy* writePolicy = nullptr,
-            bool usedAlignment = false,
-            bool usedOverrideStyle = false,
-            bool clampRequested = false,
-            bool clamped = false,
-            bool success = true,
-            std::string_view regionName = {},
-            std::string_view detail = {},
-            std::string_view errorMessage = {});
+    static std::vector<std::u32string> wrapSingleLineToLines(
+        std::u32string_view text,
+        int maxWidth);
 
-        void recordSourcePlacement(
-            PageCompositionDiagnostics::OperationKind operation,
-            std::string_view operationName,
-            const ResolvedObjectSource& resolvedSource,
-            const Rect* requestedRegion,
-            const SourcePlacementResult& result,
-            const WritePolicy& writePolicy,
-            bool usedAlignment,
-            bool usedOverrideStyle,
-            bool clampRequested,
-            std::string_view regionName = {});
+    static int measureDisplayWidth(std::u32string_view text);
+    static Size measureTextBlockDisplay(const std::vector<std::u32string>& lines);
 
-        void refreshDeterministicSignature();
-        void synchronizeTarget();
+    static std::vector<std::u32string> wrapTextToLines(
+        std::u32string_view text,
+        int maxWidth);
 
-    private:
-        ScreenBuffer* m_target = nullptr;
-        Assets::AssetLibrary* m_assetLibrary = nullptr;
-        PageCompositionDiagnostics* m_diagnostics = nullptr;
-        ScreenBuffer m_composedBuffer;
-        RegionRegistry m_regions;
-        std::vector<TextObject> m_frames;
-        ScreenTemplateLoader m_screenTemplateLoader;
-        PageCompositionDiagnostics::FrameContext m_frameContext;
+    int resolveActiveFrameIndex() const;
+
+    void recordOperation(
+        PageCompositionDiagnostics::OperationKind operation,
+        std::string_view operationName,
+        const Rect* requestedRegion = nullptr,
+        const Rect* resolvedRegion = nullptr,
+        const Point* origin = nullptr,
+        const Size* contentSize = nullptr,
+        const Alignment* alignment = nullptr,
+        const WritePolicy* writePolicy = nullptr,
+        bool usedAlignment = false,
+        bool usedOverrideStyle = false,
+        bool clampRequested = false,
+        bool clamped = false,
+        bool success = true,
+        std::string_view regionName = {},
+        std::string_view detail = {},
+        std::string_view errorMessage = {});
+
+    void recordSourcePlacement(
+        PageCompositionDiagnostics::OperationKind operation,
+        std::string_view operationName,
+        const ResolvedObjectSource& resolvedSource,
+        const Rect* requestedRegion,
+        const SourcePlacementResult& result,
+        const WritePolicy& writePolicy,
+        bool usedAlignment,
+        bool usedOverrideStyle,
+        bool clampRequested,
+        std::string_view regionName = {});
+
+    void refreshDeterministicSignature();
+    void synchronizeTarget();
+
+private:
+    ScreenBuffer* m_target = nullptr;
+    Assets::AssetLibrary* m_assetLibrary = nullptr;
+    PageCompositionDiagnostics* m_diagnostics = nullptr;
+    ScreenBuffer m_composedBuffer;
+    RegionRegistry m_regions;
+    std::vector<TextObject> m_frames;
+    ScreenTemplateLoader m_screenTemplateLoader;
+    PageCompositionDiagnostics::FrameContext m_frameContext;
     };
 }


### PR DESCRIPTION
…cal Unicode pipeline and remove duplicate wrapping engine

Modifies:
- Rendering/Composition/PageComposer.h/,cpp

- Eliminated anonymous-namespace wrapped-text layout helpers that acted as a separate local layout engine (isWrapWhitespace, joinClusterRange, wrapSingleSegmentedLine, etc.)
- Consolidated wrapped-text behavior into a single helper path using:
  - GraphemeSegmentation::segment(...)
  - TextCluster::displayWidth
  - splitLines(...) / extractFirstLine(...)
- Introduced PageComposer-scoped helpers:
  - isWrapWhitespaceText(...)
  - trimTrailingWrapWhitespace(...)
  - wrapSingleLineToLines(...)
- Ensured wrapped layout flows through:
  - resolvePlacement(...) for region/origin resolution
  - resolveAlignedOrigin(...) for per-line alignment
  - writeSegmentedLine(...) as the only rendering path
- Removed duplicate width and whitespace logic based on code units; all layout now operates on grapheme clusters
- Preserved full Unicode correctness (combining marks, wide glyphs, emoji, multi-codepoint clusters)
- Preserved existing PageComposer public APIs for wrapped text, aligned text, and text blocks (no breaking changes)

Retained Object Composition Audit:
- Verified TextObject composition routes through a single coherent API surface:
  - writeObject(...) as the core entry point
  - WritePresets-backed helpers (writeSolidObject, writeVisibleObject, etc.) as thin convenience layers
- Confirmed placement/alignment flows through Placement/Alignment utilities (no parallel systems)
- Confirmed ObjectSource/asset placement (placeSource, placeAsset, etc.) remains a separate, non-conflicting abstraction layer

Result:
- Removed duplicate layout implementation
- Unified wrapped-text behavior under the project’s canonical Unicode-aware pipeline
- Preserved architectural consistency and author-facing API stability

Closes: #193 
Closes: #194 
Closes: #195 
Closes: #197