### PR TITLE
WindowInteraction: Add window interaction layer foundation

### DIFF
--- a/TUI/TUI.vcxproj
+++ b/TUI/TUI.vcxproj
@@ -283,6 +283,7 @@
     <ClInclude Include="UI\Base\WindowManager.h" />
     <ClInclude Include="UI\Config\MenuStatusConfig.h" />
     <ClInclude Include="UI\Content\TileGrid.h" />
+    <ClInclude Include="UI\Interaction\WindowInteraction.h" />
     <ClInclude Include="UI\Menus\MenuController.h" />
     <ClInclude Include="UI\Menus\MenuItem.h" />
     <ClInclude Include="UI\Menus\MenuModel.h" />
@@ -441,6 +442,7 @@
     <ClCompile Include="UI\Base\WindowManager.cpp" />
     <ClCompile Include="UI\Config\MenuStatusConfig.cpp" />
     <ClCompile Include="UI\Content\TileGrid.cpp" />
+    <ClCompile Include="UI\Interaction\WindowInteraction.cpp" />
     <ClCompile Include="UI\Menus\MenuController.cpp" />
     <ClCompile Include="UI\Menus\MenuItem.cpp" />
     <ClCompile Include="UI\Menus\MenuModel.cpp" />

--- a/TUI/UI/Base/WindowManager.cpp
+++ b/TUI/UI/Base/WindowManager.cpp
@@ -233,6 +233,258 @@ bool WindowManager::canRouteTo(const Window& window) const
     return targetEntry->zOrder >= modalEntry->zOrder;
 }
 
+UI::WindowHitTestResult WindowManager::hitTest(Point screenPosition)
+{
+    const WindowManager* self = this;
+    UI::WindowHitTestResult result = self->hitTest(screenPosition);
+    return result;
+}
+
+UI::WindowHitTestResult WindowManager::hitTest(Point screenPosition) const
+{
+    for (auto it = m_windows.rbegin(); it != m_windows.rend(); ++it)
+    {
+        const ManagedWindow& entry = *it;
+
+        if (entry.window == nullptr)
+        {
+            continue;
+        }
+
+        if (!canRouteTo(*entry.window))
+        {
+            continue;
+        }
+
+        const UI::CursorRegion region = entry.window->hitTest(screenPosition);
+        if (region == UI::CursorRegion::Outside)
+        {
+            continue;
+        }
+
+        return UI::WindowHitTestResult{
+            entry.window,
+            region,
+            screenPosition,
+            Point{
+                screenPosition.x - entry.window->x(),
+                screenPosition.y - entry.window->y()
+            }
+        };
+    }
+
+    return UI::WindowHitTestResult{
+        nullptr,
+        UI::CursorRegion::Outside,
+        screenPosition,
+        Point{}
+    };
+}
+
+void WindowManager::capturePointer(
+    Window& window,
+    UI::PointerButton button,
+    Point screenPosition)
+{
+    if (!canRouteTo(window))
+    {
+        return;
+    }
+
+    m_pointerCapture.window = &window;
+    m_pointerCapture.button = button;
+    m_pointerCapture.origin = screenPosition;
+    m_pointerCapture.current = screenPosition;
+}
+
+void WindowManager::releasePointer(Window& window)
+{
+    if (m_pointerCapture.window == &window)
+    {
+        releasePointer();
+    }
+}
+
+void WindowManager::releasePointer()
+{
+    m_pointerCapture.clear();
+}
+
+bool WindowManager::hasPointerCapture() const
+{
+    return m_pointerCapture.active();
+}
+
+const UI::PointerCaptureState& WindowManager::pointerCapture() const
+{
+    return m_pointerCapture;
+}
+
+Window* WindowManager::capturedWindow()
+{
+    return m_pointerCapture.window;
+}
+
+const Window* WindowManager::capturedWindow() const
+{
+    return m_pointerCapture.window;
+}
+
+bool WindowManager::beginDrag(
+    Window& window,
+    Point screenPosition,
+    UI::PointerButton button)
+{
+    if (!canRouteTo(window) || !window.isDraggable())
+    {
+        return false;
+    }
+
+    m_resizeState.clear();
+    m_dragState.window = &window;
+    m_dragState.pointerOrigin = screenPosition;
+    m_dragState.currentPointer = screenPosition;
+    m_dragState.originalBounds = window.bounds();
+
+    capturePointer(window, button, screenPosition);
+    bringToFront(window);
+    return true;
+}
+
+bool WindowManager::beginDragAt(Point screenPosition, UI::PointerButton button)
+{
+    UI::WindowHitTestResult result = hitTest(screenPosition);
+    if (!result.hit() || result.region != UI::CursorRegion::TitleBar)
+    {
+        return false;
+    }
+
+    return beginDrag(*result.window, screenPosition, button);
+}
+
+bool WindowManager::updateDrag(Point screenPosition)
+{
+    if (!m_dragState.active())
+    {
+        return false;
+    }
+
+    Window* window = m_dragState.window;
+    if (window == nullptr)
+    {
+        m_dragState.clear();
+        releasePointer();
+        return false;
+    }
+
+    m_dragState.currentPointer = screenPosition;
+    m_pointerCapture.current = screenPosition;
+
+    const int deltaX = screenPosition.x - m_dragState.pointerOrigin.x;
+    const int deltaY = screenPosition.y - m_dragState.pointerOrigin.y;
+
+    Rect movedBounds = m_dragState.originalBounds;
+    movedBounds.position.x += deltaX;
+    movedBounds.position.y += deltaY;
+    window->setBounds(movedBounds);
+    return true;
+}
+
+void WindowManager::endDrag()
+{
+    m_dragState.clear();
+    releasePointer();
+}
+
+bool WindowManager::isDragging() const
+{
+    return m_dragState.active();
+}
+
+const UI::WindowDragState& WindowManager::dragState() const
+{
+    return m_dragState;
+}
+
+bool WindowManager::beginResize(
+    Window& window,
+    UI::CursorRegion region,
+    Point screenPosition,
+    UI::PointerButton button)
+{
+    if (!canRouteTo(window) || !window.isResizable() || !UI::isResizeRegion(region))
+    {
+        return false;
+    }
+
+    m_dragState.clear();
+    m_resizeState.window = &window;
+    m_resizeState.region = region;
+    m_resizeState.pointerOrigin = screenPosition;
+    m_resizeState.currentPointer = screenPosition;
+    m_resizeState.originalBounds = window.bounds();
+    m_resizeState.minimumSize = window.minimumSize();
+
+    capturePointer(window, button, screenPosition);
+    bringToFront(window);
+    return true;
+}
+
+bool WindowManager::beginResizeAt(Point screenPosition, UI::PointerButton button)
+{
+    UI::WindowHitTestResult result = hitTest(screenPosition);
+    if (!result.hit() || !UI::isResizeRegion(result.region))
+    {
+        return false;
+    }
+
+    return beginResize(*result.window, result.region, screenPosition, button);
+}
+
+bool WindowManager::updateResize(Point screenPosition)
+{
+    if (!m_resizeState.active())
+    {
+        return false;
+    }
+
+    Window* window = m_resizeState.window;
+    if (window == nullptr)
+    {
+        m_resizeState.clear();
+        releasePointer();
+        return false;
+    }
+
+    m_resizeState.currentPointer = screenPosition;
+    m_pointerCapture.current = screenPosition;
+
+    window->setBounds(UI::resizedBounds(
+        m_resizeState.originalBounds,
+        m_resizeState.region,
+        m_resizeState.pointerOrigin,
+        screenPosition,
+        m_resizeState.minimumSize));
+
+    return true;
+}
+
+void WindowManager::endResize()
+{
+    m_resizeState.clear();
+    releasePointer();
+}
+
+bool WindowManager::isResizing() const
+{
+    return m_resizeState.active();
+}
+
+const UI::WindowResizeState& WindowManager::resizeState() const
+{
+    return m_resizeState;
+}
+
 void WindowManager::update(double deltaTime)
 {
     for (ManagedWindow& entry : m_windows)

--- a/TUI/UI/Base/WindowManager.h
+++ b/TUI/UI/Base/WindowManager.h
@@ -1,10 +1,13 @@
+// UI/Base/WindowManager.h
 #pragma once
 
 #include <cstddef>
 #include <vector>
 
+#include "Core/Point.h"
 #include "Rendering/LayerInstance.h"
 #include "Rendering/Surface.h"
+#include "UI/Interaction/WindowInteraction.h"
 
 class Window;
 
@@ -40,6 +43,31 @@ public:
     bool hasModalWindow() const;
     bool canRouteTo(const Window& window) const;
 
+    UI::WindowHitTestResult hitTest(Point screenPosition);
+    UI::WindowHitTestResult hitTest(Point screenPosition) const;
+
+    void capturePointer(Window& window, UI::PointerButton button, Point screenPosition);
+    void releasePointer(Window& window);
+    void releasePointer();
+    bool hasPointerCapture() const;
+    const UI::PointerCaptureState& pointerCapture() const;
+    Window* capturedWindow();
+    const Window* capturedWindow() const;
+
+    bool beginDrag(Window& window, Point screenPosition, UI::PointerButton button = UI::PointerButton::Primary);
+    bool beginDragAt(Point screenPosition, UI::PointerButton button = UI::PointerButton::Primary);
+    bool updateDrag(Point screenPosition);
+    void endDrag();
+    bool isDragging() const;
+    const UI::WindowDragState& dragState() const;
+
+    bool beginResize(Window& window, UI::CursorRegion region, Point screenPosition, UI::PointerButton button = UI::PointerButton::Primary);
+    bool beginResizeAt(Point screenPosition, UI::PointerButton button = UI::PointerButton::Primary);
+    bool updateResize(Point screenPosition);
+    void endResize();
+    bool isResizing() const;
+    const UI::WindowResizeState& resizeState() const;
+
     void update(double deltaTime);
     void draw(Surface& surface);
 
@@ -64,4 +92,8 @@ private:
 private:
     std::vector<ManagedWindow> m_windows;
     std::size_t m_nextInsertionOrder = 0;
+
+    UI::PointerCaptureState m_pointerCapture;
+    UI::WindowDragState m_dragState;
+    UI::WindowResizeState m_resizeState;
 };

--- a/TUI/UI/Interaction/WindowInteraction.cpp
+++ b/TUI/UI/Interaction/WindowInteraction.cpp
@@ -1,0 +1,266 @@
+#include "UI/Interaction/WindowInteraction.h"
+
+#include <algorithm>
+
+namespace
+{
+    int rightExclusive(const Rect& rect)
+    {
+        return rect.position.x + rect.size.width;
+    }
+
+    int bottomExclusive(const Rect& rect)
+    {
+        return rect.position.y + rect.size.height;
+    }
+}
+
+namespace UI
+{
+    bool WindowHitTestResult::hit() const
+    {
+        return window != nullptr && region != CursorRegion::Outside;
+    }
+
+    bool PointerCaptureState::active() const
+    {
+        return window != nullptr;
+    }
+
+    void PointerCaptureState::clear()
+    {
+        window = nullptr;
+        button = PointerButton::None;
+        origin = Point{};
+        current = Point{};
+    }
+
+    bool WindowDragState::active() const
+    {
+        return window != nullptr;
+    }
+
+    void WindowDragState::clear()
+    {
+        window = nullptr;
+        pointerOrigin = Point{};
+        currentPointer = Point{};
+        originalBounds = Rect{};
+    }
+
+    bool WindowResizeState::active() const
+    {
+        return window != nullptr;
+    }
+
+    void WindowResizeState::clear()
+    {
+        window = nullptr;
+        region = CursorRegion::Outside;
+        pointerOrigin = Point{};
+        currentPointer = Point{};
+        originalBounds = Rect{};
+        minimumSize = Size{ 4, 3 };
+    }
+
+    bool isResizeRegion(CursorRegion region)
+    {
+        switch (region)
+        {
+        case CursorRegion::LeftEdge:
+        case CursorRegion::RightEdge:
+        case CursorRegion::TopEdge:
+        case CursorRegion::BottomEdge:
+        case CursorRegion::TopLeftCorner:
+        case CursorRegion::TopRightCorner:
+        case CursorRegion::BottomLeftCorner:
+        case CursorRegion::BottomRightCorner:
+            return true;
+
+        default:
+            return false;
+        }
+    }
+
+    bool isEdgeRegion(CursorRegion region)
+    {
+        switch (region)
+        {
+        case CursorRegion::LeftEdge:
+        case CursorRegion::RightEdge:
+        case CursorRegion::TopEdge:
+        case CursorRegion::BottomEdge:
+            return true;
+
+        default:
+            return false;
+        }
+    }
+
+    bool isCornerRegion(CursorRegion region)
+    {
+        switch (region)
+        {
+        case CursorRegion::TopLeftCorner:
+        case CursorRegion::TopRightCorner:
+        case CursorRegion::BottomLeftCorner:
+        case CursorRegion::BottomRightCorner:
+            return true;
+
+        default:
+            return false;
+        }
+    }
+
+    bool isInsideWindowRegion(CursorRegion region)
+    {
+        return region != CursorRegion::Outside;
+    }
+
+    CursorRegion hitTestWindowBounds(
+        const Rect& bounds,
+        Point screenPosition,
+        int resizeBorderThickness,
+        int titleBarHeight)
+    {
+        if (bounds.size.width <= 0 || bounds.size.height <= 0)
+        {
+            return CursorRegion::Outside;
+        }
+
+        if (!bounds.contains(screenPosition.x, screenPosition.y))
+        {
+            return CursorRegion::Outside;
+        }
+
+        resizeBorderThickness = std::max(0, resizeBorderThickness);
+        titleBarHeight = std::max(0, titleBarHeight);
+
+        const int left = bounds.position.x;
+        const int top = bounds.position.y;
+        const int right = rightExclusive(bounds) - 1;
+        const int bottom = bottomExclusive(bounds) - 1;
+
+        const bool onLeft = resizeBorderThickness > 0
+            && screenPosition.x < left + resizeBorderThickness;
+        const bool onRight = resizeBorderThickness > 0
+            && screenPosition.x > right - resizeBorderThickness;
+        const bool onTop = resizeBorderThickness > 0
+            && screenPosition.y < top + resizeBorderThickness;
+        const bool onBottom = resizeBorderThickness > 0
+            && screenPosition.y > bottom - resizeBorderThickness;
+
+        if (onTop && onLeft)
+        {
+            return CursorRegion::TopLeftCorner;
+        }
+
+        if (onTop && onRight)
+        {
+            return CursorRegion::TopRightCorner;
+        }
+
+        if (onBottom && onLeft)
+        {
+            return CursorRegion::BottomLeftCorner;
+        }
+
+        if (onBottom && onRight)
+        {
+            return CursorRegion::BottomRightCorner;
+        }
+
+        if (onLeft)
+        {
+            return CursorRegion::LeftEdge;
+        }
+
+        if (onRight)
+        {
+            return CursorRegion::RightEdge;
+        }
+
+        if (onTop)
+        {
+            return CursorRegion::TopEdge;
+        }
+
+        if (onBottom)
+        {
+            return CursorRegion::BottomEdge;
+        }
+
+        if (titleBarHeight > 0 && screenPosition.y < top + titleBarHeight)
+        {
+            return CursorRegion::TitleBar;
+        }
+
+        return CursorRegion::Client;
+    }
+
+    Rect resizedBounds(
+        const Rect& originalBounds,
+        CursorRegion resizeRegion,
+        Point pointerOrigin,
+        Point currentPointer,
+        Size minimumSize)
+    {
+        const int deltaX = currentPointer.x - pointerOrigin.x;
+        const int deltaY = currentPointer.y - pointerOrigin.y;
+
+        const int originalRight = originalBounds.position.x + originalBounds.size.width;
+        const int originalBottom = originalBounds.position.y + originalBounds.size.height;
+
+        Rect result = originalBounds;
+        minimumSize.width = std::max(1, minimumSize.width);
+        minimumSize.height = std::max(1, minimumSize.height);
+
+        switch (resizeRegion)
+        {
+        case CursorRegion::LeftEdge:
+        case CursorRegion::TopLeftCorner:
+        case CursorRegion::BottomLeftCorner:
+            result.position.x = std::min(
+                originalBounds.position.x + deltaX,
+                originalRight - minimumSize.width);
+            result.size.width = originalRight - result.position.x;
+            break;
+
+        case CursorRegion::RightEdge:
+        case CursorRegion::TopRightCorner:
+        case CursorRegion::BottomRightCorner:
+            result.size.width = std::max(
+                minimumSize.width,
+                originalBounds.size.width + deltaX);
+            break;
+
+        default:
+            break;
+        }
+
+        switch (resizeRegion)
+        {
+        case CursorRegion::TopEdge:
+        case CursorRegion::TopLeftCorner:
+        case CursorRegion::TopRightCorner:
+            result.position.y = std::min(
+                originalBounds.position.y + deltaY,
+                originalBottom - minimumSize.height);
+            result.size.height = originalBottom - result.position.y;
+            break;
+
+        case CursorRegion::BottomEdge:
+        case CursorRegion::BottomLeftCorner:
+        case CursorRegion::BottomRightCorner:
+            result.size.height = std::max(
+                minimumSize.height,
+                originalBounds.size.height + deltaY);
+            break;
+
+        default:
+            break;
+        }
+
+        return result;
+    }
+}

--- a/TUI/UI/Interaction/WindowInteraction.h
+++ b/TUI/UI/Interaction/WindowInteraction.h
@@ -1,0 +1,112 @@
+#pragma once
+
+#include "Core/Point.h"
+#include "Core/Rect.h"
+
+class Window;
+
+namespace UI
+{
+    enum class PointerButton
+    {
+        None,
+        Primary,
+        Secondary,
+        Middle
+    };
+
+    enum class PointerAction
+    {
+        Move,
+        Press,
+        Release,
+        Drag,
+        Cancel
+    };
+
+    enum class CursorRegion
+    {
+        Outside,
+        Client,
+        TitleBar,
+        LeftEdge,
+        RightEdge,
+        TopEdge,
+        BottomEdge,
+        TopLeftCorner,
+        TopRightCorner,
+        BottomLeftCorner,
+        BottomRightCorner
+    };
+
+    struct PointerEvent
+    {
+        Point position;
+        PointerButton button = PointerButton::None;
+        PointerAction action = PointerAction::Move;
+        int clickCount = 0;
+    };
+
+    struct WindowHitTestResult
+    {
+        Window* window = nullptr;
+        CursorRegion region = CursorRegion::Outside;
+        Point screenPosition;
+        Point localPosition;
+
+        bool hit() const;
+    };
+
+    struct PointerCaptureState
+    {
+        Window* window = nullptr;
+        PointerButton button = PointerButton::None;
+        Point origin;
+        Point current;
+
+        bool active() const;
+        void clear();
+    };
+
+    struct WindowDragState
+    {
+        Window* window = nullptr;
+        Point pointerOrigin;
+        Point currentPointer;
+        Rect originalBounds;
+
+        bool active() const;
+        void clear();
+    };
+
+    struct WindowResizeState
+    {
+        Window* window = nullptr;
+        CursorRegion region = CursorRegion::Outside;
+        Point pointerOrigin;
+        Point currentPointer;
+        Rect originalBounds;
+        Size minimumSize{ 4, 3 };
+
+        bool active() const;
+        void clear();
+    };
+
+    bool isResizeRegion(CursorRegion region);
+    bool isEdgeRegion(CursorRegion region);
+    bool isCornerRegion(CursorRegion region);
+    bool isInsideWindowRegion(CursorRegion region);
+
+    CursorRegion hitTestWindowBounds(
+        const Rect& bounds,
+        Point screenPosition,
+        int resizeBorderThickness = 1,
+        int titleBarHeight = 1);
+
+    Rect resizedBounds(
+        const Rect& originalBounds,
+        CursorRegion resizeRegion,
+        Point pointerOrigin,
+        Point currentPointer,
+        Size minimumSize);
+}

--- a/TUI/UI/Panels/Window.cpp
+++ b/TUI/UI/Panels/Window.cpp
@@ -1,5 +1,6 @@
 #include "UI/Panels/Window.h"
 
+#include <algorithm>
 #include <utility>
 
 Window::Window()
@@ -31,4 +32,81 @@ bool Window::isModal() const
 void Window::setModal(bool modal)
 {
     m_modal = modal;
+}
+
+bool Window::isDraggable() const
+{
+    return m_draggable;
+}
+
+void Window::setDraggable(bool draggable)
+{
+    m_draggable = draggable;
+}
+
+bool Window::isResizable() const
+{
+    return m_resizable;
+}
+
+void Window::setResizable(bool resizable)
+{
+    m_resizable = resizable;
+}
+
+Size Window::minimumSize() const
+{
+    return m_minimumSize;
+}
+
+void Window::setMinimumSize(Size size)
+{
+    m_minimumSize.width = std::max(1, size.width);
+    m_minimumSize.height = std::max(1, size.height);
+}
+
+void Window::setMinimumSize(int width, int height)
+{
+    setMinimumSize(Size{ width, height });
+}
+
+int Window::resizeBorderThickness() const
+{
+    return m_resizeBorderThickness;
+}
+
+void Window::setResizeBorderThickness(int thickness)
+{
+    m_resizeBorderThickness = std::max(0, thickness);
+}
+
+int Window::titleBarHeight() const
+{
+    return m_titleBarHeight;
+}
+
+void Window::setTitleBarHeight(int height)
+{
+    m_titleBarHeight = std::max(0, height);
+}
+
+UI::CursorRegion Window::hitTest(Point screenPosition) const
+{
+    UI::CursorRegion region = UI::hitTestWindowBounds(
+        bounds(),
+        screenPosition,
+        m_resizable ? m_resizeBorderThickness : 0,
+        m_titleBarHeight);
+
+    if (!m_draggable && region == UI::CursorRegion::TitleBar)
+    {
+        return UI::CursorRegion::Client;
+    }
+
+    return region;
+}
+
+bool Window::containsScreenPoint(Point screenPosition) const
+{
+    return hitTest(screenPosition) != UI::CursorRegion::Outside;
 }

--- a/TUI/UI/Panels/Window.h
+++ b/TUI/UI/Panels/Window.h
@@ -2,7 +2,9 @@
 
 #include <string>
 
+#include "Core/Point.h"
 #include "Core/Rect.h"
+#include "UI/Interaction/WindowInteraction.h"
 #include "UI/Panels/Panel.h"
 
 class Window : public Panel
@@ -16,6 +18,30 @@ public:
     bool isModal() const;
     void setModal(bool modal);
 
+    bool isDraggable() const;
+    void setDraggable(bool draggable);
+
+    bool isResizable() const;
+    void setResizable(bool resizable);
+
+    Size minimumSize() const;
+    void setMinimumSize(Size size);
+    void setMinimumSize(int width, int height);
+
+    int resizeBorderThickness() const;
+    void setResizeBorderThickness(int thickness);
+
+    int titleBarHeight() const;
+    void setTitleBarHeight(int height);
+
+    UI::CursorRegion hitTest(Point screenPosition) const;
+    bool containsScreenPoint(Point screenPosition) const;
+
 private:
     bool m_modal = false;
+    bool m_draggable = true;
+    bool m_resizable = true;
+    Size m_minimumSize{ 4, 3 };
+    int m_resizeBorderThickness = 1;
+    int m_titleBarHeight = 1;
 };


### PR DESCRIPTION
Modifies:
- TUI.vcxproj
- UI/Base/WindowManager.h/.cpp
- UI/Panels/Window.h/.cpp

Adds:
- UI/Interaction/WindowInteraction.h/.cpp

- Add reusable window interaction foundation types under UI/Interaction
- Add pointer event, pointer capture, drag state, resize state, and hit-test result structures
- Add CursorRegion support for client area, title bar, edges, and resize corners
- Add reusable window hit testing and resize bounds helpers
- Extend Window with draggable/resizable configuration and hit-test support
- Add WindowManager support for pointer capture, hit testing, drag tracking, and resize tracking
- Preserve existing rendering and window composition behavior
- Keep interaction layer backend-agnostic for future mouse/pointer integrations

Closes: #263 