### PR TITLE
Compositor: Add Compositor core for layered surface composition

### DIFF
--- a/TUI/Rendering/Compositor.cpp
+++ b/TUI/Rendering/Compositor.cpp
@@ -1,0 +1,291 @@
+#include "Rendering/Compositor.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <vector>
+
+#include "Rendering/Composition/GlyphPolicy.h"
+#include "Rendering/Composition/OverwriteRule.h"
+#include "Rendering/Composition/SourceMask.h"
+#include "Rendering/Composition/StylePolicy.h"
+#include "Rendering/Composition/WritePresets.h"
+
+namespace
+{
+    struct LayerSortEntry
+    {
+        const LayerInstance* layer = nullptr;
+        std::size_t originalIndex = 0;
+    };
+
+    bool isSourceLeadingCell(const ScreenCell& cell)
+    {
+        return cell.kind == CellKind::Glyph || cell.kind == CellKind::Empty;
+    }
+
+    bool sourceMaskAllows(const ScreenCell& cell, Composition::SourceMask mask)
+    {
+        switch (mask)
+        {
+        case Composition::SourceMask::GlyphCellsOnly:
+            return cell.kind == CellKind::Glyph;
+
+        case Composition::SourceMask::SpaceCellsOnly:
+            return cell.kind == CellKind::Empty;
+
+        case Composition::SourceMask::AllCells:
+        default:
+            return cell.kind == CellKind::Glyph || cell.kind == CellKind::Empty;
+        }
+    }
+
+    bool glyphPolicyAllows(const ScreenCell& cell, Composition::GlyphPolicy policy)
+    {
+        switch (policy)
+        {
+        case Composition::GlyphPolicy::None:
+            return false;
+
+        case Composition::GlyphPolicy::VisibleObject:
+            return cell.kind == CellKind::Glyph && cell.glyph != U' ';
+
+        case Composition::GlyphPolicy::AuthoredObject:
+            return cell.kind == CellKind::Glyph;
+
+        case Composition::GlyphPolicy::SolidObject:
+            return cell.kind == CellKind::Glyph || cell.kind == CellKind::Empty;
+
+        default:
+            return false;
+        }
+    }
+
+    bool overwriteRuleAllows(
+        const ScreenBuffer& destination,
+        int x,
+        int y,
+        Composition::OverwriteRule rule)
+    {
+        switch (rule)
+        {
+        case Composition::OverwriteRule::Never:
+            return false;
+
+        case Composition::OverwriteRule::Always:
+            return true;
+
+        case Composition::OverwriteRule::IfTargetEmpty:
+            return destination.getLogicalCell(x, y).kind == CellKind::Empty;
+
+        case Composition::OverwriteRule::IfTargetNonEmpty:
+            return destination.getLogicalCell(x, y).kind != CellKind::Empty;
+
+        default:
+            return true;
+        }
+    }
+
+    ScreenCell makeGlyphWriteCell(
+        const ScreenCell& sourceCell,
+        Composition::GlyphPolicy glyphPolicy)
+    {
+        if (glyphPolicy == Composition::GlyphPolicy::SolidObject &&
+            sourceCell.kind == CellKind::Empty)
+        {
+            ScreenCell authoredSpace;
+            authoredSpace.glyph = U' ';
+            authoredSpace.cluster = std::u32string(1, U' ');
+            authoredSpace.style = sourceCell.style;
+            authoredSpace.kind = CellKind::Glyph;
+            authoredSpace.width = CellWidth::One;
+            authoredSpace.metadata = sourceCell.metadata;
+            return authoredSpace;
+        }
+
+        return sourceCell;
+    }
+
+    bool isValidWideSourceCell(const ScreenBuffer& source, int x, int y)
+    {
+        if (!source.inBounds(x + 1, y))
+        {
+            return false;
+        }
+
+        return source.getCell(x + 1, y).kind == CellKind::WideTrailing;
+    }
+}
+
+void Compositor::compose(
+    const std::vector<LayerInstance>& layers,
+    Surface& destination)
+{
+    compose(layers, destination.buffer());
+}
+
+void Compositor::compose(
+    const std::vector<LayerInstance>& layers,
+    ScreenBuffer& destination)
+{
+    compose(layers, destination, Composition::WritePresets::authoredObject());
+}
+
+void Compositor::compose(
+    const std::vector<LayerInstance>& layers,
+    Surface& destination,
+    const Composition::WritePolicy& writePolicy)
+{
+    compose(layers, destination.buffer(), writePolicy);
+}
+
+void Compositor::compose(
+    const std::vector<LayerInstance>& layers,
+    ScreenBuffer& destination,
+    const Composition::WritePolicy& writePolicy)
+{
+    if (!writePolicy.canWriteAnything())
+    {
+        return;
+    }
+
+    std::vector<LayerSortEntry> sortedLayers;
+    sortedLayers.reserve(layers.size());
+
+    for (std::size_t index = 0; index < layers.size(); ++index)
+    {
+        const LayerInstance& layer = layers[index];
+
+        if (!layer.isVisible() || layer.isEmpty())
+        {
+            continue;
+        }
+
+        sortedLayers.push_back({ &layer, index });
+    }
+
+    std::stable_sort(
+        sortedLayers.begin(),
+        sortedLayers.end(),
+        [](const LayerSortEntry& lhs, const LayerSortEntry& rhs)
+        {
+            if (lhs.layer->zOrder() != rhs.layer->zOrder())
+            {
+                return lhs.layer->zOrder() < rhs.layer->zOrder();
+            }
+
+            return lhs.originalIndex < rhs.originalIndex;
+        });
+
+    for (const LayerSortEntry& entry : sortedLayers)
+    {
+        composeLayer(*entry.layer, destination, writePolicy);
+    }
+}
+
+void Compositor::composeLayer(
+    const LayerInstance& layer,
+    ScreenBuffer& destination,
+    const Composition::WritePolicy& writePolicy)
+{
+    const ScreenBuffer& source = layer.buffer();
+
+    const int sourceWidth = source.getWidth();
+    const int sourceHeight = source.getHeight();
+
+    if (sourceWidth <= 0 || sourceHeight <= 0)
+    {
+        return;
+    }
+
+    const int destinationWidth = destination.getWidth();
+    const int destinationHeight = destination.getHeight();
+
+    if (destinationWidth <= 0 || destinationHeight <= 0)
+    {
+        return;
+    }
+
+    for (int sourceY = 0; sourceY < sourceHeight; ++sourceY)
+    {
+        const int destinationY = layer.y() + sourceY;
+
+        if (destinationY < 0 || destinationY >= destinationHeight)
+        {
+            continue;
+        }
+
+        for (int sourceX = 0; sourceX < sourceWidth; ++sourceX)
+        {
+            const ScreenCell& sourceCell = source.getCell(sourceX, sourceY);
+
+            if (!isSourceLeadingCell(sourceCell))
+            {
+                continue;
+            }
+
+            if (!sourceMaskAllows(sourceCell, writePolicy.sourceMask))
+            {
+                continue;
+            }
+
+            const int destinationX = layer.x() + sourceX;
+
+            if (destinationX < 0 || destinationX >= destinationWidth)
+            {
+                continue;
+            }
+
+            const bool sourceIsWideGlyph =
+                sourceCell.kind == CellKind::Glyph &&
+                sourceCell.width == CellWidth::Two;
+
+            if (sourceIsWideGlyph)
+            {
+                if (!isValidWideSourceCell(source, sourceX, sourceY))
+                {
+                    continue;
+                }
+
+                if (!destination.inBounds(destinationX + 1, destinationY))
+                {
+                    continue;
+                }
+            }
+
+            const bool canWriteGlyph =
+                glyphPolicyAllows(sourceCell, writePolicy.glyphPolicy) &&
+                overwriteRuleAllows(
+                    destination,
+                    destinationX,
+                    destinationY,
+                    writePolicy.glyphOverwriteRule);
+
+            const bool canWriteStyle =
+                writePolicy.stylePolicy == Composition::StylePolicy::Apply &&
+                overwriteRuleAllows(
+                    destination,
+                    destinationX,
+                    destinationY,
+                    writePolicy.styleOverwriteRule);
+
+            if (!canWriteGlyph && !canWriteStyle)
+            {
+                continue;
+            }
+
+            if (canWriteGlyph)
+            {
+                const ScreenCell destinationCell =
+                    makeGlyphWriteCell(sourceCell, writePolicy.glyphPolicy);
+
+                destination.setCell(destinationX, destinationY, destinationCell);
+                continue;
+            }
+
+            if (canWriteStyle && sourceCell.kind != CellKind::Empty)
+            {
+                destination.setCellStyle(destinationX, destinationY, sourceCell.style);
+            }
+        }
+    }
+}

--- a/TUI/Rendering/Compositor.h
+++ b/TUI/Rendering/Compositor.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <vector>
+
+#include "Rendering/Composition/WritePolicy.h"
+#include "Rendering/LayerInstance.h"
+#include "Rendering/ScreenBuffer.h"
+#include "Rendering/Surface.h"
+
+class Compositor
+{
+public:
+    static void compose(
+        const std::vector<LayerInstance>& layers,
+        Surface& destination);
+
+    static void compose(
+        const std::vector<LayerInstance>& layers,
+        ScreenBuffer& destination);
+
+    static void compose(
+        const std::vector<LayerInstance>& layers,
+        Surface& destination,
+        const Composition::WritePolicy& writePolicy);
+
+    static void compose(
+        const std::vector<LayerInstance>& layers,
+        ScreenBuffer& destination,
+        const Composition::WritePolicy& writePolicy);
+
+private:
+    static void composeLayer(
+        const LayerInstance& layer,
+        ScreenBuffer& destination,
+        const Composition::WritePolicy& writePolicy);
+};

--- a/TUI/TUI.vcxproj
+++ b/TUI/TUI.vcxproj
@@ -178,6 +178,7 @@
     <ClInclude Include="Rendering\Composition\WritePolicyBuilder.h" />
     <ClInclude Include="Rendering\Composition\WritePolicyUtils.h" />
     <ClInclude Include="Rendering\Composition\WritePresets.h" />
+    <ClInclude Include="Rendering\Compositor.h" />
     <ClInclude Include="Rendering\ConsoleRenderer.h" />
     <ClInclude Include="Rendering\Diagnostics\AuthorRenderHints.h" />
     <ClInclude Include="Rendering\Diagnostics\PageCompositionDiagnostics.h" />
@@ -307,6 +308,7 @@
     <ClCompile Include="Rendering\Composition\WritePolicyBuilder.cpp" />
     <ClCompile Include="Rendering\Composition\WritePolicyUtils.cpp" />
     <ClCompile Include="Rendering\Composition\WritePresets.cpp" />
+    <ClCompile Include="Rendering\Compositor.cpp" />
     <ClCompile Include="Rendering\ConsoleRenderer.cpp" />
     <ClCompile Include="Rendering\Diagnostics\AuthorRenderHints.cpp" />
     <ClCompile Include="Rendering\Diagnostics\PageCompositionDiagnostics.cpp" />

--- a/TUI/TUI.vcxproj.filters
+++ b/TUI/TUI.vcxproj.filters
@@ -384,6 +384,9 @@
     <ClInclude Include="Rendering\LayerInstance.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="Rendering\Compositor.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Rendering\ScreenBuffer.cpp">
@@ -705,6 +708,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="Rendering\LayerInstance.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Rendering\Compositor.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
Modifies:
- TUI.vcxproj
- TUI.vcxproj.filters

Adds:
-Rendering/Compositor.h/.cpp

- Introduced Rendering/Compositor.h/.cpp as the foundation for layered UI composition
- Implemented deterministic multi-layer composition using LayerInstance metadata
  - Stable z-order sorting (zOrder ascending, then input order)
  - Hidden and empty layers are filtered out early
- Added overloads for composing into both Surface and ScreenBuffer
- Integrated full WritePolicy support (defaults to authoredObject preset)
  - Preserves existing glyph/style/depth semantics
  - Honors SourceMask, GlyphPolicy, StylePolicy, and OverwriteRule
- Implemented strict clipping against destination bounds
  - Safe handling for partially/fully out-of-bounds layers
- Added correct wide-glyph handling
  - Validates trailing cells
  - Prevents partial writes at edges
- Ensured composition obeys core rendering contract:
  - Transparent cells remain true no-op unless explicitly authored

This establishes the core composition pipeline for layered UI (panels, popups, overlapping surfaces).

Closes: #232 