### PR TITLE
WidgetStyle: Add unified widget style integration system

### DIFF
--- a/TUI/Rendering/Styles/UIThemes.h
+++ b/TUI/Rendering/Styles/UIThemes.h
@@ -160,4 +160,32 @@ namespace UIThemes
             Color::FromBasic(Color::Basic::BrightGreen),
             Color::FromIndexed(46),
             Color::FromRgb(0, 255, 95)));
+
+
+    // Reusable widget role/state styles. These aliases keep widget rendering
+    // consistent without introducing a second theme system. Existing roles above
+    // remain valid for older rendering code.
+    inline const Style WidgetLabelNormal = Label;
+    inline const Style WidgetLabelFocused = Label + Focused;
+    inline const Style WidgetLabelDisabled = DisabledText;
+    inline const Style WidgetLabelSelected = Selection;
+    inline const Style WidgetLabelSelectedFocused = Selection + Focused;
+
+    inline const Style WidgetTextNormal = NormalText;
+    inline const Style WidgetTextFocused = NormalText + Focused;
+    inline const Style WidgetTextDisabled = DisabledText;
+    inline const Style WidgetTextSelected = Selection;
+    inline const Style WidgetTextSelectedFocused = Selection + Focused;
+
+    inline const Style WidgetButtonNormal = ButtonNormal;
+    inline const Style WidgetButtonFocused = ButtonHot;
+    inline const Style WidgetButtonDisabled = ButtonDisabled;
+    inline const Style WidgetButtonSelected = ButtonHot;
+    inline const Style WidgetButtonSelectedFocused = ButtonHot + Focused;
+
+    inline const Style WidgetListItemNormal = NormalText;
+    inline const Style WidgetListItemFocused = Focused;
+    inline const Style WidgetListItemDisabled = DisabledText;
+    inline const Style WidgetListItemSelected = Selection;
+    inline const Style WidgetListItemSelectedFocused = Selection + Focused;
 }

--- a/TUI/TUI.vcxproj
+++ b/TUI/TUI.vcxproj
@@ -301,6 +301,7 @@
     <ClInclude Include="UI\Widgets\TextView.h" />
     <ClInclude Include="UI\Widgets\TileGridView.h" />
     <ClInclude Include="UI\Widgets\Widget.h" />
+    <ClInclude Include="UI\Widgets\WidgetStyle.h" />
     <ClInclude Include="Utilities\AssetPaths.h" />
     <ClInclude Include="Utilities\Text\TextClip.h" />
     <ClInclude Include="Utilities\Text\TextWrap.h" />
@@ -465,6 +466,7 @@
     <ClCompile Include="UI\Widgets\TextView.cpp" />
     <ClCompile Include="UI\Widgets\TileGridView.cpp" />
     <ClCompile Include="UI\Widgets\Widget.cpp" />
+    <ClCompile Include="UI\Widgets\WidgetStyle.cpp" />
     <ClCompile Include="Utilities\AssetPaths.cpp" />
     <ClCompile Include="Utilities\Unicode\GraphemeSegmentation.cpp" />
     <ClCompile Include="Utilities\Unicode\GraphemeSegmentationTests.cpp" />

--- a/TUI/UI/Widgets/Button.cpp
+++ b/TUI/UI/Widgets/Button.cpp
@@ -6,16 +6,13 @@
 #include "Input/Command.h"
 #include "Input/Event.h"
 #include "Rendering/ScreenBuffer.h"
-#include "Rendering/Styles/UIThemes.h"
 #include "Rendering/Surface.h"
 #include "Utilities/Text/TextClip.h"
 #include "Utilities/Unicode/UnicodeConversion.h"
 
 Button::Button()
     : Widget()
-    , m_normalStyle(UIThemes::ButtonNormal)
-    , m_focusedStyle(UIThemes::ButtonHot)
-    , m_disabledStyle(UIThemes::ButtonDisabled)
+    , m_styleSet(WidgetStyles::defaultStyleSet(WidgetStyles::Role::Button))
 {
     setFocusable(true);
 }
@@ -23,9 +20,7 @@ Button::Button()
 Button::Button(std::string label)
     : Widget()
     , m_label(std::move(label))
-    , m_normalStyle(UIThemes::ButtonNormal)
-    , m_focusedStyle(UIThemes::ButtonHot)
-    , m_disabledStyle(UIThemes::ButtonDisabled)
+    , m_styleSet(WidgetStyles::defaultStyleSet(WidgetStyles::Role::Button))
 {
     setFocusable(true);
 }
@@ -33,9 +28,7 @@ Button::Button(std::string label)
 Button::Button(const Rect& bounds, std::string label, std::string commandId)
     : Widget(bounds)
     , m_label(std::move(label))
-    , m_normalStyle(UIThemes::ButtonNormal)
-    , m_focusedStyle(UIThemes::ButtonHot)
-    , m_disabledStyle(UIThemes::ButtonDisabled)
+    , m_styleSet(WidgetStyles::defaultStyleSet(WidgetStyles::Role::Button))
 {
     if (!commandId.empty())
     {
@@ -88,32 +81,42 @@ void Button::clearCommandId()
 
 const Style& Button::normalStyle() const
 {
-    return m_normalStyle;
+    return m_styleSet.normal;
 }
 
 void Button::setNormalStyle(const Style& style)
 {
-    m_normalStyle = style;
+    m_styleSet.normal = style;
 }
 
 const Style& Button::focusedStyle() const
 {
-    return m_focusedStyle;
+    return m_styleSet.focused;
 }
 
 void Button::setFocusedStyle(const Style& style)
 {
-    m_focusedStyle = style;
+    m_styleSet.focused = style;
 }
 
 const Style& Button::disabledStyle() const
 {
-    return m_disabledStyle;
+    return m_styleSet.disabled;
 }
 
 void Button::setDisabledStyle(const Style& style)
 {
-    m_disabledStyle = style;
+    m_styleSet.disabled = style;
+}
+
+const WidgetStyles::StyleSet& Button::styleSet() const
+{
+    return m_styleSet;
+}
+
+void Button::setStyleSet(const WidgetStyles::StyleSet& styleSet)
+{
+    m_styleSet = styleSet;
 }
 
 void Button::setActivationCallback(ActivationCallback callback)
@@ -226,17 +229,9 @@ bool Button::handleEvent(const Input::Event& event)
 
 const Style& Button::resolveRenderStyle() const
 {
-    if (!isEnabled())
-    {
-        return m_disabledStyle;
-    }
-
-    if (isFocused())
-    {
-        return m_focusedStyle;
-    }
-
-    return m_normalStyle;
+    return WidgetStyles::resolve(
+        m_styleSet,
+        WidgetStyles::stateFor(isEnabled(), isFocused()));
 }
 
 std::string Button::buildDisplayText(int availableWidth) const

--- a/TUI/UI/Widgets/Button.h
+++ b/TUI/UI/Widgets/Button.h
@@ -8,6 +8,7 @@
 #include "Core/Rect.h"
 #include "Rendering/Styles/Style.h"
 #include "UI/Widgets/Widget.h"
+#include "UI/Widgets/WidgetStyle.h"
 
 class Surface;
 
@@ -50,6 +51,9 @@ public:
     const Style& disabledStyle() const;
     void setDisabledStyle(const Style& style);
 
+    const WidgetStyles::StyleSet& styleSet() const;
+    void setStyleSet(const WidgetStyles::StyleSet& styleSet);
+
     void setActivationCallback(ActivationCallback callback);
     void clearActivationCallback();
 
@@ -71,9 +75,7 @@ private:
     std::string m_label;
     std::optional<std::string> m_commandId;
 
-    Style m_normalStyle;
-    Style m_focusedStyle;
-    Style m_disabledStyle;
+    WidgetStyles::StyleSet m_styleSet;
 
     ActivationCallback m_activationCallback;
     std::optional<ButtonActivationResult> m_lastActivationResult;

--- a/TUI/UI/Widgets/Label.cpp
+++ b/TUI/UI/Widgets/Label.cpp
@@ -3,13 +3,12 @@
 #include <utility>
 
 #include "Rendering/ScreenBuffer.h"
-#include "Rendering/Styles/UIThemes.h"
 #include "Rendering/Surface.h"
 #include "Utilities/Text/TextClip.h"
 
 Label::Label()
     : Widget()
-    , m_textStyle(UIThemes::Label)
+    , m_styleSet(WidgetStyles::defaultStyleSet(WidgetStyles::Role::Label))
 {
     setFocusable(false);
 }
@@ -17,7 +16,7 @@ Label::Label()
 Label::Label(std::string text)
     : Widget()
     , m_text(std::move(text))
-    , m_textStyle(UIThemes::Label)
+    , m_styleSet(WidgetStyles::defaultStyleSet(WidgetStyles::Role::Label))
 {
     setFocusable(false);
 }
@@ -25,7 +24,7 @@ Label::Label(std::string text)
 Label::Label(const Rect& bounds, std::string text)
     : Widget(bounds)
     , m_text(std::move(text))
-    , m_textStyle(UIThemes::Label)
+    , m_styleSet(WidgetStyles::defaultStyleSet(WidgetStyles::Role::Label))
 {
     setFocusable(false);
 }
@@ -52,12 +51,22 @@ bool Label::empty() const
 
 const Style& Label::textStyle() const
 {
-    return m_textStyle;
+    return m_styleSet.normal;
 }
 
 void Label::setTextStyle(const Style& style)
 {
-    m_textStyle = style;
+    m_styleSet.normal = style;
+}
+
+const WidgetStyles::StyleSet& Label::styleSet() const
+{
+    return m_styleSet;
+}
+
+void Label::setStyleSet(const WidgetStyles::StyleSet& styleSet)
+{
+    m_styleSet = styleSet;
 }
 
 void Label::draw(Surface& surface)
@@ -88,9 +97,9 @@ void Label::draw(Surface& surface)
         return;
     }
 
-    const Style& renderStyle = isEnabled()
-        ? m_textStyle
-        : UIThemes::DisabledText;
+    const Style& renderStyle = WidgetStyles::resolve(
+        m_styleSet,
+        WidgetStyles::stateFor(isEnabled(), isFocused()));
 
     surface.buffer().writeString(
         labelBounds.position.x,

--- a/TUI/UI/Widgets/Label.h
+++ b/TUI/UI/Widgets/Label.h
@@ -6,6 +6,7 @@
 #include "Core/Rect.h"
 #include "Rendering/Styles/Style.h"
 #include "UI/Widgets/Widget.h"
+#include "UI/Widgets/WidgetStyle.h"
 
 class Surface;
 
@@ -24,9 +25,12 @@ public:
     const Style& textStyle() const;
     void setTextStyle(const Style& style);
 
+    const WidgetStyles::StyleSet& styleSet() const;
+    void setStyleSet(const WidgetStyles::StyleSet& styleSet);
+
     void draw(Surface& surface) override;
 
 private:
     std::string m_text;
-    Style m_textStyle;
+    WidgetStyles::StyleSet m_styleSet;
 };

--- a/TUI/UI/Widgets/ListBox.cpp
+++ b/TUI/UI/Widgets/ListBox.cpp
@@ -6,17 +6,12 @@
 #include "Input/Command.h"
 #include "Input/Event.h"
 #include "Rendering/ScreenBuffer.h"
-#include "Rendering/Styles/UIThemes.h"
 #include "Rendering/Surface.h"
 #include "Utilities/Text/TextClip.h"
 
 ListBox::ListBox()
     : Widget()
-    , m_normalStyle(UIThemes::NormalText)
-    , m_focusedStyle(UIThemes::Focused)
-    , m_selectedStyle(UIThemes::Selection)
-    , m_selectedFocusedStyle(UIThemes::Selection + UIThemes::Focused)
-    , m_disabledStyle(UIThemes::DisabledText)
+    , m_styleSet(WidgetStyles::defaultStyleSet(WidgetStyles::Role::ListBoxItem))
 {
     setFocusable(true);
     updateViewport();
@@ -25,11 +20,7 @@ ListBox::ListBox()
 ListBox::ListBox(std::vector<ListBoxItem> items)
     : Widget()
     , m_items(std::move(items))
-    , m_normalStyle(UIThemes::NormalText)
-    , m_focusedStyle(UIThemes::Focused)
-    , m_selectedStyle(UIThemes::Selection)
-    , m_selectedFocusedStyle(UIThemes::Selection + UIThemes::Focused)
-    , m_disabledStyle(UIThemes::DisabledText)
+    , m_styleSet(WidgetStyles::defaultStyleSet(WidgetStyles::Role::ListBoxItem))
 {
     setFocusable(true);
     normalizeSelection();
@@ -39,11 +30,7 @@ ListBox::ListBox(std::vector<ListBoxItem> items)
 ListBox::ListBox(const Rect& bounds, std::vector<ListBoxItem> items)
     : Widget(bounds)
     , m_items(std::move(items))
-    , m_normalStyle(UIThemes::NormalText)
-    , m_focusedStyle(UIThemes::Focused)
-    , m_selectedStyle(UIThemes::Selection)
-    , m_selectedFocusedStyle(UIThemes::Selection + UIThemes::Focused)
-    , m_disabledStyle(UIThemes::DisabledText)
+    , m_styleSet(WidgetStyles::defaultStyleSet(WidgetStyles::Role::ListBoxItem))
 {
     setFocusable(true);
     normalizeSelection();
@@ -303,52 +290,62 @@ Viewport& ListBox::viewport()
 
 const Style& ListBox::normalStyle() const
 {
-    return m_normalStyle;
+    return m_styleSet.normal;
 }
 
 void ListBox::setNormalStyle(const Style& style)
 {
-    m_normalStyle = style;
+    m_styleSet.normal = style;
 }
 
 const Style& ListBox::focusedStyle() const
 {
-    return m_focusedStyle;
+    return m_styleSet.focused;
 }
 
 void ListBox::setFocusedStyle(const Style& style)
 {
-    m_focusedStyle = style;
+    m_styleSet.focused = style;
 }
 
 const Style& ListBox::selectedStyle() const
 {
-    return m_selectedStyle;
+    return m_styleSet.selected;
 }
 
 void ListBox::setSelectedStyle(const Style& style)
 {
-    m_selectedStyle = style;
+    m_styleSet.selected = style;
 }
 
 const Style& ListBox::selectedFocusedStyle() const
 {
-    return m_selectedFocusedStyle;
+    return m_styleSet.selectedFocused;
 }
 
 void ListBox::setSelectedFocusedStyle(const Style& style)
 {
-    m_selectedFocusedStyle = style;
+    m_styleSet.selectedFocused = style;
 }
 
 const Style& ListBox::disabledStyle() const
 {
-    return m_disabledStyle;
+    return m_styleSet.disabled;
 }
 
 void ListBox::setDisabledStyle(const Style& style)
 {
-    m_disabledStyle = style;
+    m_styleSet.disabled = style;
+}
+
+const WidgetStyles::StyleSet& ListBox::styleSet() const
+{
+    return m_styleSet;
+}
+
+void ListBox::setStyleSet(const WidgetStyles::StyleSet& styleSet)
+{
+    m_styleSet = styleSet;
 }
 
 void ListBox::draw(Surface& surface)
@@ -365,7 +362,7 @@ void ListBox::draw(Surface& surface)
     }
 
     updateViewport();
-    surface.buffer().fillRect(listBounds, U' ', m_normalStyle);
+    surface.buffer().fillRect(listBounds, U' ', m_styleSet.normal);
 
     const int firstVisibleItem = m_viewport.scrollY();
     const int visibleRows = std::min(
@@ -522,20 +519,9 @@ std::optional<std::size_t> ListBox::lastEnabledIndex() const
 
 const Style& ListBox::resolveItemStyle(std::size_t index) const
 {
-    if (!isEnabled() || !m_items[index].enabled)
-    {
-        return m_disabledStyle;
-    }
+    const bool selected = m_selectedIndex.has_value() && *m_selectedIndex == index;
 
-    if (m_selectedIndex == index)
-    {
-        return isFocused() ? m_selectedFocusedStyle : m_selectedStyle;
-    }
-
-    if (isFocused())
-    {
-        return m_focusedStyle;
-    }
-
-    return m_normalStyle;
+    return WidgetStyles::resolve(
+        m_styleSet,
+        WidgetStyles::stateFor(isEnabled() && isItemEnabled(index), isFocused(), selected));
 }

--- a/TUI/UI/Widgets/ListBox.h
+++ b/TUI/UI/Widgets/ListBox.h
@@ -10,6 +10,7 @@
 #include "Rendering/Styles/Style.h"
 #include "UI/Base/Viewport.h"
 #include "UI/Widgets/Widget.h"
+#include "UI/Widgets/WidgetStyle.h"
 
 class Surface;
 
@@ -77,6 +78,9 @@ public:
     const Style& disabledStyle() const;
     void setDisabledStyle(const Style& style);
 
+    const WidgetStyles::StyleSet& styleSet() const;
+    void setStyleSet(const WidgetStyles::StyleSet& styleSet);
+
     void draw(Surface& surface) override;
     bool handleEvent(const Input::Event& event) override;
 
@@ -97,10 +101,5 @@ private:
     std::optional<std::size_t> m_selectedIndex;
     Viewport m_viewport;
 
-    Style m_normalStyle;
-    Style m_focusedStyle;
-    Style m_selectedStyle;
-    Style m_selectedFocusedStyle;
-    Style m_disabledStyle;
+    WidgetStyles::StyleSet m_styleSet;
 };
-

--- a/TUI/UI/Widgets/TextView.cpp
+++ b/TUI/UI/Widgets/TextView.cpp
@@ -10,7 +10,15 @@
 #include "Utilities/Text/TextClip.h"
 #include "Utilities/Unicode/UnicodeConversion.h"
 
+TextView::TextView()
+    : ScrollablePanel()
+    , m_textStyleSet(WidgetStyles::defaultStyleSet(WidgetStyles::Role::TextViewText))
+{
+}
+
 TextView::TextView(std::string title)
+    : ScrollablePanel()
+    , m_textStyleSet(WidgetStyles::defaultStyleSet(WidgetStyles::Role::TextViewText))
 {
     setTitle(std::move(title));
 }
@@ -62,12 +70,22 @@ std::size_t TextView::lineCount() const
 
 void TextView::setTextStyle(const Style& style)
 {
-    m_textStyle = style;
+    m_textStyleSet.normal = style;
 }
 
 const Style& TextView::textStyle() const
 {
-    return m_textStyle;
+    return m_textStyleSet.normal;
+}
+
+const WidgetStyles::StyleSet& TextView::textStyleSet() const
+{
+    return m_textStyleSet;
+}
+
+void TextView::setTextStyleSet(const WidgetStyles::StyleSet& styleSet)
+{
+    m_textStyleSet = styleSet;
 }
 
 void TextView::drawScrollableContent(
@@ -99,7 +117,13 @@ void TextView::drawScrollableContent(
             sourceLine.substr(static_cast<std::size_t>(offsetX)),
             visibleContentRect.size.width);
 
-        buffer.writeString(0, viewY, visibleText, m_textStyle);
+        buffer.writeString(
+            0,
+            viewY,
+            visibleText,
+            WidgetStyles::resolve(
+                m_textStyleSet,
+                WidgetStyles::stateFor(isEnabled(), false)));
     }
 }
 

--- a/TUI/UI/Widgets/TextView.h
+++ b/TUI/UI/Widgets/TextView.h
@@ -8,13 +8,14 @@
 #include "Core/Rect.h"
 #include "Rendering/Styles/Style.h"
 #include "UI/Panels/ScrollablePanel.h"
+#include "UI/Widgets/WidgetStyle.h"
 
 class Surface;
 
 class TextView : public ScrollablePanel
 {
 public:
-    TextView() = default;
+    TextView();
     explicit TextView(std::string title);
 
     void setText(std::string_view text);
@@ -30,6 +31,9 @@ public:
     void setTextStyle(const Style& style);
     const Style& textStyle() const;
 
+    const WidgetStyles::StyleSet& textStyleSet() const;
+    void setTextStyleSet(const WidgetStyles::StyleSet& styleSet);
+
 protected:
     void drawScrollableContent(
         Surface& surface,
@@ -41,5 +45,5 @@ private:
 
 private:
     std::vector<std::string> m_lines;
-    Style m_textStyle;
+    WidgetStyles::StyleSet m_textStyleSet;
 };

--- a/TUI/UI/Widgets/WidgetStyle.cpp
+++ b/TUI/UI/Widgets/WidgetStyle.cpp
@@ -1,0 +1,102 @@
+#include "UI/Widgets/WidgetStyle.h"
+
+#include "Rendering/Styles/UIThemes.h"
+
+namespace WidgetStyles
+{
+    StyleSet defaultStyleSet(Role role)
+    {
+        switch (role)
+        {
+        case Role::Label:
+            return StyleSet{
+                UIThemes::WidgetLabelNormal,
+                UIThemes::WidgetLabelFocused,
+                UIThemes::WidgetLabelDisabled,
+                UIThemes::WidgetLabelSelected,
+                UIThemes::WidgetLabelSelectedFocused
+            };
+
+        case Role::Button:
+            return StyleSet{
+                UIThemes::WidgetButtonNormal,
+                UIThemes::WidgetButtonFocused,
+                UIThemes::WidgetButtonDisabled,
+                UIThemes::WidgetButtonSelected,
+                UIThemes::WidgetButtonSelectedFocused
+            };
+
+        case Role::ListBoxItem:
+            return StyleSet{
+                UIThemes::WidgetListItemNormal,
+                UIThemes::WidgetListItemFocused,
+                UIThemes::WidgetListItemDisabled,
+                UIThemes::WidgetListItemSelected,
+                UIThemes::WidgetListItemSelectedFocused
+            };
+
+        case Role::TextViewText:
+            return StyleSet{
+                UIThemes::WidgetTextNormal,
+                UIThemes::WidgetTextFocused,
+                UIThemes::WidgetTextDisabled,
+                UIThemes::WidgetTextSelected,
+                UIThemes::WidgetTextSelectedFocused
+            };
+        }
+
+        return StyleSet{};
+    }
+
+    const Style& resolve(const StyleSet& styleSet, State state)
+    {
+        switch (state)
+        {
+        case State::Disabled:
+            return styleSet.disabled;
+
+        case State::SelectedFocused:
+            return styleSet.selectedFocused;
+
+        case State::Selected:
+            return styleSet.selected;
+
+        case State::Focused:
+            return styleSet.focused;
+
+        case State::Normal:
+        default:
+            return styleSet.normal;
+        }
+    }
+
+    Style resolve(Role role, State state)
+    {
+        return resolve(defaultStyleSet(role), state);
+    }
+
+    State stateFor(bool enabled, bool focused, bool selected)
+    {
+        if (!enabled)
+        {
+            return State::Disabled;
+        }
+
+        if (selected && focused)
+        {
+            return State::SelectedFocused;
+        }
+
+        if (selected)
+        {
+            return State::Selected;
+        }
+
+        if (focused)
+        {
+            return State::Focused;
+        }
+
+        return State::Normal;
+    }
+}

--- a/TUI/UI/Widgets/WidgetStyle.h
+++ b/TUI/UI/Widgets/WidgetStyle.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "Rendering/Styles/Style.h"
+
+namespace WidgetStyles
+{
+    enum class Role
+    {
+        Label,
+        Button,
+        ListBoxItem,
+        TextViewText
+    };
+
+    enum class State
+    {
+        Normal,
+        Focused,
+        Disabled,
+        Selected,
+        SelectedFocused
+    };
+
+    struct StyleSet
+    {
+        Style normal;
+        Style focused;
+        Style disabled;
+        Style selected;
+        Style selectedFocused;
+    };
+
+    StyleSet defaultStyleSet(Role role);
+
+    const Style& resolve(const StyleSet& styleSet, State state);
+    Style resolve(Role role, State state);
+
+    State stateFor(bool enabled, bool focused, bool selected = false);
+}


### PR DESCRIPTION
Modifies:
- TUI.vcxproj
- Rendering/UIThemes.h
- UI/Widgets/Button.h/.cpp
- UI/Widgets/Label.h/.cpp
- UI/Widgets/ListBox.h/.cpp
- UI/Widgets/TextView.h/.cpp

Adds:
- UI/Widgets/WidgetStyle.h/.cpp

Implemented reusable widget style integration for controls, providing consistent rendering behavior across Label, Button, ListBox, TextView, and future widgets.

Added a centralized WidgetStyle resolver layer that maps widget states to existing UI theme/style infrastructure without introducing a separate theme system.

Highlights:
- Added reusable WidgetStyle helper utilities.
- Integrated widget state styling:
  - Normal
  - Focused
  - Disabled
  - Selected
  - Selected + Focused
- Centralized widget style resolution logic to avoid duplication.
- Reused existing Style/UITheme/ThemeColor infrastructure.
- Preserved backward compatibility with existing rendering systems.
- Updated widgets to consume shared style resolution APIs.
- Added extensible style role support for future widget types.
- Improved consistency of focus and selection rendering behavior.
- Kept rendering/state styling separate from widget behavior logic.
- Maintained safe rendering and clipping compatibility.

Closes: #271 