### PR TITLE
TextView: TextView Clipping Cleanup

### DIFF
--- a/TUI/UI/Widgets/TextView.cpp
+++ b/TUI/UI/Widgets/TextView.cpp
@@ -2,15 +2,13 @@
 
 #include <algorithm>
 #include <cstddef>
-#include <sstream>
 #include <utility>
-#include < algorithm >
 
 #include "Core/Rect.h"
-#include "Core/Size.h"
 #include "Rendering/ScreenBuffer.h"
 #include "Rendering/Surface.h"
 #include "Utilities/Text/TextClip.h"
+#include "Utilities/Unicode/UnicodeConversion.h"
 
 TextView::TextView(std::string title)
 {
@@ -72,27 +70,17 @@ const Style& TextView::textStyle() const
     return m_textStyle;
 }
 
-void TextView::draw(Surface& surface)
+void TextView::drawScrollableContent(
+    Surface& surface,
+    const Rect& visibleContentRect)
 {
-    ScrollablePanel::draw(surface);
-
-    ScreenBuffer& buffer = surface.buffer();
-    const Rect textRect = resolveTextRect();
-
-    if (textRect.size.width <= 0 || textRect.size.height <= 0)
-    {
-        return;
-    }
-
-    viewport().setViewSize(textRect.size.width, textRect.size.height);
     updateContentSizeFromLines();
 
-    const int offsetX = viewport().scrollX();
-    const int offsetY = viewport().scrollY();
+    ScreenBuffer& buffer = surface.buffer();
 
-    for (int row = 0; row < textRect.size.height; ++row)
+    for (int viewY = 0; viewY < visibleContentRect.size.height; ++viewY)
     {
-        const int lineIndex = offsetY + row;
+        const int lineIndex = visibleContentRect.position.y + viewY;
 
         if (lineIndex < 0 || lineIndex >= static_cast<int>(m_lines.size()))
         {
@@ -100,20 +88,18 @@ void TextView::draw(Surface& surface)
         }
 
         const std::string& sourceLine = m_lines[static_cast<std::size_t>(lineIndex)];
+        const int offsetX = visibleContentRect.position.x;
 
         if (offsetX >= static_cast<int>(sourceLine.size()))
         {
             continue;
         }
 
-        const std::string visibleText =
-            TextClip::clipUtf8Text(sourceLine.substr(static_cast<std::size_t>(offsetX)), textRect.size.width);
+        const std::string visibleText = TextClip::clipUtf8Text(
+            sourceLine.substr(static_cast<std::size_t>(offsetX)),
+            visibleContentRect.size.width);
 
-        buffer.writeString(
-            textRect.position.x,
-            textRect.position.y + row,
-            visibleText,
-            m_textStyle);
+        buffer.writeString(0, viewY, visibleText, m_textStyle);
     }
 }
 
@@ -123,24 +109,12 @@ void TextView::updateContentSizeFromLines()
 
     for (const std::string& line : m_lines)
     {
-        maxWidth = std::max(maxWidth, TextClip::measureDisplayWidth(
-            UnicodeConversion::utf8ToU32(line)));
+        maxWidth = std::max(
+            maxWidth,
+            TextClip::measureDisplayWidth(UnicodeConversion::utf8ToU32(line)));
     }
 
     viewport().setContentSize(maxWidth, static_cast<int>(m_lines.size()));
-}
-
-Rect TextView::resolveTextRect() const
-{
-    Rect rect = bounds();
-
-    // Inner panel area: leave room for border.
-    rect.position.x += 1;
-    rect.position.y += 1;
-    rect.size.width = std::max(0, rect.size.width - 2);
-    rect.size.height = std::max(0, rect.size.height - 2);
-
-    return rect;
 }
 
 std::vector<std::string> TextView::splitLines(std::string_view text)

--- a/TUI/UI/Widgets/TextView.h
+++ b/TUI/UI/Widgets/TextView.h
@@ -1,9 +1,11 @@
 #pragma once
 
+#include <cstddef>
 #include <string>
 #include <string_view>
 #include <vector>
 
+#include "Core/Rect.h"
 #include "Rendering/Styles/Style.h"
 #include "UI/Panels/ScrollablePanel.h"
 
@@ -28,11 +30,13 @@ public:
     void setTextStyle(const Style& style);
     const Style& textStyle() const;
 
-    void draw(Surface& surface) override;
+protected:
+    void drawScrollableContent(
+        Surface& surface,
+        const Rect& visibleContentRect) override;
 
 private:
     void updateContentSizeFromLines();
-    Rect resolveTextRect() const;
     static std::vector<std::string> splitLines(std::string_view text);
 
 private:


### PR DESCRIPTION
Modifies:
- UI/Widgets/TextView.h/.cpp

- Performed final Phase 10 validation against the roadmap:
  - Viewport
  - ScrollablePanel
  - TextView
  - Tile/grid content support
  - Grid loading
  - Scrollable demo integration
  - Window interaction foundation

- Confirmed viewport scroll clamping behaves correctly for oversized content.
- Confirmed ScrollablePanel performs clipping-aware rendering through viewport surfaces.
- Confirmed large text and grid content scroll cleanly without bypassing rendering composition.
- Confirmed tile/grid assets normalize into engine-owned structures before rendering.
- Confirmed all rendering still resolves through ScreenCell / ScreenBuffer composition.
- Confirmed WindowInteraction integrates as a supplemental interaction layer without replacing WindowManager.
- Confirmed no ownership or lifetime regressions were introduced.

TextView cleanup:
- Refactored TextView to render through ScrollablePanel::drawScrollableContent().
- Removed incorrect rendering/include dependencies.
- Centralized clipping behavior through the scrollable panel pipeline.
- Improved consistency between text rendering and viewport composition behavior.
- Preserved UTF-8 clipping and display-width handling.

Result:
- TUI now has a reusable scrolling and structured content foundation suitable for:
  - manuals
  - reports
  - logs
  - dashboards
  - tile/grid layouts
  - future interactive window systems

Closes: #256 
Closes: #264 