### PR TITLE
Phase 7 Tier 1: Input foundation (InputManager + raw keyboard pipeline)

### DIFF
--- a/TUI/App/Application.cpp
+++ b/TUI/App/Application.cpp
@@ -1,5 +1,6 @@
 #include "App/Application.h"
 #include "App/ScreenManager.h"
+#include "Input/InputManager.h"
 
 #include <chrono>
 #include <thread>
@@ -124,6 +125,12 @@ bool Application::initialize()
     m_surface = std::make_unique<Surface>(m_width, m_height);
     m_screenManager = std::make_unique<ScreenManager>();
 
+    m_inputManager = std::make_unique<Input::InputManager>();
+    if (!m_inputManager->initialize())
+    {
+        return false;
+    }
+
     configureAssetLibrary();
 
     if (m_validationScreenStart == StartupValidationScreenPreference::ValidationStartTrue)
@@ -157,6 +164,15 @@ void Application::run()
 
         handleResize();
 
+        if (m_inputManager)
+        {
+            m_inputManager->poll();
+
+            // Phase 7 Tier 1 only establishes the low-level input queue.
+            // Later tiers should route drained events into command mapping or screen dispatch.
+            m_inputManager->clear();
+        }
+
         update(delta.count());
         render();
 
@@ -178,6 +194,12 @@ void Application::shutdown()
     if (m_renderer)
     {
         m_renderer->shutdown();
+    }
+
+    if (m_inputManager)
+    {
+        m_inputManager->shutdown();
+        m_inputManager.reset();
     }
 }
 

--- a/TUI/App/Application.h
+++ b/TUI/App/Application.h
@@ -10,6 +10,11 @@ class ScreenManager;
 class IRenderer;
 class Surface;
 
+namespace Input
+{
+    class InputManager;
+}
+
 class Application
 {
 public:
@@ -57,6 +62,7 @@ private:
     std::unique_ptr<ScreenManager> m_screenManager;
     std::unique_ptr<IRenderer> m_renderer;
     std::unique_ptr<Surface> m_surface;
+    std::unique_ptr<Input::InputManager> m_inputManager;
 
     Assets::AssetLibrary m_assetLibrary;
 
@@ -65,7 +71,7 @@ private:
     int m_width = 0;
     int m_height = 0;
 
-//    ScreenType m_currentScreenType = ScreenType::DigitalRain;
+    // default start-up screen, but the actual is declared in Application.cpp/initialize
     ScreenType m_currentScreenType = ScreenType::ControlDeck;
     double m_screenCycleElapsedSeconds = 0.0;
     double m_screenCycleIntervalSeconds = 20.0;

--- a/TUI/Input/InputManager.cpp
+++ b/TUI/Input/InputManager.cpp
@@ -1,0 +1,191 @@
+#include "Input/InputManager.h"
+
+#include "Input/WindowsConsoleKeyboardSource.h"
+
+namespace Input
+{
+    namespace
+    {
+        KeyCode mapVirtualKey(std::uint16_t virtualKey, char32_t character)
+        {
+            if (character != U'\0')
+            {
+                if (character == U' ')
+                {
+                    return KeyCode::Space;
+                }
+
+                if (character == U'\r' || character == U'\n')
+                {
+                    return KeyCode::Enter;
+                }
+
+                if (character == U'\b')
+                {
+                    return KeyCode::Backspace;
+                }
+
+                if (character == U'\t')
+                {
+                    return KeyCode::Tab;
+                }
+
+                if (character == U'\x1B')
+                {
+                    return KeyCode::Escape;
+                }
+
+                return KeyCode::Character;
+            }
+
+            switch (virtualKey)
+            {
+            case 0x1B: return KeyCode::Escape;
+            case 0x0D: return KeyCode::Enter;
+            case 0x08: return KeyCode::Backspace;
+            case 0x09: return KeyCode::Tab;
+            case 0x20: return KeyCode::Space;
+
+            case 0x25: return KeyCode::Left;
+            case 0x27: return KeyCode::Right;
+            case 0x26: return KeyCode::Up;
+            case 0x28: return KeyCode::Down;
+
+            case 0x24: return KeyCode::Home;
+            case 0x23: return KeyCode::End;
+            case 0x21: return KeyCode::PageUp;
+            case 0x22: return KeyCode::PageDown;
+            case 0x2D: return KeyCode::Insert;
+            case 0x2E: return KeyCode::Delete;
+
+            case 0x70: return KeyCode::F1;
+            case 0x71: return KeyCode::F2;
+            case 0x72: return KeyCode::F3;
+            case 0x73: return KeyCode::F4;
+            case 0x74: return KeyCode::F5;
+            case 0x75: return KeyCode::F6;
+            case 0x76: return KeyCode::F7;
+            case 0x77: return KeyCode::F8;
+            case 0x78: return KeyCode::F9;
+            case 0x79: return KeyCode::F10;
+            case 0x7A: return KeyCode::F11;
+            case 0x7B: return KeyCode::F12;
+
+            default:
+                return KeyCode::Unknown;
+            }
+        }
+    }
+
+    InputManager::InputManager()
+        : m_keyboardSource(std::make_unique<WindowsConsoleKeyboardSource>())
+    {
+    }
+
+    InputManager::InputManager(std::unique_ptr<IRawKeyboardSource> keyboardSource)
+        : m_keyboardSource(std::move(keyboardSource))
+    {
+    }
+
+    InputManager::~InputManager()
+    {
+        shutdown();
+    }
+
+    bool InputManager::initialize()
+    {
+        if (m_initialized)
+        {
+            return true;
+        }
+
+        if (!m_keyboardSource)
+        {
+            return false;
+        }
+
+        if (!m_keyboardSource->initialize())
+        {
+            return false;
+        }
+
+        m_initialized = true;
+        return true;
+    }
+
+    void InputManager::shutdown()
+    {
+        if (!m_initialized)
+        {
+            return;
+        }
+
+        if (m_keyboardSource)
+        {
+            m_keyboardSource->shutdown();
+        }
+
+        m_events.clear();
+        m_initialized = false;
+    }
+
+    void InputManager::poll()
+    {
+        if (!m_initialized || !m_keyboardSource)
+        {
+            return;
+        }
+
+        while (true)
+        {
+            std::optional<RawKeyEvent> raw = m_keyboardSource->pollRawKey();
+            if (!raw.has_value())
+            {
+                break;
+            }
+
+            m_events.push_back(normalizeRawKey(raw.value()));
+        }
+    }
+
+    bool InputManager::hasEvents() const
+    {
+        return !m_events.empty();
+    }
+
+    std::optional<KeyEvent> InputManager::popEvent()
+    {
+        if (m_events.empty())
+        {
+            return std::nullopt;
+        }
+
+        KeyEvent event = m_events.front();
+        m_events.erase(m_events.begin());
+        return event;
+    }
+
+    std::vector<KeyEvent> InputManager::drainEvents()
+    {
+        std::vector<KeyEvent> drained;
+        drained.swap(m_events);
+        return drained;
+    }
+
+    void InputManager::clear()
+    {
+        m_events.clear();
+    }
+
+    KeyEvent InputManager::normalizeRawKey(const RawKeyEvent& raw) const
+    {
+        KeyEvent event;
+        event.code = mapVirtualKey(raw.virtualKey, raw.character);
+        event.character = raw.character;
+        event.modifiers = raw.modifiers;
+        event.pressed = raw.pressed;
+        event.repeatCount = raw.repeatCount == 0 ? 1 : raw.repeatCount;
+
+        return event;
+    }
+}

--- a/TUI/Input/InputManager.h
+++ b/TUI/Input/InputManager.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <vector>
+
+#include "Input/KeyEvent.h"
+#include "Input/RawKeyboardSource.h"
+
+namespace Input
+{
+    class InputManager
+    {
+    public:
+        InputManager();
+        explicit InputManager(std::unique_ptr<IRawKeyboardSource> keyboardSource);
+        ~InputManager();
+
+        bool initialize();
+        void shutdown();
+
+        void poll();
+
+        bool hasEvents() const;
+        std::optional<KeyEvent> popEvent();
+        std::vector<KeyEvent> drainEvents();
+
+        void clear();
+
+    private:
+        KeyEvent normalizeRawKey(const RawKeyEvent& raw) const;
+
+    private:
+        std::unique_ptr<IRawKeyboardSource> m_keyboardSource;
+        std::vector<KeyEvent> m_events;
+        bool m_initialized = false;
+    };
+}

--- a/TUI/Input/KeyEvent.h
+++ b/TUI/Input/KeyEvent.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <cstdint>
+
+namespace Input
+{
+    enum class KeyCode
+    {
+        Unknown,
+
+        Character,
+
+        Escape,
+        Enter,
+        Backspace,
+        Tab,
+        Space,
+
+        Left,
+        Right,
+        Up,
+        Down,
+
+        Home,
+        End,
+        PageUp,
+        PageDown,
+        Insert,
+        Delete,
+
+        F1,
+        F2,
+        F3,
+        F4,
+        F5,
+        F6,
+        F7,
+        F8,
+        F9,
+        F10,
+        F11,
+        F12
+    };
+
+    struct KeyModifiers
+    {
+        bool shift = false;
+        bool ctrl = false;
+        bool alt = false;
+    };
+
+    struct KeyEvent
+    {
+        KeyCode code = KeyCode::Unknown;
+        char32_t character = U'\0';
+        KeyModifiers modifiers;
+        bool pressed = false;
+        std::uint16_t repeatCount = 1;
+    };
+}

--- a/TUI/Input/RawKeyboardSource.h
+++ b/TUI/Input/RawKeyboardSource.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <cstdint>
+#include <optional>
+
+#include "Input/KeyEvent.h"
+
+namespace Input
+{
+    struct RawKeyEvent
+    {
+        std::uint16_t virtualKey = 0;
+        char32_t character = U'\0';
+        KeyModifiers modifiers;
+        bool pressed = false;
+        std::uint16_t repeatCount = 1;
+    };
+
+    class IRawKeyboardSource
+    {
+    public:
+        virtual ~IRawKeyboardSource() = default;
+
+        virtual bool initialize() = 0;
+        virtual void shutdown() = 0;
+
+        virtual std::optional<RawKeyEvent> pollRawKey() = 0;
+    };
+}

--- a/TUI/Input/WindowsConsoleKeyboardSource.cpp
+++ b/TUI/Input/WindowsConsoleKeyboardSource.cpp
@@ -1,0 +1,128 @@
+#include "Input/WindowsConsoleKeyboardSource.h"
+
+#define NOMINMAX
+#include <windows.h>
+
+namespace Input
+{
+    namespace
+    {
+        KeyModifiers readModifiers(DWORD controlKeyState)
+        {
+            KeyModifiers modifiers;
+            modifiers.shift = (controlKeyState & SHIFT_PRESSED) != 0;
+            modifiers.ctrl =
+                (controlKeyState & LEFT_CTRL_PRESSED) != 0 ||
+                (controlKeyState & RIGHT_CTRL_PRESSED) != 0;
+            modifiers.alt =
+                (controlKeyState & LEFT_ALT_PRESSED) != 0 ||
+                (controlKeyState & RIGHT_ALT_PRESSED) != 0;
+
+            return modifiers;
+        }
+    }
+
+    WindowsConsoleKeyboardSource::~WindowsConsoleKeyboardSource()
+    {
+        shutdown();
+    }
+
+    bool WindowsConsoleKeyboardSource::initialize()
+    {
+        if (m_initialized)
+        {
+            return true;
+        }
+
+        HANDLE handle = GetStdHandle(STD_INPUT_HANDLE);
+        if (handle == INVALID_HANDLE_VALUE || handle == nullptr)
+        {
+            return false;
+        }
+
+        DWORD mode = 0;
+        if (!GetConsoleMode(handle, &mode))
+        {
+            return false;
+        }
+
+        m_inputHandle = handle;
+        m_originalMode = mode;
+
+        DWORD rawMode = mode;
+        rawMode &= ~ENABLE_LINE_INPUT;
+        rawMode &= ~ENABLE_ECHO_INPUT;
+        rawMode &= ~ENABLE_PROCESSED_INPUT;
+        rawMode |= ENABLE_WINDOW_INPUT;
+
+        if (!SetConsoleMode(handle, rawMode))
+        {
+            m_inputHandle = nullptr;
+            m_originalMode = 0;
+            return false;
+        }
+
+        m_initialized = true;
+        return true;
+    }
+
+    void WindowsConsoleKeyboardSource::shutdown()
+    {
+        if (!m_initialized)
+        {
+            return;
+        }
+
+        HANDLE handle = static_cast<HANDLE>(m_inputHandle);
+        if (handle != INVALID_HANDLE_VALUE && handle != nullptr)
+        {
+            SetConsoleMode(handle, m_originalMode);
+        }
+
+        m_inputHandle = nullptr;
+        m_originalMode = 0;
+        m_initialized = false;
+    }
+
+    std::optional<RawKeyEvent> WindowsConsoleKeyboardSource::pollRawKey()
+    {
+        if (!m_initialized)
+        {
+            return std::nullopt;
+        }
+
+        HANDLE handle = static_cast<HANDLE>(m_inputHandle);
+
+        while (true)
+        {
+            DWORD eventCount = 0;
+            if (!GetNumberOfConsoleInputEvents(handle, &eventCount) || eventCount == 0)
+            {
+                return std::nullopt;
+            }
+
+            INPUT_RECORD record{};
+            DWORD recordsRead = 0;
+            if (!ReadConsoleInputW(handle, &record, 1, &recordsRead) || recordsRead == 0)
+            {
+                return std::nullopt;
+            }
+
+            if (record.EventType != KEY_EVENT)
+            {
+                continue;
+            }
+
+            const KEY_EVENT_RECORD& key = record.Event.KeyEvent;
+
+            RawKeyEvent raw;
+            raw.virtualKey = static_cast<std::uint16_t>(key.wVirtualKeyCode);
+            raw.character = static_cast<char32_t>(key.uChar.UnicodeChar);
+            raw.modifiers = readModifiers(key.dwControlKeyState);
+            raw.pressed = key.bKeyDown != FALSE;
+            raw.repeatCount = static_cast<std::uint16_t>(key.wRepeatCount == 0 ? 1 : key.wRepeatCount);
+
+            return raw;
+        }
+    }
+}

--- a/TUI/Input/WindowsConsoleKeyboardSource.h
+++ b/TUI/Input/WindowsConsoleKeyboardSource.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "Input/RawKeyboardSource.h"
+
+namespace Input
+{
+    class WindowsConsoleKeyboardSource final : public IRawKeyboardSource
+    {
+    public:
+        WindowsConsoleKeyboardSource() = default;
+        ~WindowsConsoleKeyboardSource() override;
+
+        bool initialize() override;
+        void shutdown() override;
+
+        std::optional<RawKeyEvent> pollRawKey() override;
+
+    private:
+        void* m_inputHandle = nullptr;
+        unsigned long m_originalMode = 0;
+        bool m_initialized = false;
+    };
+}

--- a/TUI/TUI.vcxproj
+++ b/TUI/TUI.vcxproj
@@ -144,6 +144,10 @@
     <ClInclude Include="Core\Point.h" />
     <ClInclude Include="Core\Rect.h" />
     <ClInclude Include="Core\Size.h" />
+    <ClInclude Include="Input\InputManager.h" />
+    <ClInclude Include="Input\KeyEvent.h" />
+    <ClInclude Include="Input\RawKeyboardSource.h" />
+    <ClInclude Include="Input\WindowsConsoleKeyboardSource.h" />
     <ClInclude Include="Rendering\Backends\ConsoleCapabilityDetector.h" />
     <ClInclude Include="Rendering\Backends\RendererCapabilityDetector.h" />
     <ClInclude Include="Rendering\Backends\TerminalCapabilityDetector.h">
@@ -273,6 +277,8 @@
     <ClCompile Include="App\TerminalLauncher.cpp" />
     <ClCompile Include="Assets\AssetLibrary.cpp" />
     <ClCompile Include="Assets\Loaders\AsciiBannerFontLoader.cpp" />
+    <ClCompile Include="Input\InputManager.cpp" />
+    <ClCompile Include="Input\WindowsConsoleKeyboardSource.cpp" />
     <ClCompile Include="main.cpp" />
     <ClCompile Include="Rendering\Backends\ConsoleCapabilityDetector.cpp" />
     <ClCompile Include="Rendering\Backends\RendererCapabiltiyDetector.cpp" />

--- a/TUI/TUI.vcxproj.filters
+++ b/TUI/TUI.vcxproj.filters
@@ -351,6 +351,18 @@
     <ClInclude Include="Rendering\Diagnostics\PageCompositionDiagnostics.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="Input\KeyEvent.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Input\RawKeyboardSource.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Input\InputManager.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Input\WindowsConsoleKeyboardSource.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Rendering\ScreenBuffer.cpp">
@@ -657,6 +669,12 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="Rendering\Diagnostics\PageCompositionDiagnostics.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Input\InputManager.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Input\WindowsConsoleKeyboardSource.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
Modifies:
- TUI.vcxproj
- TUI.vcxproj.filters
- App/Application.h/.cpp

Adds:
- Input/ - InputManager.h/.cpp - KeyEvent.h - RawKeyboardSource.h - WindowsConsoleKeyboardSource.h/.cpp

- Introduced InputManager as the authoritative low-level input entry point
- Established platform-independent input pipeline: Raw console input -> RawKeyEvent -> KeyEvent normalization -> event queue

- Added Input core types:
  - KeyCode enum for normalized key representation
  - KeyModifiers for shift/ctrl/alt state
  - KeyEvent as the public, normalized input event
  - RawKeyEvent for platform-facing input data

- Implemented IRawKeyboardSource interface to decouple platform input from engine logic

- Added WindowsConsoleKeyboardSource:
  - Uses Win32 console input (ReadConsoleInputW)
  - Configures console for raw input mode (disables line/echo/processed input)
  - Extracts virtual key, Unicode character, modifiers, and repeat count
  - Restores original console mode on shutdown

- Implemented InputManager:
  - Owns keyboard source and lifecycle (initialize/shutdown)
  - Polls raw input non-blocking per frame
  - Normalizes RawKeyEvent → KeyEvent
  - Buffers events in an internal queue
  - Provides popEvent(), drainEvents(), hasEvents(), clear()

- Integrated InputManager into Application:
  - Initialized alongside core systems
  - Polled once per frame before update()
  - Currently clears events after polling (no command layer yet)
  - Shutdown cleanly restores console state

- Maintains strict separation of concerns:
  - No command mapping or UI behavior introduced
  - No coupling to ScreenManager or PageComposer
  - No global state added

- Establishes stable foundation for:
  - Input mapping (commands/actions)
  - Event dispatch to screens/widgets
  - Future device expansion (mouse/gamepad)

Result:
TUI now supports non-blocking raw keyboard input with a clean, normalized, platform-independent event pipeline ready for higher-level input systems.

Closes: #215 