### PR TITLE
Window: Add Window class as top-level Panel with modal semantics

### DIFF
--- a/TUI/TUI.vcxproj
+++ b/TUI/TUI.vcxproj
@@ -270,6 +270,7 @@
     <ClInclude Include="ThirdParty\zlib-1.3.1\zutil.h" />
     <ClInclude Include="UI\Base\UIElement.h" />
     <ClInclude Include="UI\Panels\Panel.h" />
+    <ClInclude Include="UI\Panels\Window.h" />
     <ClInclude Include="Utilities\AssetPaths.h" />
     <ClInclude Include="Utilities\Text\TextClip.h" />
     <ClInclude Include="Utilities\Text\TextWrap.h" />
@@ -404,6 +405,7 @@
     <ClCompile Include="ThirdParty\zlib-1.3.1\zutil.c" />
     <ClCompile Include="UI\Base\UIElement.cpp" />
     <ClCompile Include="UI\Panels\Panel.cpp" />
+    <ClCompile Include="UI\Panels\Window.cpp" />
     <ClCompile Include="Utilities\AssetPaths.cpp" />
     <ClCompile Include="Utilities\Unicode\GraphemeSegmentation.cpp" />
     <ClCompile Include="Utilities\Unicode\GraphemeSegmentationTests.cpp" />

--- a/TUI/UI/Panels/Window.cpp
+++ b/TUI/UI/Panels/Window.cpp
@@ -1,0 +1,34 @@
+#include "UI/Panels/Window.h"
+
+#include <utility>
+
+Window::Window()
+    : Panel()
+{
+}
+
+Window::Window(const Rect& bounds)
+    : Panel(bounds)
+{
+}
+
+Window::Window(const Rect& bounds, std::string title)
+    : Panel(bounds, std::move(title))
+{
+}
+
+Window::Window(const Rect& bounds, std::string title, bool modal)
+    : Panel(bounds, std::move(title))
+    , m_modal(modal)
+{
+}
+
+bool Window::isModal() const
+{
+    return m_modal;
+}
+
+void Window::setModal(bool modal)
+{
+    m_modal = modal;
+}

--- a/TUI/UI/Panels/Window.h
+++ b/TUI/UI/Panels/Window.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <string>
+
+#include "Core/Rect.h"
+#include "UI/Panels/Panel.h"
+
+class Window : public Panel
+{
+public:
+    Window();
+    explicit Window(const Rect& bounds);
+    Window(const Rect& bounds, std::string title);
+    Window(const Rect& bounds, std::string title, bool modal);
+
+    bool isModal() const;
+    void setModal(bool modal);
+
+private:
+    bool m_modal = false;
+};


### PR DESCRIPTION
Modifies:
- TUI.vcxproj

Adds:
- UI/Panels/Window.h/.cpp

- Implemented Window as a lightweight subclass of Panel
- Added modal flag with isModal() and setModal() API
- Provided constructor overloads for bounds, title, and modal state
- Reused all Panel rendering and layout behavior (no duplication)
- Preserved UIElement visibility/enabled semantics
- Designed for future integration with WindowManager (z-order, modal routing)

This establishes the core Window abstraction without introducing input handling, lifecycle management, or popup behavior, keeping the class minimal and extensible.

Closes: #235 