### PR TITLE
WindowManager: add WindowManager with z-order, visibility control, an…

### DIFF
--- a/TUI/TUI.vcxproj
+++ b/TUI/TUI.vcxproj
@@ -269,6 +269,7 @@
     <ClInclude Include="ThirdParty\zlib-1.3.1\zconf.h" />
     <ClInclude Include="ThirdParty\zlib-1.3.1\zutil.h" />
     <ClInclude Include="UI\Base\UIElement.h" />
+    <ClInclude Include="UI\Base\WindowManager.h" />
     <ClInclude Include="UI\Panels\Panel.h" />
     <ClInclude Include="UI\Panels\PopupWindow.h" />
     <ClInclude Include="UI\Panels\Window.h" />
@@ -405,6 +406,7 @@
     <ClCompile Include="ThirdParty\zlib-1.3.1\uncompr.c" />
     <ClCompile Include="ThirdParty\zlib-1.3.1\zutil.c" />
     <ClCompile Include="UI\Base\UIElement.cpp" />
+    <ClCompile Include="UI\Base\WindowManager.cpp" />
     <ClCompile Include="UI\Panels\Panel.cpp" />
     <ClCompile Include="UI\Panels\PopupWindow.cpp" />
     <ClCompile Include="UI\Panels\Window.cpp" />

--- a/TUI/UI/Base/WindowManager.cpp
+++ b/TUI/UI/Base/WindowManager.cpp
@@ -1,0 +1,386 @@
+#include "UI/Base/WindowManager.h"
+
+#include <algorithm>
+#include <utility>
+
+#include "Core/Rect.h"
+#include "UI/Panels/Window.h"
+
+WindowManager::WindowManager() = default;
+
+WindowManager::~WindowManager() = default;
+
+void WindowManager::addWindow(Window& window)
+{
+    if (contains(window))
+    {
+        return;
+    }
+
+    m_windows.push_back({
+        &window,
+        nextFrontZOrder(),
+        m_nextInsertionOrder++
+        });
+
+    sortWindows();
+}
+
+void WindowManager::removeWindow(Window& window)
+{
+    m_windows.erase(
+        std::remove_if(
+            m_windows.begin(),
+            m_windows.end(),
+            [&window](const ManagedWindow& entry)
+            {
+                return entry.window == &window;
+            }),
+        m_windows.end());
+}
+
+void WindowManager::clear()
+{
+    m_windows.clear();
+}
+
+bool WindowManager::contains(const Window& window) const
+{
+    return findEntry(window) != nullptr;
+}
+
+std::size_t WindowManager::count() const
+{
+    return m_windows.size();
+}
+
+bool WindowManager::empty() const
+{
+    return m_windows.empty();
+}
+
+void WindowManager::show(Window& window)
+{
+    if (!contains(window))
+    {
+        addWindow(window);
+    }
+
+    window.show();
+}
+
+void WindowManager::hide(Window& window)
+{
+    if (ManagedWindow* entry = findEntry(window))
+    {
+        entry->window->hide();
+    }
+}
+
+void WindowManager::bringToFront(Window& window)
+{
+    ManagedWindow* entry = findEntry(window);
+
+    if (entry == nullptr)
+    {
+        addWindow(window);
+        return;
+    }
+
+    entry->zOrder = nextFrontZOrder();
+    entry->insertionOrder = m_nextInsertionOrder++;
+
+    sortWindows();
+}
+
+void WindowManager::sendToBack(Window& window)
+{
+    ManagedWindow* entry = findEntry(window);
+
+    if (entry == nullptr)
+    {
+        addWindow(window);
+        entry = findEntry(window);
+    }
+
+    if (entry == nullptr)
+    {
+        return;
+    }
+
+    entry->zOrder = nextBackZOrder();
+    entry->insertionOrder = m_nextInsertionOrder++;
+
+    sortWindows();
+}
+
+void WindowManager::setZOrder(Window& window, int zOrder)
+{
+    ManagedWindow* entry = findEntry(window);
+
+    if (entry == nullptr)
+    {
+        addWindow(window);
+        entry = findEntry(window);
+    }
+
+    if (entry == nullptr)
+    {
+        return;
+    }
+
+    entry->zOrder = zOrder;
+    entry->insertionOrder = m_nextInsertionOrder++;
+
+    sortWindows();
+}
+
+int WindowManager::zOrderOf(const Window& window) const
+{
+    const ManagedWindow* entry = findEntry(window);
+    return entry != nullptr ? entry->zOrder : 0;
+}
+
+Window* WindowManager::topWindow()
+{
+    for (auto it = m_windows.rbegin(); it != m_windows.rend(); ++it)
+    {
+        if (it->window != nullptr && it->window->isVisible())
+        {
+            return it->window;
+        }
+    }
+
+    return nullptr;
+}
+
+const Window* WindowManager::topWindow() const
+{
+    for (auto it = m_windows.rbegin(); it != m_windows.rend(); ++it)
+    {
+        if (it->window != nullptr && it->window->isVisible())
+        {
+            return it->window;
+        }
+    }
+
+    return nullptr;
+}
+
+Window* WindowManager::topModalWindow()
+{
+    for (auto it = m_windows.rbegin(); it != m_windows.rend(); ++it)
+    {
+        if (it->window != nullptr &&
+            it->window->isVisible() &&
+            it->window->isModal())
+        {
+            return it->window;
+        }
+    }
+
+    return nullptr;
+}
+
+const Window* WindowManager::topModalWindow() const
+{
+    for (auto it = m_windows.rbegin(); it != m_windows.rend(); ++it)
+    {
+        if (it->window != nullptr &&
+            it->window->isVisible() &&
+            it->window->isModal())
+        {
+            return it->window;
+        }
+    }
+
+    return nullptr;
+}
+
+bool WindowManager::hasModalWindow() const
+{
+    return topModalWindow() != nullptr;
+}
+
+bool WindowManager::canRouteTo(const Window& window) const
+{
+    if (!window.isVisible() || !window.isEnabled())
+    {
+        return false;
+    }
+
+    const ManagedWindow* targetEntry = findEntry(window);
+
+    if (targetEntry == nullptr)
+    {
+        return false;
+    }
+
+    const Window* modalWindow = topModalWindow();
+
+    if (modalWindow == nullptr)
+    {
+        return true;
+    }
+
+    const ManagedWindow* modalEntry = findEntry(*modalWindow);
+
+    if (modalEntry == nullptr)
+    {
+        return true;
+    }
+
+    return targetEntry->zOrder >= modalEntry->zOrder;
+}
+
+void WindowManager::update(double deltaTime)
+{
+    for (ManagedWindow& entry : m_windows)
+    {
+        if (entry.window == nullptr)
+        {
+            continue;
+        }
+
+        if (!canRouteTo(*entry.window))
+        {
+            continue;
+        }
+
+        entry.window->update(deltaTime);
+    }
+}
+
+void WindowManager::draw(Surface& surface)
+{
+    sortWindows();
+
+    for (ManagedWindow& entry : m_windows)
+    {
+        if (entry.window == nullptr || !entry.window->isVisible())
+        {
+            continue;
+        }
+
+        entry.window->draw(surface);
+    }
+}
+
+std::vector<LayerInstance> WindowManager::buildLayers()
+{
+    sortWindows();
+
+    std::vector<LayerInstance> layers;
+    layers.reserve(m_windows.size());
+
+    for (ManagedWindow& entry : m_windows)
+    {
+        Window* window = entry.window;
+
+        if (window == nullptr || !window->isVisible())
+        {
+            continue;
+        }
+
+        const Rect originalBounds = window->bounds();
+
+        if (originalBounds.size.width <= 0 || originalBounds.size.height <= 0)
+        {
+            continue;
+        }
+
+        Surface layerSurface(
+            originalBounds.size.width,
+            originalBounds.size.height);
+
+        window->setPosition(0, 0);
+        window->draw(layerSurface);
+        window->setBounds(originalBounds);
+
+        layers.emplace_back(
+            std::move(layerSurface),
+            originalBounds.position,
+            entry.zOrder,
+            true);
+    }
+
+    return layers;
+}
+
+WindowManager::ManagedWindow* WindowManager::findEntry(Window& window)
+{
+    auto it = std::find_if(
+        m_windows.begin(),
+        m_windows.end(),
+        [&window](const ManagedWindow& entry)
+        {
+            return entry.window == &window;
+        });
+
+    return it != m_windows.end() ? &(*it) : nullptr;
+}
+
+const WindowManager::ManagedWindow* WindowManager::findEntry(const Window& window) const
+{
+    auto it = std::find_if(
+        m_windows.begin(),
+        m_windows.end(),
+        [&window](const ManagedWindow& entry)
+        {
+            return entry.window == &window;
+        });
+
+    return it != m_windows.end() ? &(*it) : nullptr;
+}
+
+void WindowManager::sortWindows()
+{
+    std::stable_sort(
+        m_windows.begin(),
+        m_windows.end(),
+        [](const ManagedWindow& lhs, const ManagedWindow& rhs)
+        {
+            if (lhs.zOrder != rhs.zOrder)
+            {
+                return lhs.zOrder < rhs.zOrder;
+            }
+
+            return lhs.insertionOrder < rhs.insertionOrder;
+        });
+}
+
+int WindowManager::nextFrontZOrder() const
+{
+    if (m_windows.empty())
+    {
+        return 0;
+    }
+
+    const auto it = std::max_element(
+        m_windows.begin(),
+        m_windows.end(),
+        [](const ManagedWindow& lhs, const ManagedWindow& rhs)
+        {
+            return lhs.zOrder < rhs.zOrder;
+        });
+
+    return it->zOrder + 1;
+}
+
+int WindowManager::nextBackZOrder() const
+{
+    if (m_windows.empty())
+    {
+        return 0;
+    }
+
+    const auto it = std::min_element(
+        m_windows.begin(),
+        m_windows.end(),
+        [](const ManagedWindow& lhs, const ManagedWindow& rhs)
+        {
+            return lhs.zOrder < rhs.zOrder;
+        });
+
+    return it->zOrder - 1;
+}

--- a/TUI/UI/Base/WindowManager.h
+++ b/TUI/UI/Base/WindowManager.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <cstddef>
+#include <vector>
+
+#include "Rendering/LayerInstance.h"
+#include "Rendering/Surface.h"
+
+class Window;
+
+class WindowManager
+{
+public:
+    WindowManager();
+    ~WindowManager();
+
+    void addWindow(Window& window);
+    void removeWindow(Window& window);
+    void clear();
+
+    bool contains(const Window& window) const;
+    std::size_t count() const;
+    bool empty() const;
+
+    void show(Window& window);
+    void hide(Window& window);
+
+    void bringToFront(Window& window);
+    void sendToBack(Window& window);
+
+    void setZOrder(Window& window, int zOrder);
+    int zOrderOf(const Window& window) const;
+
+    Window* topWindow();
+    const Window* topWindow() const;
+
+    Window* topModalWindow();
+    const Window* topModalWindow() const;
+
+    bool hasModalWindow() const;
+    bool canRouteTo(const Window& window) const;
+
+    void update(double deltaTime);
+    void draw(Surface& surface);
+
+    std::vector<LayerInstance> buildLayers();
+
+private:
+    struct ManagedWindow
+    {
+        Window* window = nullptr;
+        int zOrder = 0;
+        std::size_t insertionOrder = 0;
+    };
+
+private:
+    ManagedWindow* findEntry(Window& window);
+    const ManagedWindow* findEntry(const Window& window) const;
+
+    void sortWindows();
+    int nextFrontZOrder() const;
+    int nextBackZOrder() const;
+
+private:
+    std::vector<ManagedWindow> m_windows;
+    std::size_t m_nextInsertionOrder = 0;
+};


### PR DESCRIPTION
…d modal routing

Modifies:
- TUI.vcxproj

Adds:
- UI/Base/WindowManager.h/.cpp

- Manage non-owning collection of Window instances with stable ordering
- Implement z-order system with deterministic tie-breaking via insertion order
- Add window lifecycle helpers:
  - addWindow(), removeWindow(), clear()
  - show(), hide()
- Provide z-order controls:
  - bringToFront(), sendToBack(), setZOrder(), zOrderOf()
- Implement top-level queries:
  - topWindow(), topModalWindow(), hasModalWindow()
- Add modal routing model:
  - topmost visible modal window establishes interaction floor
  - canRouteTo() enforces routing rules for update/input layers
- Implement update() with routing-aware dispatch
- Implement draw() with ordered rendering using existing Window::draw()
- Add optional compositor integration:
  - buildLayers() converts windows into LayerInstance surfaces
- Ensure no ownership conflicts with existing TUI lifetime model
- Keep WindowManager independent of terminal output and screen-specific logic

This establishes the core window orchestration foundation for panels, popups, and future dialogs while remaining minimal, deterministic, and compositor-compatible.

Closes: #237 