### PR TITLE
PopupWindow: add PopupWindow with open/close lifecycle and modal support

### DIFF
--- a/TUI/TUI.vcxproj
+++ b/TUI/TUI.vcxproj
@@ -270,6 +270,7 @@
     <ClInclude Include="ThirdParty\zlib-1.3.1\zutil.h" />
     <ClInclude Include="UI\Base\UIElement.h" />
     <ClInclude Include="UI\Panels\Panel.h" />
+    <ClInclude Include="UI\Panels\PopupWindow.h" />
     <ClInclude Include="UI\Panels\Window.h" />
     <ClInclude Include="Utilities\AssetPaths.h" />
     <ClInclude Include="Utilities\Text\TextClip.h" />
@@ -405,6 +406,7 @@
     <ClCompile Include="ThirdParty\zlib-1.3.1\zutil.c" />
     <ClCompile Include="UI\Base\UIElement.cpp" />
     <ClCompile Include="UI\Panels\Panel.cpp" />
+    <ClCompile Include="UI\Panels\PopupWindow.cpp" />
     <ClCompile Include="UI\Panels\Window.cpp" />
     <ClCompile Include="Utilities\AssetPaths.cpp" />
     <ClCompile Include="Utilities\Unicode\GraphemeSegmentation.cpp" />

--- a/TUI/UI/Panels/PopupWindow.cpp
+++ b/TUI/UI/Panels/PopupWindow.cpp
@@ -1,0 +1,71 @@
+#include "UI/Panels/PopupWindow.h"
+
+#include <utility>
+
+PopupWindow::PopupWindow()
+    : Window()
+{
+    close();
+}
+
+PopupWindow::PopupWindow(const Rect& bounds)
+    : Window(bounds)
+{
+    close();
+}
+
+PopupWindow::PopupWindow(const Rect& bounds, std::string title)
+    : Window(bounds, std::move(title))
+{
+    close();
+}
+
+PopupWindow::PopupWindow(const Rect& bounds, std::string title, bool modal)
+    : Window(bounds, std::move(title), modal)
+{
+    close();
+}
+
+bool PopupWindow::isOpen() const
+{
+    return m_open;
+}
+
+void PopupWindow::setOpen(bool open)
+{
+    if (open)
+    {
+        this->open();
+    }
+    else
+    {
+        close();
+    }
+}
+
+void PopupWindow::open()
+{
+    m_open = true;
+    show();
+}
+
+void PopupWindow::close()
+{
+    m_open = false;
+    hide();
+}
+
+void PopupWindow::toggle()
+{
+    setOpen(!m_open);
+}
+
+void PopupWindow::draw(Surface& surface)
+{
+    if (!m_open || !isVisible())
+    {
+        return;
+    }
+
+    Window::draw(surface);
+}

--- a/TUI/UI/Panels/PopupWindow.h
+++ b/TUI/UI/Panels/PopupWindow.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <string>
+
+#include "Core/Rect.h"
+#include "UI/Panels/Window.h"
+
+class Surface;
+
+class PopupWindow : public Window
+{
+public:
+    PopupWindow();
+    explicit PopupWindow(const Rect& bounds);
+    PopupWindow(const Rect& bounds, std::string title);
+    PopupWindow(const Rect& bounds, std::string title, bool modal);
+
+    bool isOpen() const;
+    void setOpen(bool open);
+
+    void open();
+    void close();
+    void toggle();
+
+    void draw(Surface& surface) override;
+
+private:
+    bool m_open = false;
+};


### PR DESCRIPTION
Modifies:
- TUI.vcxproj

Adds:
- UI/Panels/PopupWindow.h/.cpp

- Introduce PopupWindow as a specialization of Window
- Add open(), close(), toggle(), setOpen(), and isOpen() API
- Maintain internal open state (m_open) independent of construction
- Synchronize open/close with UIElement visibility via show()/hide()
- Ensure closed popups are not rendered (draw early-exit)
- Preserve modal behavior through inherited Window flag
- Delegate all rendering to Window/Panel (no duplication)
- Keep implementation independent of WindowManager and input routing

This establishes a reusable popup abstraction for future dialogs and widgets without introducing window management or interaction complexity at this stage.

Closes: #236 