### PR TITLE
Label: Implement Label widget foundation

### DIFF
--- a/TUI/TUI.vcxproj
+++ b/TUI/TUI.vcxproj
@@ -295,6 +295,7 @@
     <ClInclude Include="UI\Panels\StatusBar.h" />
     <ClInclude Include="UI\Panels\Window.h" />
     <ClInclude Include="UI\Widgets\ContainerWidget.h" />
+    <ClInclude Include="UI\Widgets\Label.h" />
     <ClInclude Include="UI\Widgets\TextView.h" />
     <ClInclude Include="UI\Widgets\TileGridView.h" />
     <ClInclude Include="UI\Widgets\Widget.h" />
@@ -456,6 +457,7 @@
     <ClCompile Include="UI\Panels\StatusBar.cpp" />
     <ClCompile Include="UI\Panels\Window.cpp" />
     <ClCompile Include="UI\Widgets\ContainerWidget.cpp" />
+    <ClCompile Include="UI\Widgets\Label.cpp" />
     <ClCompile Include="UI\Widgets\TextView.cpp" />
     <ClCompile Include="UI\Widgets\TileGridView.cpp" />
     <ClCompile Include="UI\Widgets\Widget.cpp" />

--- a/TUI/UI/Widgets/Label.cpp
+++ b/TUI/UI/Widgets/Label.cpp
@@ -1,0 +1,100 @@
+#include "UI/Widgets/Label.h"
+
+#include <utility>
+
+#include "Rendering/ScreenBuffer.h"
+#include "Rendering/Styles/UIThemes.h"
+#include "Rendering/Surface.h"
+#include "Utilities/Text/TextClip.h"
+
+Label::Label()
+    : Widget()
+    , m_textStyle(UIThemes::Label)
+{
+    setFocusable(false);
+}
+
+Label::Label(std::string text)
+    : Widget()
+    , m_text(std::move(text))
+    , m_textStyle(UIThemes::Label)
+{
+    setFocusable(false);
+}
+
+Label::Label(const Rect& bounds, std::string text)
+    : Widget(bounds)
+    , m_text(std::move(text))
+    , m_textStyle(UIThemes::Label)
+{
+    setFocusable(false);
+}
+
+const std::string& Label::text() const
+{
+    return m_text;
+}
+
+void Label::setText(std::string_view text)
+{
+    m_text.assign(text.begin(), text.end());
+}
+
+void Label::clearText()
+{
+    m_text.clear();
+}
+
+bool Label::empty() const
+{
+    return m_text.empty();
+}
+
+const Style& Label::textStyle() const
+{
+    return m_textStyle;
+}
+
+void Label::setTextStyle(const Style& style)
+{
+    m_textStyle = style;
+}
+
+void Label::draw(Surface& surface)
+{
+    if (!isVisible())
+    {
+        return;
+    }
+
+    const Rect labelBounds = bounds();
+
+    if (labelBounds.size.width <= 0 || labelBounds.size.height <= 0)
+    {
+        return;
+    }
+
+    if (m_text.empty())
+    {
+        return;
+    }
+
+    const std::string clippedText = TextClip::clipUtf8Text(
+        m_text,
+        labelBounds.size.width);
+
+    if (clippedText.empty())
+    {
+        return;
+    }
+
+    const Style& renderStyle = isEnabled()
+        ? m_textStyle
+        : UIThemes::DisabledText;
+
+    surface.buffer().writeString(
+        labelBounds.position.x,
+        labelBounds.position.y,
+        clippedText,
+        renderStyle);
+}

--- a/TUI/UI/Widgets/Label.h
+++ b/TUI/UI/Widgets/Label.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <string>
+#include <string_view>
+
+#include "Core/Rect.h"
+#include "Rendering/Styles/Style.h"
+#include "UI/Widgets/Widget.h"
+
+class Surface;
+
+class Label : public Widget
+{
+public:
+    Label();
+    explicit Label(std::string text);
+    Label(const Rect& bounds, std::string text = {});
+
+    const std::string& text() const;
+    void setText(std::string_view text);
+    void clearText();
+    bool empty() const;
+
+    const Style& textStyle() const;
+    void setTextStyle(const Style& style);
+
+    void draw(Surface& surface) override;
+
+private:
+    std::string m_text;
+    Style m_textStyle;
+};


### PR DESCRIPTION
Modifies:
- TUI.vcxproj

Adds:
- UI/Widget/Label.h/.cpp

- Implemented lightweight read-only Label widget derived from Widget
- Added single-line text rendering for captions, headings, and field labels
- Added setText(), text(), clearText(), and empty() APIs
- Added configurable text style support via setTextStyle()
- Integrated rendering with existing Surface and ScreenBuffer systems
- Added clipping-safe rendering using TextClip utilities
- Added disabled-state rendering support using theme styles
- Configured Label as non-focusable by default
- Kept implementation intentionally simple and reusable for future UI composition

Closes: #268 