### PR TITLE
MenuController: Implement MenuController navigation system

### DIFF
--- a/TUI/TUI.vcxproj
+++ b/TUI/TUI.vcxproj
@@ -277,6 +277,7 @@
     <ClInclude Include="UI\Base\FocusManager.h" />
     <ClInclude Include="UI\Base\UIElement.h" />
     <ClInclude Include="UI\Base\WindowManager.h" />
+    <ClInclude Include="UI\Menus\MenuController.h" />
     <ClInclude Include="UI\Menus\MenuItem.h" />
     <ClInclude Include="UI\Menus\MenuModel.h" />
     <ClInclude Include="UI\Menus\MenuView.h" />
@@ -425,6 +426,7 @@
     <ClCompile Include="UI\Base\FocusManager.cpp" />
     <ClCompile Include="UI\Base\UIElement.cpp" />
     <ClCompile Include="UI\Base\WindowManager.cpp" />
+    <ClCompile Include="UI\Menus\MenuController.cpp" />
     <ClCompile Include="UI\Menus\MenuItem.cpp" />
     <ClCompile Include="UI\Menus\MenuModel.cpp" />
     <ClCompile Include="UI\Menus\MenuView.cpp" />

--- a/TUI/UI/Menus/MenuController.cpp
+++ b/TUI/UI/Menus/MenuController.cpp
@@ -1,0 +1,438 @@
+#include "UI/Menus/MenuController.h"
+
+#include <utility>
+
+namespace UI::Menus
+{
+    bool MenuControllerResult::handled() const
+    {
+        return action != MenuControllerAction::None;
+    }
+
+    bool MenuControllerResult::selectionChanged() const
+    {
+        return action == MenuControllerAction::SelectionChanged;
+    }
+
+    bool MenuControllerResult::confirmed() const
+    {
+        return action == MenuControllerAction::Confirmed;
+    }
+
+    bool MenuControllerResult::cancelled() const
+    {
+        return action == MenuControllerAction::Cancelled;
+    }
+
+    MenuController::MenuController(MenuModel& model)
+    {
+        setModel(model);
+    }
+
+    MenuController::MenuController(MenuModel& model, MenuView& view)
+    {
+        setView(view);
+        setModel(model);
+    }
+
+    MenuModel* MenuController::model()
+    {
+        return m_model;
+    }
+
+    const MenuModel* MenuController::model() const
+    {
+        return m_model;
+    }
+
+    void MenuController::setModel(MenuModel* model)
+    {
+        m_model = model;
+
+        if (m_view != nullptr)
+        {
+            m_view->setModel(m_model);
+        }
+
+        if (!hasValidModel())
+        {
+            m_selectedIndex.reset();
+            syncView();
+            syncModelSelectionFlags();
+            return;
+        }
+
+        const std::optional<std::size_t> normalized = normalizedSelection();
+        if (normalized.has_value())
+        {
+            m_selectedIndex = normalized;
+        }
+        else
+        {
+            m_selectedIndex = m_model->firstEnabledIndex();
+        }
+
+        syncView();
+        syncModelSelectionFlags();
+    }
+
+    void MenuController::setModel(MenuModel& model)
+    {
+        setModel(&model);
+    }
+
+    void MenuController::clearModel()
+    {
+        m_model = nullptr;
+        m_selectedIndex.reset();
+
+        if (m_view != nullptr)
+        {
+            m_view->clearModel();
+        }
+    }
+
+    MenuView* MenuController::view()
+    {
+        return m_view;
+    }
+
+    const MenuView* MenuController::view() const
+    {
+        return m_view;
+    }
+
+    void MenuController::setView(MenuView* view)
+    {
+        m_view = view;
+
+        if (m_view == nullptr)
+        {
+            return;
+        }
+
+        m_view->setOrientation(m_orientation);
+        m_view->setModel(m_model);
+        syncView();
+    }
+
+    void MenuController::setView(MenuView& view)
+    {
+        setView(&view);
+    }
+
+    void MenuController::clearView()
+    {
+        if (m_view != nullptr)
+        {
+            m_view->clearSelectedIndex();
+        }
+
+        m_view = nullptr;
+    }
+
+    MenuOrientation MenuController::orientation() const
+    {
+        return m_orientation;
+    }
+
+    void MenuController::setOrientation(MenuOrientation orientation)
+    {
+        m_orientation = orientation;
+
+        if (m_view != nullptr)
+        {
+            m_view->setOrientation(orientation);
+        }
+    }
+
+    MenuNavigationMode MenuController::navigationMode() const
+    {
+        return m_navigationMode;
+    }
+
+    void MenuController::setNavigationMode(MenuNavigationMode mode)
+    {
+        m_navigationMode = mode;
+    }
+
+    std::optional<std::size_t> MenuController::selectedIndex() const
+    {
+        return m_selectedIndex;
+    }
+
+    const MenuItem* MenuController::selectedItem() const
+    {
+        if (!hasValidModel() || !m_selectedIndex.has_value())
+        {
+            return nullptr;
+        }
+
+        return m_model->itemAt(m_selectedIndex.value());
+    }
+
+    std::string MenuController::selectedCommandId() const
+    {
+        const MenuItem* item = selectedItem();
+        return item != nullptr ? item->commandId() : std::string();
+    }
+
+    void MenuController::setOnSelectionChanged(SelectionChangedCallback callback)
+    {
+        m_onSelectionChanged = std::move(callback);
+    }
+
+    void MenuController::clearOnSelectionChanged()
+    {
+        m_onSelectionChanged = nullptr;
+    }
+
+    MenuControllerResult MenuController::selectFirstEnabled()
+    {
+        if (!hasValidModel())
+        {
+            return clearSelection();
+        }
+
+        return setSelectionInternal(m_model->firstEnabledIndex(), true);
+    }
+
+    MenuControllerResult MenuController::selectLastEnabled()
+    {
+        if (!hasValidModel())
+        {
+            return clearSelection();
+        }
+
+        return setSelectionInternal(m_model->lastEnabledIndex(), true);
+    }
+
+    MenuControllerResult MenuController::setSelectedIndex(std::size_t index)
+    {
+        if (!isValidEnabledIndex(index))
+        {
+            return MenuControllerResult{};
+        }
+
+        return setSelectionInternal(index, true);
+    }
+
+    MenuControllerResult MenuController::clearSelection()
+    {
+        return setSelectionInternal(std::nullopt, true);
+    }
+
+    MenuControllerResult MenuController::next()
+    {
+        return moveSelection(1);
+    }
+
+    MenuControllerResult MenuController::previous()
+    {
+        return moveSelection(-1);
+    }
+
+    MenuControllerResult MenuController::up()
+    {
+        if (m_orientation != MenuOrientation::Vertical)
+        {
+            return MenuControllerResult{};
+        }
+
+        return previous();
+    }
+
+    MenuControllerResult MenuController::down()
+    {
+        if (m_orientation != MenuOrientation::Vertical)
+        {
+            return MenuControllerResult{};
+        }
+
+        return next();
+    }
+
+    MenuControllerResult MenuController::left()
+    {
+        if (m_orientation != MenuOrientation::Horizontal)
+        {
+            return MenuControllerResult{};
+        }
+
+        return previous();
+    }
+
+    MenuControllerResult MenuController::right()
+    {
+        if (m_orientation != MenuOrientation::Horizontal)
+        {
+            return MenuControllerResult{};
+        }
+
+        return next();
+    }
+
+    MenuControllerResult MenuController::confirm() const
+    {
+        const MenuItem* item = selectedItem();
+
+        if (item == nullptr || !item->isEnabled())
+        {
+            return MenuControllerResult{};
+        }
+
+        return MenuControllerResult{
+            MenuControllerAction::Confirmed,
+            m_selectedIndex,
+            item->commandId()
+        };
+    }
+
+    MenuControllerResult MenuController::cancel() const
+    {
+        return MenuControllerResult{
+            MenuControllerAction::Cancelled,
+            m_selectedIndex,
+            std::string()
+        };
+    }
+
+    MenuControllerResult MenuController::moveSelection(int direction)
+    {
+        if (!hasValidModel())
+        {
+            return clearSelection();
+        }
+
+        if (!m_model->hasEnabledItems())
+        {
+            return clearSelection();
+        }
+
+        if (!m_selectedIndex.has_value() || !isValidEnabledIndex(m_selectedIndex.value()))
+        {
+            return setSelectionInternal(m_model->firstEnabledIndex(), true);
+        }
+
+        std::optional<std::size_t> nextIndex;
+
+        if (direction > 0)
+        {
+            nextIndex = m_model->nextEnabledIndex(m_selectedIndex.value(), m_navigationMode);
+        }
+        else if (direction < 0)
+        {
+            nextIndex = m_model->previousEnabledIndex(m_selectedIndex.value(), m_navigationMode);
+        }
+        else
+        {
+            nextIndex = m_selectedIndex;
+        }
+
+        if (!nextIndex.has_value())
+        {
+            return MenuControllerResult{};
+        }
+
+        return setSelectionInternal(nextIndex, true);
+    }
+
+    MenuControllerResult MenuController::setSelectionInternal(
+        std::optional<std::size_t> index,
+        bool notifySelectionChanged)
+    {
+        if (index.has_value() && !isValidEnabledIndex(index.value()))
+        {
+            return MenuControllerResult{};
+        }
+
+        if (m_selectedIndex == index)
+        {
+            syncView();
+            syncModelSelectionFlags();
+            return MenuControllerResult{};
+        }
+
+        m_selectedIndex = index;
+        syncView();
+        syncModelSelectionFlags();
+
+        if (notifySelectionChanged && m_onSelectionChanged && m_selectedIndex.has_value())
+        {
+            const MenuItem* item = selectedItem();
+            if (item != nullptr)
+            {
+                m_onSelectionChanged(m_selectedIndex.value(), *item);
+            }
+        }
+
+        return makeSelectionChangedResult();
+    }
+
+    bool MenuController::hasValidModel() const
+    {
+        return m_model != nullptr && !m_model->isEmpty();
+    }
+
+    bool MenuController::isValidEnabledIndex(std::size_t index) const
+    {
+        if (!hasValidModel())
+        {
+            return false;
+        }
+
+        const MenuItem* item = m_model->itemAt(index);
+        return item != nullptr && item->isEnabled();
+    }
+
+    std::optional<std::size_t> MenuController::normalizedSelection() const
+    {
+        if (!hasValidModel() || !m_selectedIndex.has_value())
+        {
+            return std::nullopt;
+        }
+
+        if (isValidEnabledIndex(m_selectedIndex.value()))
+        {
+            return m_selectedIndex;
+        }
+
+        return std::nullopt;
+    }
+
+    void MenuController::syncView() const
+    {
+        if (m_view == nullptr)
+        {
+            return;
+        }
+
+        m_view->setSelectedIndex(m_selectedIndex);
+    }
+
+    void MenuController::syncModelSelectionFlags() const
+    {
+        if (m_model == nullptr)
+        {
+            return;
+        }
+
+        for (std::size_t index = 0; index < m_model->itemCount(); ++index)
+        {
+            MenuItem* item = m_model->itemAt(index);
+            if (item != nullptr)
+            {
+                item->setSelected(m_selectedIndex.has_value() && m_selectedIndex.value() == index);
+            }
+        }
+    }
+
+    MenuControllerResult MenuController::makeSelectionChangedResult() const
+    {
+        return MenuControllerResult{
+            MenuControllerAction::SelectionChanged,
+            m_selectedIndex,
+            selectedCommandId()
+        };
+    }
+}

--- a/TUI/UI/Menus/MenuController.h
+++ b/TUI/UI/Menus/MenuController.h
@@ -1,0 +1,102 @@
+#pragma once
+
+#include <cstddef>
+#include <functional>
+#include <optional>
+#include <string>
+
+#include "UI/Menus/MenuModel.h"
+#include "UI/Menus/MenuView.h"
+
+namespace UI::Menus
+{
+    enum class MenuControllerAction
+    {
+        None,
+        SelectionChanged,
+        Confirmed,
+        Cancelled
+    };
+
+    struct MenuControllerResult
+    {
+        MenuControllerAction action = MenuControllerAction::None;
+        std::optional<std::size_t> selectedIndex;
+        std::string commandId;
+
+        bool handled() const;
+        bool selectionChanged() const;
+        bool confirmed() const;
+        bool cancelled() const;
+    };
+
+    class MenuController
+    {
+    public:
+        using SelectionChangedCallback = std::function<void(std::size_t, const MenuItem&)>;
+
+        MenuController() = default;
+        explicit MenuController(MenuModel& model);
+        MenuController(MenuModel& model, MenuView& view);
+
+        MenuModel* model();
+        const MenuModel* model() const;
+        void setModel(MenuModel* model);
+        void setModel(MenuModel& model);
+        void clearModel();
+
+        MenuView* view();
+        const MenuView* view() const;
+        void setView(MenuView* view);
+        void setView(MenuView& view);
+        void clearView();
+
+        MenuOrientation orientation() const;
+        void setOrientation(MenuOrientation orientation);
+
+        MenuNavigationMode navigationMode() const;
+        void setNavigationMode(MenuNavigationMode mode);
+
+        std::optional<std::size_t> selectedIndex() const;
+        const MenuItem* selectedItem() const;
+        std::string selectedCommandId() const;
+
+        void setOnSelectionChanged(SelectionChangedCallback callback);
+        void clearOnSelectionChanged();
+
+        MenuControllerResult selectFirstEnabled();
+        MenuControllerResult selectLastEnabled();
+        MenuControllerResult setSelectedIndex(std::size_t index);
+        MenuControllerResult clearSelection();
+
+        MenuControllerResult next();
+        MenuControllerResult previous();
+        MenuControllerResult up();
+        MenuControllerResult down();
+        MenuControllerResult left();
+        MenuControllerResult right();
+        MenuControllerResult confirm() const;
+        MenuControllerResult cancel() const;
+
+    private:
+        MenuControllerResult moveSelection(int direction);
+        MenuControllerResult setSelectionInternal(
+            std::optional<std::size_t> index,
+            bool notifySelectionChanged);
+
+        bool hasValidModel() const;
+        bool isValidEnabledIndex(std::size_t index) const;
+        std::optional<std::size_t> normalizedSelection() const;
+        void syncView() const;
+        void syncModelSelectionFlags() const;
+        MenuControllerResult makeSelectionChangedResult() const;
+
+    private:
+        MenuModel* m_model = nullptr;
+        MenuView* m_view = nullptr;
+        MenuOrientation m_orientation = MenuOrientation::Vertical;
+        MenuNavigationMode m_navigationMode = MenuNavigationMode::Wrap;
+        std::optional<std::size_t> m_selectedIndex;
+        SelectionChangedCallback m_onSelectionChanged;
+    };
+}


### PR DESCRIPTION
Modifies:
- TUI.vcxproj

Adds:
UI/Menus/MenuController.h/.cpp

- Implemented menu navigation controller
- Added support for next/previous navigation behavior
- Added directional navigation methods:
  - up()
  - down()
  - left()
  - right()
- Added confirm() and cancel() action handling
- Added MenuControllerAction enum and MenuControllerResult struct
- Added support for vertical and horizontal menu orientations
- Added wrap and clamp navigation behavior integration
- Implemented disabled-item skipping during traversal
- Added selected item tracking and synchronization
- Added command ID retrieval on confirm actions
- Added selection normalization and validation helpers
- Added callback support for reacting to selection changes
- Synced controller state with MenuView selected index
- Synced MenuItem selected state flags with active selection
- Kept controller independent from rendering and input backend details
- Preserved non-owning relationships with MenuModel and MenuView
- Designed for future integration with FocusManager and input abstraction layers

Architectural Notes:
- MenuController coordinates interaction state only
- MenuView remains rendering-only
- MenuModel remains data-only
- Navigation logic centralized for authored interactive pages and future widgets