### PR TITLE
Panel: add Panel UIElement with frame, background, and title rendering

### DIFF
--- a/TUI/TUI.vcxproj
+++ b/TUI/TUI.vcxproj
@@ -269,6 +269,7 @@
     <ClInclude Include="ThirdParty\zlib-1.3.1\zconf.h" />
     <ClInclude Include="ThirdParty\zlib-1.3.1\zutil.h" />
     <ClInclude Include="UI\Base\UIElement.h" />
+    <ClInclude Include="UI\Panels\Panel.h" />
     <ClInclude Include="Utilities\AssetPaths.h" />
     <ClInclude Include="Utilities\Text\TextClip.h" />
     <ClInclude Include="Utilities\Text\TextWrap.h" />
@@ -402,6 +403,7 @@
     <ClCompile Include="ThirdParty\zlib-1.3.1\uncompr.c" />
     <ClCompile Include="ThirdParty\zlib-1.3.1\zutil.c" />
     <ClCompile Include="UI\Base\UIElement.cpp" />
+    <ClCompile Include="UI\Panels\Panel.cpp" />
     <ClCompile Include="Utilities\AssetPaths.cpp" />
     <ClCompile Include="Utilities\Unicode\GraphemeSegmentation.cpp" />
     <ClCompile Include="Utilities\Unicode\GraphemeSegmentationTests.cpp" />

--- a/TUI/UI/Panels/Panel.cpp
+++ b/TUI/UI/Panels/Panel.cpp
@@ -1,0 +1,214 @@
+#include "UI/Panels/Panel.h"
+
+#include <algorithm>
+
+#include "Rendering/ScreenBuffer.h"
+#include "Rendering/Styles/AppThemes.h"
+#include "Rendering/Styles/UIThemes.h"
+#include "Rendering/Surface.h"
+#include "Utilities/Unicode/GraphemeSegmentation.h"
+#include "Utilities/Unicode/UnicodeConversion.h"
+
+namespace
+{
+    std::u32string truncateToDisplayWidth(
+        const std::u32string& text,
+        int maxWidth)
+    {
+        if (maxWidth <= 0 || text.empty())
+        {
+            return {};
+        }
+
+        std::u32string result;
+        int width = 0;
+
+        for (const TextCluster& cluster : GraphemeSegmentation::segment(text))
+        {
+            if (cluster.displayWidth <= 0)
+            {
+                result += cluster.codePoints;
+                continue;
+            }
+
+            if (width + cluster.displayWidth > maxWidth)
+            {
+                break;
+            }
+
+            result += cluster.codePoints;
+            width += cluster.displayWidth;
+        }
+
+        return result;
+    }
+}
+
+Panel::Panel()
+    : UIElement()
+    , m_backgroundStyle(AppThemes::Panel)
+    , m_frameStyle(UIThemes::Border)
+    , m_titleStyle(UIThemes::PanelTitle)
+{
+}
+
+Panel::Panel(const Rect& bounds)
+    : UIElement(bounds)
+    , m_backgroundStyle(AppThemes::Panel)
+    , m_frameStyle(UIThemes::Border)
+    , m_titleStyle(UIThemes::PanelTitle)
+{
+}
+
+Panel::Panel(const Rect& bounds, std::string title)
+    : UIElement(bounds)
+    , m_title(std::move(title))
+    , m_backgroundStyle(AppThemes::Panel)
+    , m_frameStyle(UIThemes::Border)
+    , m_titleStyle(UIThemes::PanelTitle)
+{
+}
+
+const std::string& Panel::title() const
+{
+    return m_title;
+}
+
+void Panel::setTitle(std::string title)
+{
+    m_title = std::move(title);
+}
+
+bool Panel::hasTitle() const
+{
+    return !m_title.empty();
+}
+
+const Style& Panel::backgroundStyle() const
+{
+    return m_backgroundStyle;
+}
+
+void Panel::setBackgroundStyle(const Style& style)
+{
+    m_backgroundStyle = style;
+}
+
+const Style& Panel::frameStyle() const
+{
+    return m_frameStyle;
+}
+
+void Panel::setFrameStyle(const Style& style)
+{
+    m_frameStyle = style;
+}
+
+const Style& Panel::titleStyle() const
+{
+    return m_titleStyle;
+}
+
+void Panel::setTitleStyle(const Style& style)
+{
+    m_titleStyle = style;
+}
+
+const Panel::FrameChars& Panel::frameChars() const
+{
+    return m_frameChars;
+}
+
+void Panel::setFrameChars(const FrameChars& chars)
+{
+    m_frameChars = chars;
+}
+
+Rect Panel::contentBounds() const
+{
+    const Rect panelBounds = bounds();
+
+    if (panelBounds.size.width <= 2 || panelBounds.size.height <= 2)
+    {
+        return Rect{
+            Point{ panelBounds.position.x, panelBounds.position.y },
+            Size{ 0, 0 }
+        };
+    }
+
+    return Rect{
+        Point{ panelBounds.position.x + 1, panelBounds.position.y + 1 },
+        Size{ panelBounds.size.width - 2, panelBounds.size.height - 2 }
+    };
+}
+
+void Panel::draw(Surface& surface)
+{
+    if (!isVisible())
+    {
+        return;
+    }
+
+    const Rect panelBounds = bounds();
+
+    if (panelBounds.size.width <= 0 || panelBounds.size.height <= 0)
+    {
+        return;
+    }
+
+    ScreenBuffer& buffer = surface.buffer();
+
+    buffer.fillRect(panelBounds, U' ', m_backgroundStyle);
+
+    if (panelBounds.size.width >= 2 && panelBounds.size.height >= 2)
+    {
+        const Style& frameRenderStyle = isEnabled()
+            ? m_frameStyle
+            : UIThemes::DisabledText;
+
+        buffer.drawFrame(
+            panelBounds,
+            frameRenderStyle,
+            m_frameChars.topLeft,
+            m_frameChars.topRight,
+            m_frameChars.bottomLeft,
+            m_frameChars.bottomRight,
+            m_frameChars.horizontal,
+            m_frameChars.vertical);
+    }
+
+    drawTitle(surface);
+}
+
+void Panel::drawTitle(Surface& surface) const
+{
+    if (!hasTitle())
+    {
+        return;
+    }
+
+    const Rect panelBounds = bounds();
+
+    if (panelBounds.size.width <= 4 || panelBounds.size.height <= 0)
+    {
+        return;
+    }
+
+    const int titleX = panelBounds.position.x + 2;
+    const int titleY = panelBounds.position.y;
+    const int maxTitleWidth = std::max(0, panelBounds.size.width - 4);
+
+    std::u32string titleText = UnicodeConversion::utf8ToU32(m_title);
+    titleText = truncateToDisplayWidth(titleText, maxTitleWidth);
+
+    if (titleText.empty())
+    {
+        return;
+    }
+
+    const Style& titleRenderStyle = isEnabled()
+        ? m_titleStyle
+        : UIThemes::DisabledText;
+
+    surface.buffer().writeText(titleX, titleY, titleText, titleRenderStyle);
+}

--- a/TUI/UI/Panels/Panel.h
+++ b/TUI/UI/Panels/Panel.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <string>
+
+#include "Core/Rect.h"
+#include "Rendering/Styles/Style.h"
+#include "UI/Base/UIElement.h"
+
+class Surface;
+
+class Panel : public UIElement
+{
+public:
+    struct FrameChars
+    {
+        char32_t topLeft = U'+';
+        char32_t topRight = U'+';
+        char32_t bottomLeft = U'+';
+        char32_t bottomRight = U'+';
+        char32_t horizontal = U'-';
+        char32_t vertical = U'|';
+    };
+
+public:
+    Panel();
+    explicit Panel(const Rect& bounds);
+    Panel(const Rect& bounds, std::string title);
+
+    const std::string& title() const;
+    void setTitle(std::string title);
+    bool hasTitle() const;
+
+    const Style& backgroundStyle() const;
+    void setBackgroundStyle(const Style& style);
+
+    const Style& frameStyle() const;
+    void setFrameStyle(const Style& style);
+
+    const Style& titleStyle() const;
+    void setTitleStyle(const Style& style);
+
+    const FrameChars& frameChars() const;
+    void setFrameChars(const FrameChars& chars);
+
+    Rect contentBounds() const;
+
+    void draw(Surface& surface) override;
+
+private:
+    void drawTitle(Surface& surface) const;
+
+private:
+    std::string m_title;
+
+    Style m_backgroundStyle;
+    Style m_frameStyle;
+    Style m_titleStyle;
+
+    FrameChars m_frameChars;
+};


### PR DESCRIPTION
Modifies:
- TUI.vcxproj

Adds:
- UI/Panels/Panel.h/.cpp

- Panel derives from UIElement and provides a reusable rectangular container primitive

Core features:
- Rectangular background fill using existing ScreenBuffer/Surface pipeline
- Configurable frame/border rendering with customizable frame characters
- Title support with clean API (setTitle / hasTitle / title)
- Grapheme-aware UTF-8 title rendering with safe width clipping
- Disabled state styling for frame and title via UIThemes::DisabledText
- contentBounds() helper for future child/layout usage

Design considerations:
- Uses existing TUI rendering primitives (Surface, ScreenBuffer, Style, Themes)
- Preserves strict separation of concerns (no windowing, modal, or popup behavior)
- Fully respects UIElement visibility/enabled flags
- Safe clipping and bounds validation at all stages
- Avoids introducing layout/container policy (keeps Panel as a pure visual primitive)

Notes:
- Title is rendered on the top border with left padding and width clipping
- Frame rendering only occurs when bounds are large enough (>= 2x2)
- Background always fills full panel bounds for deterministic composition

This establishes the foundational visual container for upcoming Window, Popup, and layout systems.

Closes: #234 