### PR TITLE
Button: Implement reusable Button widget control

### DIFF
--- a/TUI/TUI.vcxproj
+++ b/TUI/TUI.vcxproj
@@ -294,6 +294,7 @@
     <ClInclude Include="UI\Panels\ScrollablePanel.h" />
     <ClInclude Include="UI\Panels\StatusBar.h" />
     <ClInclude Include="UI\Panels\Window.h" />
+    <ClInclude Include="UI\Widgets\Button.h" />
     <ClInclude Include="UI\Widgets\ContainerWidget.h" />
     <ClInclude Include="UI\Widgets\Label.h" />
     <ClInclude Include="UI\Widgets\TextView.h" />
@@ -456,6 +457,7 @@
     <ClCompile Include="UI\Panels\ScrollablePanel.cpp" />
     <ClCompile Include="UI\Panels\StatusBar.cpp" />
     <ClCompile Include="UI\Panels\Window.cpp" />
+    <ClCompile Include="UI\Widgets\Button.cpp" />
     <ClCompile Include="UI\Widgets\ContainerWidget.cpp" />
     <ClCompile Include="UI\Widgets\Label.cpp" />
     <ClCompile Include="UI\Widgets\TextView.cpp" />

--- a/TUI/UI/Widgets/Button.cpp
+++ b/TUI/UI/Widgets/Button.cpp
@@ -1,0 +1,267 @@
+#include "UI/Widgets/Button.h"
+
+#include <algorithm>
+#include <utility>
+
+#include "Input/Command.h"
+#include "Input/Event.h"
+#include "Rendering/ScreenBuffer.h"
+#include "Rendering/Styles/UIThemes.h"
+#include "Rendering/Surface.h"
+#include "Utilities/Text/TextClip.h"
+#include "Utilities/Unicode/UnicodeConversion.h"
+
+Button::Button()
+    : Widget()
+    , m_normalStyle(UIThemes::ButtonNormal)
+    , m_focusedStyle(UIThemes::ButtonHot)
+    , m_disabledStyle(UIThemes::ButtonDisabled)
+{
+    setFocusable(true);
+}
+
+Button::Button(std::string label)
+    : Widget()
+    , m_label(std::move(label))
+    , m_normalStyle(UIThemes::ButtonNormal)
+    , m_focusedStyle(UIThemes::ButtonHot)
+    , m_disabledStyle(UIThemes::ButtonDisabled)
+{
+    setFocusable(true);
+}
+
+Button::Button(const Rect& bounds, std::string label, std::string commandId)
+    : Widget(bounds)
+    , m_label(std::move(label))
+    , m_normalStyle(UIThemes::ButtonNormal)
+    , m_focusedStyle(UIThemes::ButtonHot)
+    , m_disabledStyle(UIThemes::ButtonDisabled)
+{
+    if (!commandId.empty())
+    {
+        m_commandId = std::move(commandId);
+    }
+
+    setFocusable(true);
+}
+
+const std::string& Button::label() const
+{
+    return m_label;
+}
+
+void Button::setLabel(std::string_view label)
+{
+    m_label.assign(label.begin(), label.end());
+}
+
+void Button::clearLabel()
+{
+    m_label.clear();
+}
+
+bool Button::hasCommandId() const
+{
+    return m_commandId.has_value() && !m_commandId->empty();
+}
+
+const std::optional<std::string>& Button::commandId() const
+{
+    return m_commandId;
+}
+
+void Button::setCommandId(std::string_view commandId)
+{
+    if (commandId.empty())
+    {
+        clearCommandId();
+        return;
+    }
+
+    m_commandId = std::string(commandId);
+}
+
+void Button::clearCommandId()
+{
+    m_commandId.reset();
+}
+
+const Style& Button::normalStyle() const
+{
+    return m_normalStyle;
+}
+
+void Button::setNormalStyle(const Style& style)
+{
+    m_normalStyle = style;
+}
+
+const Style& Button::focusedStyle() const
+{
+    return m_focusedStyle;
+}
+
+void Button::setFocusedStyle(const Style& style)
+{
+    m_focusedStyle = style;
+}
+
+const Style& Button::disabledStyle() const
+{
+    return m_disabledStyle;
+}
+
+void Button::setDisabledStyle(const Style& style)
+{
+    m_disabledStyle = style;
+}
+
+void Button::setActivationCallback(ActivationCallback callback)
+{
+    m_activationCallback = std::move(callback);
+}
+
+void Button::clearActivationCallback()
+{
+    m_activationCallback = nullptr;
+}
+
+ButtonActivationResult Button::activate()
+{
+    ButtonActivationResult result;
+    result.activated = isVisible() && isEnabled();
+    result.label = m_label;
+
+    if (m_commandId.has_value())
+    {
+        result.commandId = *m_commandId;
+    }
+
+    if (!result.activated)
+    {
+        return result;
+    }
+
+    m_lastActivationResult = result;
+
+    if (m_activationCallback)
+    {
+        m_activationCallback(result);
+    }
+
+    return result;
+}
+
+bool Button::hasPendingActivation() const
+{
+    return m_lastActivationResult.has_value();
+}
+
+std::optional<ButtonActivationResult> Button::lastActivationResult() const
+{
+    return m_lastActivationResult;
+}
+
+std::optional<ButtonActivationResult> Button::consumeActivationResult()
+{
+    std::optional<ButtonActivationResult> result = m_lastActivationResult;
+    m_lastActivationResult.reset();
+    return result;
+}
+
+void Button::draw(Surface& surface)
+{
+    if (!isVisible())
+    {
+        return;
+    }
+
+    const Rect buttonBounds = bounds();
+
+    if (buttonBounds.size.width <= 0 || buttonBounds.size.height <= 0)
+    {
+        return;
+    }
+
+    const Style& renderStyle = resolveRenderStyle();
+
+    surface.buffer().fillRect(buttonBounds, U' ', renderStyle);
+
+    const std::string displayText = buildDisplayText(buttonBounds.size.width);
+    if (displayText.empty())
+    {
+        return;
+    }
+
+    const int textWidth = measureUtf8Width(displayText);
+    const int textX = buttonBounds.position.x
+        + std::max(0, (buttonBounds.size.width - textWidth) / 2);
+    const int textY = buttonBounds.position.y
+        + std::max(0, buttonBounds.size.height / 2);
+
+    surface.buffer().writeString(textX, textY, displayText, renderStyle);
+}
+
+bool Button::handleEvent(const Input::Event& event)
+{
+    if (!isVisible() || !isEnabled())
+    {
+        return false;
+    }
+
+    const Input::CommandEvent* commandEvent = event.asCommand();
+    if (!commandEvent)
+    {
+        return false;
+    }
+
+    if (commandEvent->command.code != Input::CommandCode::Confirm)
+    {
+        return false;
+    }
+
+    const ButtonActivationResult result = activate();
+    return result.activated;
+}
+
+const Style& Button::resolveRenderStyle() const
+{
+    if (!isEnabled())
+    {
+        return m_disabledStyle;
+    }
+
+    if (isFocused())
+    {
+        return m_focusedStyle;
+    }
+
+    return m_normalStyle;
+}
+
+std::string Button::buildDisplayText(int availableWidth) const
+{
+    if (availableWidth <= 0)
+    {
+        return {};
+    }
+
+    if (availableWidth == 1)
+    {
+        return TextClip::clipUtf8Text(m_label, 1);
+    }
+
+    if (availableWidth == 2)
+    {
+        return "[]";
+    }
+
+    const int labelWidth = std::max(0, availableWidth - 2);
+    return "[" + TextClip::clipUtf8Text(m_label, labelWidth) + "]";
+}
+
+int Button::measureUtf8Width(std::string_view text) const
+{
+    const std::u32string text32 = UnicodeConversion::utf8ToU32(text);
+    return TextClip::measureDisplayWidth(text32);
+}

--- a/TUI/UI/Widgets/Button.h
+++ b/TUI/UI/Widgets/Button.h
@@ -1,0 +1,80 @@
+#pragma once
+
+#include <functional>
+#include <optional>
+#include <string>
+#include <string_view>
+
+#include "Core/Rect.h"
+#include "Rendering/Styles/Style.h"
+#include "UI/Widgets/Widget.h"
+
+class Surface;
+
+namespace Input
+{
+    class Event;
+}
+
+struct ButtonActivationResult
+{
+    bool activated = false;
+    std::string commandId;
+    std::string label;
+};
+
+class Button : public Widget
+{
+public:
+    using ActivationCallback = std::function<void(const ButtonActivationResult&)>;
+
+    Button();
+    explicit Button(std::string label);
+    Button(const Rect& bounds, std::string label = {}, std::string commandId = {});
+
+    const std::string& label() const;
+    void setLabel(std::string_view label);
+    void clearLabel();
+
+    bool hasCommandId() const;
+    const std::optional<std::string>& commandId() const;
+    void setCommandId(std::string_view commandId);
+    void clearCommandId();
+
+    const Style& normalStyle() const;
+    void setNormalStyle(const Style& style);
+
+    const Style& focusedStyle() const;
+    void setFocusedStyle(const Style& style);
+
+    const Style& disabledStyle() const;
+    void setDisabledStyle(const Style& style);
+
+    void setActivationCallback(ActivationCallback callback);
+    void clearActivationCallback();
+
+    ButtonActivationResult activate();
+
+    bool hasPendingActivation() const;
+    std::optional<ButtonActivationResult> lastActivationResult() const;
+    std::optional<ButtonActivationResult> consumeActivationResult();
+
+    void draw(Surface& surface) override;
+    bool handleEvent(const Input::Event& event) override;
+
+private:
+    const Style& resolveRenderStyle() const;
+    std::string buildDisplayText(int availableWidth) const;
+    int measureUtf8Width(std::string_view text) const;
+
+private:
+    std::string m_label;
+    std::optional<std::string> m_commandId;
+
+    Style m_normalStyle;
+    Style m_focusedStyle;
+    Style m_disabledStyle;
+
+    ActivationCallback m_activationCallback;
+    std::optional<ButtonActivationResult> m_lastActivationResult;
+};


### PR DESCRIPTION
Modifies:
- TUI.vcxproj

Adds:
- UI/Widgets/Button.h/.cpp

- Implemented focusable Button widget derived from Widget
- Added label text support with runtime set/get APIs
- Added optional command ID support for action routing
- Implemented activation pipeline through:
  - activate()
  - handleEvent()
  - Input::CommandCode::Confirm
- Added ButtonActivationResult structure for backend-agnostic activation handling
- Added optional activation callback support
- Added activation result storage and consume/reset workflow
- Implemented focused, disabled, and normal visual states
- Integrated with existing UIThemes button styles:
  - ButtonNormal
  - ButtonHot
  - ButtonDisabled
- Added safe bounds-aware rendering and clipping behavior
- Added centered button label rendering with bracket-style presentation
- Preserved compatibility with:
  - FocusManager
  - ContainerWidget traversal
  - Surface/ScreenBuffer composition
  - backend-agnostic input handling
- Kept widget reusable and independent of any specific UI flow

Closes: #269 