### PR TITLE
MenuSystem: Add MenuItem and MenuModel foundation for menu data handling

### DIFF
--- a/TUI/TUI.vcxproj
+++ b/TUI/TUI.vcxproj
@@ -277,6 +277,8 @@
     <ClInclude Include="UI\Base\FocusManager.h" />
     <ClInclude Include="UI\Base\UIElement.h" />
     <ClInclude Include="UI\Base\WindowManager.h" />
+    <ClInclude Include="UI\Menus\MenuItem.h" />
+    <ClInclude Include="UI\Menus\MenuModel.h" />
     <ClInclude Include="UI\Panels\EffectWindow.h" />
     <ClInclude Include="UI\Panels\Panel.h" />
     <ClInclude Include="UI\Panels\PopupWindow.h" />
@@ -422,6 +424,8 @@
     <ClCompile Include="UI\Base\FocusManager.cpp" />
     <ClCompile Include="UI\Base\UIElement.cpp" />
     <ClCompile Include="UI\Base\WindowManager.cpp" />
+    <ClCompile Include="UI\Menus\MenuItem.cpp" />
+    <ClCompile Include="UI\Menus\MenuModel.cpp" />
     <ClCompile Include="UI\Panels\EffectWindow.cpp" />
     <ClCompile Include="UI\Panels\Panel.cpp" />
     <ClCompile Include="UI\Panels\PopupWindow.cpp" />

--- a/TUI/UI/Menus/MenuItem.cpp
+++ b/TUI/UI/Menus/MenuItem.cpp
@@ -1,0 +1,84 @@
+#include "UI/Menus/MenuItem.h"
+
+#include <utility>
+
+namespace UI::Menus
+{
+    MenuItem::MenuItem(std::string label, std::string commandId)
+        : m_label(std::move(label))
+        , m_commandId(std::move(commandId))
+    {
+    }
+
+    MenuItem::MenuItem(std::string label, std::string commandId, std::string description)
+        : m_label(std::move(label))
+        , m_commandId(std::move(commandId))
+        , m_description(std::move(description))
+    {
+    }
+
+    const std::string& MenuItem::label() const
+    {
+        return m_label;
+    }
+
+    void MenuItem::setLabel(std::string label)
+    {
+        m_label = std::move(label);
+    }
+
+    const std::string& MenuItem::commandId() const
+    {
+        return m_commandId;
+    }
+
+    void MenuItem::setCommandId(std::string commandId)
+    {
+        m_commandId = std::move(commandId);
+    }
+
+    const std::string& MenuItem::description() const
+    {
+        return m_description;
+    }
+
+    void MenuItem::setDescription(std::string description)
+    {
+        m_description = std::move(description);
+    }
+
+    bool MenuItem::hasDescription() const
+    {
+        return !m_description.empty();
+    }
+
+    bool MenuItem::isEnabled() const
+    {
+        return m_enabled;
+    }
+
+    void MenuItem::setEnabled(bool enabled)
+    {
+        m_enabled = enabled;
+    }
+
+    bool MenuItem::isChecked() const
+    {
+        return m_checked;
+    }
+
+    void MenuItem::setChecked(bool checked)
+    {
+        m_checked = checked;
+    }
+
+    bool MenuItem::isSelected() const
+    {
+        return m_selected;
+    }
+
+    void MenuItem::setSelected(bool selected)
+    {
+        m_selected = selected;
+    }
+}

--- a/TUI/UI/Menus/MenuItem.h
+++ b/TUI/UI/Menus/MenuItem.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <string>
+
+namespace UI::Menus
+{
+    class MenuItem
+    {
+    public:
+        MenuItem() = default;
+        MenuItem(std::string label, std::string commandId);
+        MenuItem(std::string label, std::string commandId, std::string description);
+
+        const std::string& label() const;
+        void setLabel(std::string label);
+
+        const std::string& commandId() const;
+        void setCommandId(std::string commandId);
+
+        const std::string& description() const;
+        void setDescription(std::string description);
+        bool hasDescription() const;
+
+        bool isEnabled() const;
+        void setEnabled(bool enabled);
+
+        bool isChecked() const;
+        void setChecked(bool checked);
+
+        bool isSelected() const;
+        void setSelected(bool selected);
+
+    private:
+        std::string m_label;
+        std::string m_commandId;
+        std::string m_description;
+
+        bool m_enabled = true;
+        bool m_checked = false;
+        bool m_selected = false;
+    };
+}

--- a/TUI/UI/Menus/MenuModel.cpp
+++ b/TUI/UI/Menus/MenuModel.cpp
@@ -1,0 +1,316 @@
+#include "UI/Menus/MenuModel.h"
+
+#include <utility>
+
+namespace UI::Menus
+{
+    void MenuModel::clear()
+    {
+        m_items.clear();
+    }
+
+    bool MenuModel::isEmpty() const
+    {
+        return m_items.empty();
+    }
+
+    std::size_t MenuModel::itemCount() const
+    {
+        return m_items.size();
+    }
+
+    std::size_t MenuModel::addItem(MenuItem item)
+    {
+        m_items.push_back(std::move(item));
+        return m_items.size() - 1;
+    }
+
+    std::size_t MenuModel::addItem(std::string label, std::string commandId)
+    {
+        return addItem(MenuItem(std::move(label), std::move(commandId)));
+    }
+
+    std::size_t MenuModel::addItem(std::string label, std::string commandId, std::string description)
+    {
+        return addItem(MenuItem(std::move(label), std::move(commandId), std::move(description)));
+    }
+
+    bool MenuModel::removeItemAt(std::size_t index)
+    {
+        if (!isValidIndex(index))
+        {
+            return false;
+        }
+
+        m_items.erase(m_items.begin() + static_cast<std::ptrdiff_t>(index));
+        return true;
+    }
+
+    bool MenuModel::removeItemByCommandId(const std::string& commandId)
+    {
+        const std::optional<std::size_t> index = indexOfCommandId(commandId);
+
+        if (!index.has_value())
+        {
+            return false;
+        }
+
+        return removeItemAt(index.value());
+    }
+
+    MenuItem* MenuModel::itemAt(std::size_t index)
+    {
+        if (!isValidIndex(index))
+        {
+            return nullptr;
+        }
+
+        return &m_items[index];
+    }
+
+    const MenuItem* MenuModel::itemAt(std::size_t index) const
+    {
+        if (!isValidIndex(index))
+        {
+            return nullptr;
+        }
+
+        return &m_items[index];
+    }
+
+    MenuItem* MenuModel::findByCommandId(const std::string& commandId)
+    {
+        const std::optional<std::size_t> index = indexOfCommandId(commandId);
+
+        if (!index.has_value())
+        {
+            return nullptr;
+        }
+
+        return &m_items[index.value()];
+    }
+
+    const MenuItem* MenuModel::findByCommandId(const std::string& commandId) const
+    {
+        const std::optional<std::size_t> index = indexOfCommandId(commandId);
+
+        if (!index.has_value())
+        {
+            return nullptr;
+        }
+
+        return &m_items[index.value()];
+    }
+
+    std::optional<std::size_t> MenuModel::indexOfCommandId(const std::string& commandId) const
+    {
+        for (std::size_t index = 0; index < m_items.size(); ++index)
+        {
+            if (m_items[index].commandId() == commandId)
+            {
+                return index;
+            }
+        }
+
+        return std::nullopt;
+    }
+
+    bool MenuModel::setLabel(std::size_t index, std::string label)
+    {
+        MenuItem* item = itemAt(index);
+
+        if (item == nullptr)
+        {
+            return false;
+        }
+
+        item->setLabel(std::move(label));
+        return true;
+    }
+
+    bool MenuModel::setCommandId(std::size_t index, std::string commandId)
+    {
+        MenuItem* item = itemAt(index);
+
+        if (item == nullptr)
+        {
+            return false;
+        }
+
+        item->setCommandId(std::move(commandId));
+        return true;
+    }
+
+    bool MenuModel::setDescription(std::size_t index, std::string description)
+    {
+        MenuItem* item = itemAt(index);
+
+        if (item == nullptr)
+        {
+            return false;
+        }
+
+        item->setDescription(std::move(description));
+        return true;
+    }
+
+    bool MenuModel::setEnabled(std::size_t index, bool enabled)
+    {
+        MenuItem* item = itemAt(index);
+
+        if (item == nullptr)
+        {
+            return false;
+        }
+
+        item->setEnabled(enabled);
+        return true;
+    }
+
+    bool MenuModel::setChecked(std::size_t index, bool checked)
+    {
+        MenuItem* item = itemAt(index);
+
+        if (item == nullptr)
+        {
+            return false;
+        }
+
+        item->setChecked(checked);
+        return true;
+    }
+
+    bool MenuModel::setSelected(std::size_t index, bool selected)
+    {
+        MenuItem* item = itemAt(index);
+
+        if (item == nullptr)
+        {
+            return false;
+        }
+
+        item->setSelected(selected);
+        return true;
+    }
+
+    const std::vector<MenuItem>& MenuModel::items() const
+    {
+        return m_items;
+    }
+
+    bool MenuModel::hasEnabledItems() const
+    {
+        return firstEnabledIndex().has_value();
+    }
+
+    std::optional<std::size_t> MenuModel::firstEnabledIndex() const
+    {
+        for (std::size_t index = 0; index < m_items.size(); ++index)
+        {
+            if (m_items[index].isEnabled())
+            {
+                return index;
+            }
+        }
+
+        return std::nullopt;
+    }
+
+    std::optional<std::size_t> MenuModel::lastEnabledIndex() const
+    {
+        for (std::size_t remaining = m_items.size(); remaining > 0; --remaining)
+        {
+            const std::size_t index = remaining - 1;
+
+            if (m_items[index].isEnabled())
+            {
+                return index;
+            }
+        }
+
+        return std::nullopt;
+    }
+
+    std::optional<std::size_t> MenuModel::nextEnabledIndex(
+        std::size_t currentIndex,
+        MenuNavigationMode mode) const
+    {
+        if (m_items.empty())
+        {
+            return std::nullopt;
+        }
+
+        const std::size_t startIndex = currentIndex < m_items.size()
+            ? currentIndex
+            : m_items.size() - 1;
+
+        for (std::size_t index = startIndex + 1; index < m_items.size(); ++index)
+        {
+            if (m_items[index].isEnabled())
+            {
+                return index;
+            }
+        }
+
+        if (mode == MenuNavigationMode::Clamp)
+        {
+            return std::nullopt;
+        }
+
+        for (std::size_t index = 0; index <= startIndex && index < m_items.size(); ++index)
+        {
+            if (m_items[index].isEnabled())
+            {
+                return index;
+            }
+        }
+
+        return std::nullopt;
+    }
+
+    std::optional<std::size_t> MenuModel::previousEnabledIndex(
+        std::size_t currentIndex,
+        MenuNavigationMode mode) const
+    {
+        if (m_items.empty())
+        {
+            return std::nullopt;
+        }
+
+        const std::size_t startIndex = currentIndex < m_items.size()
+            ? currentIndex
+            : m_items.size() - 1;
+
+        for (std::size_t remaining = startIndex; remaining > 0; --remaining)
+        {
+            const std::size_t index = remaining - 1;
+
+            if (m_items[index].isEnabled())
+            {
+                return index;
+            }
+        }
+
+        if (mode == MenuNavigationMode::Clamp)
+        {
+            return std::nullopt;
+        }
+
+        for (std::size_t remaining = m_items.size(); remaining > startIndex + 1; --remaining)
+        {
+            const std::size_t index = remaining - 1;
+
+            if (m_items[index].isEnabled())
+            {
+                return index;
+            }
+        }
+
+        return std::nullopt;
+    }
+
+    bool MenuModel::isValidIndex(std::size_t index) const
+    {
+        return index < m_items.size();
+    }
+}

--- a/TUI/UI/Menus/MenuModel.h
+++ b/TUI/UI/Menus/MenuModel.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include <cstddef>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "UI/Menus/MenuItem.h"
+
+namespace UI::Menus
+{
+    enum class MenuNavigationMode
+    {
+        Clamp,
+        Wrap
+    };
+
+    class MenuModel
+    {
+    public:
+        MenuModel() = default;
+
+        void clear();
+
+        bool isEmpty() const;
+        std::size_t itemCount() const;
+
+        std::size_t addItem(MenuItem item);
+        std::size_t addItem(std::string label, std::string commandId);
+        std::size_t addItem(std::string label, std::string commandId, std::string description);
+
+        bool removeItemAt(std::size_t index);
+        bool removeItemByCommandId(const std::string& commandId);
+
+        MenuItem* itemAt(std::size_t index);
+        const MenuItem* itemAt(std::size_t index) const;
+
+        MenuItem* findByCommandId(const std::string& commandId);
+        const MenuItem* findByCommandId(const std::string& commandId) const;
+
+        std::optional<std::size_t> indexOfCommandId(const std::string& commandId) const;
+
+        bool setLabel(std::size_t index, std::string label);
+        bool setCommandId(std::size_t index, std::string commandId);
+        bool setDescription(std::size_t index, std::string description);
+        bool setEnabled(std::size_t index, bool enabled);
+        bool setChecked(std::size_t index, bool checked);
+        bool setSelected(std::size_t index, bool selected);
+
+        const std::vector<MenuItem>& items() const;
+
+        bool hasEnabledItems() const;
+        std::optional<std::size_t> firstEnabledIndex() const;
+        std::optional<std::size_t> lastEnabledIndex() const;
+
+        std::optional<std::size_t> nextEnabledIndex(
+            std::size_t currentIndex,
+            MenuNavigationMode mode = MenuNavigationMode::Wrap) const;
+
+        std::optional<std::size_t> previousEnabledIndex(
+            std::size_t currentIndex,
+            MenuNavigationMode mode = MenuNavigationMode::Wrap) const;
+
+    private:
+        bool isValidIndex(std::size_t index) const;
+
+    private:
+        std::vector<MenuItem> m_items;
+    };
+}


### PR DESCRIPTION
Modifies:
- TUI.vcxproj

Adds:
- UI/Menus/MenuItem.h/.cpp
- UI/Menus/MenuModel.h/.cpp

- Added UI/Menus/MenuItem as a lightweight menu entry model
- Added support for:
  - label text
  - command IDs
  - optional description/help text
  - enabled/disabled state
  - checked state
  - selected state
- Added UI/Menus/MenuModel for stable ordered menu item storage
- Implemented vector-based ownership of MenuItem values
- Added APIs for:
  - add/remove menu items
  - query by index
  - query by command ID
  - update item metadata
  - clearing/resetting the model
- Added navigation helpers for:
  - first/last enabled item lookup
  - next enabled item traversal
  - previous enabled item traversal
- Added wrap vs clamp navigation behavior through MenuNavigationMode
- Kept menu system fully independent from rendering, surfaces, input, and screen APIs
- Designed as the foundation for upcoming MenuView and MenuController layers