### PR TITLE
ScrollablePanel: Add ScrollablePanel viewport-backed scrolling container

### DIFF
--- a/TUI/TUI.vcxproj
+++ b/TUI/TUI.vcxproj
@@ -287,6 +287,7 @@
     <ClInclude Include="UI\Panels\EffectWindow.h" />
     <ClInclude Include="UI\Panels\Panel.h" />
     <ClInclude Include="UI\Panels\PopupWindow.h" />
+    <ClInclude Include="UI\Panels\ScrollablePanel.h" />
     <ClInclude Include="UI\Panels\StatusBar.h" />
     <ClInclude Include="UI\Panels\Window.h" />
     <ClInclude Include="Utilities\AssetPaths.h" />
@@ -439,6 +440,7 @@
     <ClCompile Include="UI\Panels\EffectWindow.cpp" />
     <ClCompile Include="UI\Panels\Panel.cpp" />
     <ClCompile Include="UI\Panels\PopupWindow.cpp" />
+    <ClCompile Include="UI\Panels\ScrollablePanel.cpp" />
     <ClCompile Include="UI\Panels\StatusBar.cpp" />
     <ClCompile Include="UI\Panels\Window.cpp" />
     <ClCompile Include="Utilities\AssetPaths.cpp" />

--- a/TUI/UI/Panels/ScrollablePanel.cpp
+++ b/TUI/UI/Panels/ScrollablePanel.cpp
@@ -1,0 +1,207 @@
+#include "UI/Panels/ScrollablePanel.h"
+
+#include <algorithm>
+#include <utility>
+
+#include "Rendering/ScreenBuffer.h"
+
+ScrollablePanel::ScrollablePanel()
+    : Panel()
+{
+    syncViewportToPanel();
+}
+
+ScrollablePanel::ScrollablePanel(const Rect& bounds)
+    : Panel(bounds)
+{
+    syncViewportToPanel();
+}
+
+ScrollablePanel::ScrollablePanel(const Rect& bounds, std::string title)
+    : Panel(bounds, std::move(title))
+{
+    syncViewportToPanel();
+}
+
+Viewport& ScrollablePanel::viewport()
+{
+    return m_viewport;
+}
+
+const Viewport& ScrollablePanel::viewport() const
+{
+    return m_viewport;
+}
+
+void ScrollablePanel::setContentSize(Size size)
+{
+    m_viewport.setContentSize(size);
+}
+
+void ScrollablePanel::setContentSize(int width, int height)
+{
+    m_viewport.setContentSize(width, height);
+}
+
+void ScrollablePanel::setViewSize(Size size)
+{
+    m_viewport.setViewSize(size);
+}
+
+void ScrollablePanel::setViewSize(int width, int height)
+{
+    m_viewport.setViewSize(width, height);
+}
+
+Rect ScrollablePanel::viewportBounds() const
+{
+    return contentBounds();
+}
+
+Rect ScrollablePanel::visibleContentRect() const
+{
+    return m_viewport.visibleContentRect();
+}
+
+bool ScrollablePanel::scrollUp(int lines)
+{
+    return scrollToAndReportChange(
+        m_viewport.scrollX(),
+        m_viewport.scrollY() - std::max(0, lines));
+}
+
+bool ScrollablePanel::scrollDown(int lines)
+{
+    return scrollToAndReportChange(
+        m_viewport.scrollX(),
+        m_viewport.scrollY() + std::max(0, lines));
+}
+
+bool ScrollablePanel::scrollLeft(int columns)
+{
+    return scrollToAndReportChange(
+        m_viewport.scrollX() - std::max(0, columns),
+        m_viewport.scrollY());
+}
+
+bool ScrollablePanel::scrollRight(int columns)
+{
+    return scrollToAndReportChange(
+        m_viewport.scrollX() + std::max(0, columns),
+        m_viewport.scrollY());
+}
+
+bool ScrollablePanel::pageUp()
+{
+    const int pageAmount = std::max(1, m_viewport.viewSize().height);
+    return scrollUp(pageAmount);
+}
+
+bool ScrollablePanel::pageDown()
+{
+    const int pageAmount = std::max(1, m_viewport.viewSize().height);
+    return scrollDown(pageAmount);
+}
+
+bool ScrollablePanel::home()
+{
+    return scrollToAndReportChange(0, 0);
+}
+
+bool ScrollablePanel::end()
+{
+    return scrollToAndReportChange(
+        m_viewport.scrollX(),
+        m_viewport.maxScrollY());
+}
+
+void ScrollablePanel::draw(Surface& surface)
+{
+    if (!isVisible())
+    {
+        return;
+    }
+
+    Panel::draw(surface);
+
+    syncViewportToPanel();
+
+    const Rect targetRect = viewportBounds();
+
+    if (targetRect.size.width <= 0 || targetRect.size.height <= 0)
+    {
+        return;
+    }
+
+    Surface viewportSurface(targetRect.size.width, targetRect.size.height);
+    viewportSurface.clear(backgroundStyle());
+
+    drawScrollableContent(viewportSurface, m_viewport.visibleContentRect());
+    blitViewportSurface(surface, viewportSurface, targetRect);
+}
+
+void ScrollablePanel::drawScrollableContent(
+    Surface& surface,
+    const Rect& visibleContentRect)
+{
+    (void)surface;
+    (void)visibleContentRect;
+}
+
+Point ScrollablePanel::contentToViewport(Point contentPoint) const
+{
+    return m_viewport.contentToView(contentPoint);
+}
+
+Point ScrollablePanel::viewportToContent(Point viewportPoint) const
+{
+    return m_viewport.viewToContent(viewportPoint);
+}
+
+void ScrollablePanel::syncViewportToPanel()
+{
+    const Rect viewRect = viewportBounds();
+    m_viewport.setViewSize(viewRect.size);
+}
+
+bool ScrollablePanel::scrollToAndReportChange(int x, int y)
+{
+    const Point before = m_viewport.scrollOffset();
+
+    m_viewport.scrollTo(x, y);
+
+    const Point after = m_viewport.scrollOffset();
+
+    return before.x != after.x || before.y != after.y;
+}
+
+void ScrollablePanel::blitViewportSurface(
+    Surface& target,
+    const Surface& source,
+    const Rect& targetRect) const
+{
+    ScreenBuffer& targetBuffer = target.buffer();
+    const ScreenBuffer& sourceBuffer = source.buffer();
+
+    const int copyWidth = std::min(targetRect.size.width, sourceBuffer.getWidth());
+    const int copyHeight = std::min(targetRect.size.height, sourceBuffer.getHeight());
+
+    for (int y = 0; y < copyHeight; ++y)
+    {
+        for (int x = 0; x < copyWidth; ++x)
+        {
+            const int targetX = targetRect.position.x + x;
+            const int targetY = targetRect.position.y + y;
+
+            if (!targetBuffer.inBounds(targetX, targetY))
+            {
+                continue;
+            }
+
+            targetBuffer.setCell(
+                targetX,
+                targetY,
+                sourceBuffer.getCell(x, y));
+        }
+    }
+}

--- a/TUI/UI/Panels/ScrollablePanel.h
+++ b/TUI/UI/Panels/ScrollablePanel.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include "Core/Rect.h"
+#include "Core/Size.h"
+#include "Rendering/Surface.h"
+#include "UI/Base/Viewport.h"
+#include "UI/Panels/Panel.h"
+
+class ScrollablePanel : public Panel
+{
+public:
+    ScrollablePanel();
+    explicit ScrollablePanel(const Rect& bounds);
+    ScrollablePanel(const Rect& bounds, std::string title);
+
+    Viewport& viewport();
+    const Viewport& viewport() const;
+
+    void setContentSize(Size size);
+    void setContentSize(int width, int height);
+
+    void setViewSize(Size size);
+    void setViewSize(int width, int height);
+
+    Rect viewportBounds() const;
+    Rect visibleContentRect() const;
+
+    bool scrollUp(int lines = 1);
+    bool scrollDown(int lines = 1);
+    bool scrollLeft(int columns = 1);
+    bool scrollRight(int columns = 1);
+
+    bool pageUp();
+    bool pageDown();
+
+    bool home();
+    bool end();
+
+    void draw(Surface& surface) override;
+
+protected:
+    virtual void drawScrollableContent(
+        Surface& surface,
+        const Rect& visibleContentRect);
+
+    Point contentToViewport(Point contentPoint) const;
+    Point viewportToContent(Point viewportPoint) const;
+
+private:
+    void syncViewportToPanel();
+    bool scrollToAndReportChange(int x, int y);
+    void blitViewportSurface(Surface& target, const Surface& source, const Rect& targetRect) const;
+
+private:
+    Viewport m_viewport;
+};


### PR DESCRIPTION
Modifies:
-TUI.vcxproj

Adds:
- UI/Panels/ScrollablePanel.h/.cpp

- Added ScrollablePanel as a reusable scroll-aware Panel specialization
- Integrated Viewport ownership directly into ScrollablePanel
- Added viewport() accessors for direct scrolling state access
- Added content size and view size configuration helpers
- Synced viewport visible region with Panel content bounds
- Implemented clipping-aware rendering for scrollable panel interiors
- Added overridable drawScrollableContent() extension point for derived widgets
- Added keyboard-style scrolling helpers:
  - scrollUp()
  - scrollDown()
  - scrollLeft()
  - scrollRight()
  - pageUp()
  - pageDown()
  - home()
  - end()
- Added coordinate conversion helpers between content and viewport space
- Implemented safe viewport surface blitting using existing Surface and ScreenBuffer infrastructure
- Preserved existing rendering architecture and Panel drawing conventions
- Established reusable scrolling foundation for future TextView, log viewer, inspector, and document-style widgets