### PR TITLE
ScrollableTileGridDemoScreen: Add Phase 10 scrollable tile grid demo

### DIFF
--- a/TUI/App/Application.cpp
+++ b/TUI/App/Application.cpp
@@ -22,6 +22,7 @@
 #include "Screens/Developer/RendererDiagnosticsScreen.h"
 #include "Screens/Developer/TerminalCapabilitiesScreen.h"
 #include "Screens/MenuDemoScreen.h"
+#include "Screens/ScrollableTileGridDemoScreen.h"
 
 static Application* g_appInstance = nullptr;
 
@@ -369,6 +370,10 @@ void Application::switchToScreen(ScreenType screenType)
         m_screenManager->pushScreen(std::make_unique<MenuDemoScreen>());
         break;
 
+    case ScreenType::ScrollableTileGridDemo:
+        m_screenManager->pushScreen(std::make_unique<ScrollableTileGridDemoScreen>());
+        break;
+
     case ScreenType::WindowDemo:
         m_screenManager->pushScreen(std::make_unique<WindowDemo>());
         break;
@@ -415,6 +420,10 @@ void Application::advanceScreen()
         break;
 
     case ScreenType::MenuDemoScreen:
+        switchToScreen(ScreenType::ScrollableTileGridDemo);
+        break;
+
+    case ScreenType::ScrollableTileGridDemo:
         switchToScreen(ScreenType::WindowDemo);
         break;
 
@@ -472,8 +481,12 @@ void Application::previousScreen()
         switchToScreen(ScreenType::OpsWall);
         break;
 
-    case ScreenType::WindowDemo:
+    case ScreenType::ScrollableTileGridDemo:
         switchToScreen(ScreenType::MenuDemoScreen);
+        break;
+
+    case ScreenType::WindowDemo:
+        switchToScreen(ScreenType::ScrollableTileGridDemo);
         break;
 
     case ScreenType::DigitalRain:

--- a/TUI/App/Application.h
+++ b/TUI/App/Application.h
@@ -43,6 +43,7 @@ private:
         NeonDialog,
         OpsWall,
         MenuDemoScreen,
+        ScrollableTileGridDemo,
         WindowDemo,
         DigitalRain,
         WaterEffect,

--- a/TUI/Screens/ScrollableTileGridDemoScreen.cpp
+++ b/TUI/Screens/ScrollableTileGridDemoScreen.cpp
@@ -1,0 +1,367 @@
+#include "Screens/ScrollableTileGridDemoScreen.h"
+
+#include <algorithm>
+#include <string>
+
+#include "Core/Rect.h"
+#include "Input/Command.h"
+#include "Input/Event.h"
+#include "Rendering/ScreenBuffer.h"
+#include "Rendering/Styles/AppThemes.h"
+#include "Rendering/Styles/StyleBuilder.h"
+#include "Rendering/Styles/UIThemes.h"
+#include "Rendering/Surface.h"
+
+namespace
+{
+    constexpr int MinimumWidth = 70;
+    constexpr int MinimumHeight = 22;
+
+    constexpr int DemoGridWidth = 120;
+    constexpr int DemoGridHeight = 60;
+
+    const Style ScreenStyle =
+        style::Fg(Color::FromBasic(Color::Basic::BrightWhite))
+        + style::Bg(Color::FromBasic(Color::Basic::Black));
+
+    const Style HeaderStyle =
+        style::Bold
+        + style::Fg(Color::FromBasic(Color::Basic::BrightCyan))
+        + style::Bg(Color::FromBasic(Color::Basic::Blue));
+
+    const Style PanelStyle =
+        style::Fg(Color::FromBasic(Color::Basic::BrightWhite))
+        + style::Bg(Color::FromBasic(Color::Basic::Black));
+
+    const Style BorderStyle =
+        style::Bold
+        + style::Fg(Color::FromBasic(Color::Basic::BrightCyan))
+        + style::Bg(Color::FromBasic(Color::Basic::Black));
+
+    const Style TitleStyle =
+        style::Bold
+        + style::Fg(Color::FromBasic(Color::Basic::BrightYellow))
+        + style::Bg(Color::FromBasic(Color::Basic::Black));
+
+    const Style FloorStyle =
+        style::Fg(Color::FromBasic(Color::Basic::BrightBlack))
+        + style::Bg(Color::FromBasic(Color::Basic::Black));
+
+    const Style GridLineStyle =
+        style::Fg(Color::FromBasic(Color::Basic::Blue))
+        + style::Bg(Color::FromBasic(Color::Basic::Black));
+
+    const Style WallStyle =
+        style::Bold
+        + style::Fg(Color::FromBasic(Color::Basic::BrightWhite))
+        + style::Bg(Color::FromBasic(Color::Basic::Black));
+
+    const Style WaterStyle =
+        style::Fg(Color::FromBasic(Color::Basic::BrightCyan))
+        + style::Bg(Color::FromBasic(Color::Basic::Blue));
+
+    const Style ForestStyle =
+        style::Fg(Color::FromBasic(Color::Basic::BrightGreen))
+        + style::Bg(Color::FromBasic(Color::Basic::Black));
+
+    const Style RoadStyle =
+        style::Fg(Color::FromBasic(Color::Basic::BrightYellow))
+        + style::Bg(Color::FromBasic(Color::Basic::Black));
+
+    const Style MarkerStyle =
+        style::Bold
+        + style::Fg(Color::FromBasic(Color::Basic::BrightRed))
+        + style::Bg(Color::FromBasic(Color::Basic::Black));
+
+    std::string scrollPositionText(const TileGridView& view)
+    {
+        const Viewport& viewport = view.viewport();
+
+        return "Scroll "
+            + std::to_string(viewport.scrollX())
+            + ","
+            + std::to_string(viewport.scrollY())
+            + " / max "
+            + std::to_string(viewport.maxScrollX())
+            + ","
+            + std::to_string(viewport.maxScrollY());
+    }
+}
+
+ScrollableTileGridDemoScreen::ScrollableTileGridDemoScreen()
+    : m_gridView("Scrollable Tile/Grid View")
+{
+    configureControls();
+    buildDemoGrid();
+}
+
+void ScrollableTileGridDemoScreen::onEnter()
+{
+    m_gridView.home();
+    m_lastAction = "Demo grid reset to origin.";
+    updateStatusBar();
+}
+
+bool ScrollableTileGridDemoScreen::handleEvent(const Input::Event& event)
+{
+    if (const Input::CommandEvent* commandEvent = event.asCommand())
+    {
+        return handleCommand(commandEvent->command);
+    }
+
+    return false;
+}
+
+void ScrollableTileGridDemoScreen::draw(Surface& surface)
+{
+    ScreenBuffer& buffer = surface.buffer();
+
+    if (buffer.getWidth() < MinimumWidth || buffer.getHeight() < MinimumHeight)
+    {
+        drawTooSmall(surface);
+        return;
+    }
+
+    buffer.clear(ScreenStyle);
+
+    updateLayout(surface);
+    updateStatusBar();
+
+    m_headerPanel.draw(surface);
+    drawHeader(surface);
+
+    m_gridView.draw(surface);
+    m_statusBar.draw(surface);
+}
+
+void ScrollableTileGridDemoScreen::configureControls()
+{
+    m_headerPanel.setTitle("Phase 10 Demo");
+    m_headerPanel.setBackgroundStyle(HeaderStyle);
+    m_headerPanel.setBorderStyle(HeaderStyle);
+    m_headerPanel.setTitleStyle(HeaderStyle);
+
+    m_gridView.setBackgroundStyle(PanelStyle);
+    m_gridView.setBorderStyle(BorderStyle);
+    m_gridView.setTitleStyle(TitleStyle);
+    m_gridView.setEmptyCellStyle(PanelStyle);
+
+    m_statusBar.setInstructions("Scrollable grid/tile demo");
+    m_statusBar.setCommandHints({
+        "Arrows: scroll",
+        "PgUp/PgDn: page",
+        "Home: origin",
+        "End: bottom-right",
+        "Enter/Right: next screen"
+        });
+}
+
+void ScrollableTileGridDemoScreen::buildDemoGrid()
+{
+    TileGrid grid(DemoGridWidth, DemoGridHeight);
+
+    for (int y = 0; y < DemoGridHeight; ++y)
+    {
+        for (int x = 0; x < DemoGridWidth; ++x)
+        {
+            char32_t glyph = U'.';
+            Style style = FloorStyle;
+
+            if (x == 0 || y == 0 || x == DemoGridWidth - 1 || y == DemoGridHeight - 1)
+            {
+                glyph = U'#';
+                style = WallStyle;
+            }
+            else if (x % 10 == 0 || y % 6 == 0)
+            {
+                glyph = U'+';
+                style = GridLineStyle;
+            }
+            else if ((x > 12 && x < 35 && y > 10 && y < 18)
+                || (x > 78 && x < 108 && y > 36 && y < 47))
+            {
+                glyph = U'~';
+                style = WaterStyle;
+            }
+            else if ((x + y) % 17 == 0 || (x * 3 + y) % 29 == 0)
+            {
+                glyph = U'^';
+                style = ForestStyle;
+            }
+            else if (y == (x / 3) + 8 || y == 48 - (x / 4))
+            {
+                glyph = U'=';
+                style = RoadStyle;
+            }
+
+            grid.set(x, y, makeCell(glyph, style));
+        }
+    }
+
+    for (int y = 5; y < DemoGridHeight - 5; y += 10)
+    {
+        for (int x = 8; x < DemoGridWidth - 8; x += 18)
+        {
+            grid.set(x, y, makeCell(U'X', MarkerStyle));
+        }
+    }
+
+    m_gridView.setGrid(std::move(grid));
+}
+
+void ScrollableTileGridDemoScreen::updateLayout(Surface& surface)
+{
+    const ScreenBuffer& buffer = surface.buffer();
+
+    const int width = buffer.getWidth();
+    const int height = buffer.getHeight();
+
+    m_headerPanel.setBounds(Rect{
+        Point{ 1, 1 },
+        Size{ std::max(0, width - 2), 5 }
+        });
+
+    m_gridView.setBounds(Rect{
+        Point{ 2, 7 },
+        Size{ std::max(0, width - 4), std::max(0, height - 10) }
+        });
+
+    m_statusBar.setBounds(Rect{
+        Point{ 0, std::max(0, height - 2) },
+        Size{ width, 2 }
+        });
+}
+
+void ScrollableTileGridDemoScreen::updateStatusBar()
+{
+    m_statusBar.setInstructions(m_lastAction + "  " + scrollPositionText(m_gridView));
+}
+
+bool ScrollableTileGridDemoScreen::handleCommand(const Input::Command& command)
+{
+    bool changed = false;
+
+    switch (command.code)
+    {
+    case Input::CommandCode::MoveUp:
+        changed = m_gridView.scrollUp();
+        m_lastAction = changed ? "Scrolled up." : "Already at top edge.";
+        return true;
+
+    case Input::CommandCode::MoveDown:
+        changed = m_gridView.scrollDown();
+        m_lastAction = changed ? "Scrolled down." : "Already at bottom edge.";
+        return true;
+
+    case Input::CommandCode::MoveLeft:
+        changed = m_gridView.scrollLeft();
+        m_lastAction = changed ? "Scrolled left." : "Already at left edge.";
+        return true;
+
+    case Input::CommandCode::MoveRight:
+        changed = m_gridView.scrollRight();
+        m_lastAction = changed ? "Scrolled right." : "Already at right edge.";
+        return true;
+
+    case Input::CommandCode::PageUp:
+        changed = m_gridView.pageUp();
+        m_lastAction = changed ? "Paged up." : "Already at top page.";
+        return true;
+
+    case Input::CommandCode::PageDown:
+        changed = m_gridView.pageDown();
+        m_lastAction = changed ? "Paged down." : "Already at bottom page.";
+        return true;
+
+    case Input::CommandCode::MoveHome:
+        changed = m_gridView.home();
+        m_lastAction = changed ? "Moved to grid origin." : "Already at grid origin.";
+        return true;
+
+    case Input::CommandCode::MoveEnd:
+    {
+        const Point before = m_gridView.viewport().scrollOffset();
+
+        m_gridView.viewport().scrollTo(
+            m_gridView.viewport().maxScrollX(),
+            m_gridView.viewport().maxScrollY());
+
+        const Point after = m_gridView.viewport().scrollOffset();
+
+        changed = before.x != after.x || before.y != after.y;
+        m_lastAction = changed ? "Moved to bottom-right corner." : "Already at bottom-right corner.";
+        return true;
+    }
+
+    default:
+        return false;
+    }
+}
+
+void ScrollableTileGridDemoScreen::drawHeader(Surface& surface) const
+{
+    ScreenBuffer& buffer = surface.buffer();
+    const Rect content = m_headerPanel.contentBounds();
+
+    if (content.size.width <= 0 || content.size.height <= 0)
+    {
+        return;
+    }
+
+    buffer.writeString(
+        content.position.x,
+        content.position.y,
+        "Large generated tile grid rendered through TileGridView -> ScrollablePanel -> Surface.",
+        HeaderStyle);
+
+    if (content.size.height > 1)
+    {
+        buffer.writeString(
+            content.position.x,
+            content.position.y + 1,
+            "Only the visible grid region is copied into the viewport surface each frame.",
+            HeaderStyle);
+    }
+
+    if (content.size.height > 2)
+    {
+        buffer.writeString(
+            content.position.x,
+            content.position.y + 2,
+            "Legend: # wall, . floor, + gridline, ~ water, ^ trees, = road, X markers.",
+            HeaderStyle);
+    }
+}
+
+void ScrollableTileGridDemoScreen::drawTooSmall(Surface& surface) const
+{
+    ScreenBuffer& buffer = surface.buffer();
+
+    buffer.clear(ScreenStyle);
+    buffer.writeString(
+        1,
+        1,
+        "Terminal too small for Scrollable Tile/Grid Demo.",
+        UIThemes::WarningText);
+
+    buffer.writeString(
+        1,
+        3,
+        "Please resize to at least "
+        + std::to_string(MinimumWidth)
+        + "x"
+        + std::to_string(MinimumHeight)
+        + ".",
+        UIThemes::Label);
+}
+
+TileGrid::Cell ScrollableTileGridDemoScreen::makeCell(char32_t glyph, const Style& style)
+{
+    TileGrid::Cell cell;
+    cell.glyph = glyph;
+    cell.cluster.clear();
+    cell.style = style;
+    cell.kind = CellKind::Glyph;
+    cell.width = CellWidth::One;
+    return cell;
+}

--- a/TUI/Screens/ScrollableTileGridDemoScreen.h
+++ b/TUI/Screens/ScrollableTileGridDemoScreen.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <string>
+
+#include "Input/Command.h"
+#include "Input/Event.h"
+#include "Rendering/Styles/Style.h"
+#include "Screens/Screen.h"
+#include "UI/Panels/Panel.h"
+#include "UI/Panels/StatusBar.h"
+#include "UI/Widgets/TileGridView.h"
+
+class Surface;
+
+class ScrollableTileGridDemoScreen : public Screen
+{
+public:
+    ScrollableTileGridDemoScreen();
+    ~ScrollableTileGridDemoScreen() override = default;
+
+    void onEnter() override;
+    bool handleEvent(const Input::Event& event) override;
+    void draw(Surface& surface) override;
+
+private:
+    void configureControls();
+    void buildDemoGrid();
+
+    void updateLayout(Surface& surface);
+    void updateStatusBar();
+
+    bool handleCommand(const Input::Command& command);
+
+    void drawHeader(Surface& surface) const;
+    void drawTooSmall(Surface& surface) const;
+
+    static TileGrid::Cell makeCell(char32_t glyph, const Style& style);
+
+private:
+    Panel m_headerPanel;
+    TileGridView m_gridView;
+    StatusBar m_statusBar;
+
+    std::string m_lastAction;
+};

--- a/TUI/TUI.vcxproj
+++ b/TUI/TUI.vcxproj
@@ -268,6 +268,7 @@
     <ClInclude Include="Screens\PageBuffer.h" />
     <ClInclude Include="Screens\Developer\RendererDiagnosticsScreen.h" />
     <ClInclude Include="Screens\Screen.h" />
+    <ClInclude Include="Screens\ScrollableTileGridDemoScreen.h" />
     <ClInclude Include="Screens\ShowcaseScreen.h" />
     <ClInclude Include="Screens\Developer\TerminalCapabilitiesScreen.h" />
     <ClInclude Include="Screens\Developer\TextObjectExportValidationScreen.h" />
@@ -293,6 +294,7 @@
     <ClInclude Include="UI\Panels\StatusBar.h" />
     <ClInclude Include="UI\Panels\Window.h" />
     <ClInclude Include="UI\Widgets\TextView.h" />
+    <ClInclude Include="UI\Widgets\TileGridView.h" />
     <ClInclude Include="Utilities\AssetPaths.h" />
     <ClInclude Include="Utilities\Text\TextClip.h" />
     <ClInclude Include="Utilities\Text\TextWrap.h" />
@@ -411,6 +413,7 @@
     <ClCompile Include="Screens\MenuDemoScreen.cpp" />
     <ClCompile Include="Screens\PageBuffer.cpp" />
     <ClCompile Include="Screens\Developer\RendererDiagnosticsScreen.cpp" />
+    <ClCompile Include="Screens\ScrollableTileGridDemoScreen.cpp" />
     <ClCompile Include="Screens\ShowcaseScreen.cpp" />
     <ClCompile Include="Screens\Developer\TerminalCapabilitiesScreen.cpp" />
     <ClCompile Include="Screens\Developer\TextObjectExportValidationScreen.cpp" />
@@ -449,6 +452,7 @@
     <ClCompile Include="UI\Panels\StatusBar.cpp" />
     <ClCompile Include="UI\Panels\Window.cpp" />
     <ClCompile Include="UI\Widgets\TextView.cpp" />
+    <ClCompile Include="UI\Widgets\TileGridView.cpp" />
     <ClCompile Include="Utilities\AssetPaths.cpp" />
     <ClCompile Include="Utilities\Unicode\GraphemeSegmentation.cpp" />
     <ClCompile Include="Utilities\Unicode\GraphemeSegmentationTests.cpp" />

--- a/TUI/TUI.vcxproj.filters
+++ b/TUI/TUI.vcxproj.filters
@@ -423,6 +423,51 @@
     <ClInclude Include="Screens\WindowDemoScreen.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="Assets\Loaders\TileGridLoader.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Screens\MenuDemoScreen.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="UI\Base\FocusManager.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="UI\Base\Viewport.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="UI\Config\MenuStatusConfig.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="UI\Content\TileGrid.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="UI\Menus\MenuController.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="UI\Menus\MenuItem.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="UI\Menus\MenuModel.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="UI\Menus\MenuView.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="UI\Panels\ScrollablePanel.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="UI\Panels\StatusBar.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="UI\Widgets\TextView.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="UI\Widgets\TileGridView.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Screens\ScrollableTileGridDemoScreen.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Rendering\ScreenBuffer.cpp">
@@ -780,6 +825,51 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="Screens\WindowDemoScreen.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Assets\Loaders\TileGridLoader.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Screens\MenuDemoScreen.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="UI\Base\FocusManager.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="UI\Base\Viewport.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="UI\Config\MenuStatusConfig.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="UI\Content\TileGrid.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="UI\Menus\MenuController.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="UI\Menus\MenuItem.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="UI\Menus\MenuModel.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="UI\Menus\MenuView.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="UI\Panels\ScrollablePanel.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="UI\Panels\StatusBar.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="UI\Widgets\TextView.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="UI\Widgets\TileGridView.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Screens\ScrollableTileGridDemoScreen.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/TUI/UI/Widgets/TileGridView.cpp
+++ b/TUI/UI/Widgets/TileGridView.cpp
@@ -1,0 +1,82 @@
+#include "UI/Widgets/TileGridView.h"
+
+#include <utility>
+
+#include "Rendering/ScreenBuffer.h"
+#include "Rendering/Surface.h"
+
+TileGridView::TileGridView()
+    : ScrollablePanel()
+{
+    syncContentSize();
+}
+
+TileGridView::TileGridView(std::string title)
+    : ScrollablePanel(Rect{}, std::move(title))
+{
+    syncContentSize();
+}
+
+void TileGridView::setGrid(const TileGrid& grid)
+{
+    m_grid = grid;
+    syncContentSize();
+}
+
+void TileGridView::setGrid(TileGrid&& grid)
+{
+    m_grid = std::move(grid);
+    syncContentSize();
+}
+
+const TileGrid& TileGridView::grid() const
+{
+    return m_grid;
+}
+
+TileGrid& TileGridView::grid()
+{
+    return m_grid;
+}
+
+void TileGridView::setEmptyCellStyle(const Style& style)
+{
+    m_emptyCellStyle = style;
+}
+
+const Style& TileGridView::emptyCellStyle() const
+{
+    return m_emptyCellStyle;
+}
+
+void TileGridView::drawScrollableContent(
+    Surface& surface,
+    const Rect& visibleContentRect)
+{
+    ScreenBuffer& buffer = surface.buffer();
+
+    for (int viewY = 0; viewY < visibleContentRect.size.height; ++viewY)
+    {
+        const int contentY = visibleContentRect.position.y + viewY;
+
+        for (int viewX = 0; viewX < visibleContentRect.size.width; ++viewX)
+        {
+            const int contentX = visibleContentRect.position.x + viewX;
+
+            const TileGrid::Cell* cell = m_grid.tryGet(contentX, contentY);
+            if (cell != nullptr)
+            {
+                buffer.setCell(viewX, viewY, *cell);
+            }
+            else
+            {
+                buffer.writeCodePoint(viewX, viewY, U' ', m_emptyCellStyle);
+            }
+        }
+    }
+}
+
+void TileGridView::syncContentSize()
+{
+    setContentSize(m_grid.size());
+}

--- a/TUI/UI/Widgets/TileGridView.h
+++ b/TUI/UI/Widgets/TileGridView.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <string>
+
+#include "Rendering/Styles/Style.h"
+#include "UI/Content/TileGrid.h"
+#include "UI/Panels/ScrollablePanel.h"
+
+class Surface;
+
+class TileGridView : public ScrollablePanel
+{
+public:
+    TileGridView();
+    explicit TileGridView(std::string title);
+
+    void setGrid(const TileGrid& grid);
+    void setGrid(TileGrid&& grid);
+
+    const TileGrid& grid() const;
+    TileGrid& grid();
+
+    void setEmptyCellStyle(const Style& style);
+    const Style& emptyCellStyle() const;
+
+protected:
+    void drawScrollableContent(
+        Surface& surface,
+        const Rect& visibleContentRect) override;
+
+private:
+    void syncContentSize();
+
+private:
+    TileGrid m_grid;
+    Style m_emptyCellStyle;
+};


### PR DESCRIPTION
Modifies:
- TUI.vcxproj
- TUI.vcxproj.filters
- App/Application.h/.cpp

Add:
- UI/Widgets/TileGridView.h/.cpp
- Screens/ScrollableTileGridDemoScreen.h/.cpp

- Add TileGridView as a ScrollablePanel-based widget for rendering TileGrid content
- Render only the visible viewport region into the target Surface/ScreenBuffer
- Add ScrollableTileGridDemoScreen with generated larger-than-screen tile content
- Support keyboard scrolling through arrow, page, home, and end commands
- Add demo status/header text explaining scroll position and tile legend
- Wire the new demo screen into application screen navigation

Closes: #262 