### PR TITLE
WidgetDemoScreen: Add a reusable widget demo screen and validate widg…

### DIFF
--- a/TUI/App/Application.cpp
+++ b/TUI/App/Application.cpp
@@ -23,6 +23,7 @@
 #include "Screens/Developer/TerminalCapabilitiesScreen.h"
 #include "Screens/MenuDemoScreen.h"
 #include "Screens/ScrollableTileGridDemoScreen.h"
+#include "Screens/WidgetDemoScreen.h"
 
 static Application* g_appInstance = nullptr;
 
@@ -370,6 +371,10 @@ void Application::switchToScreen(ScreenType screenType)
         m_screenManager->pushScreen(std::make_unique<MenuDemoScreen>());
         break;
 
+    case ScreenType::WidgetDemoScreen:
+        m_screenManager->pushScreen(std::make_unique<WidgetDemoScreen>());
+        break;
+
     case ScreenType::ScrollableTileGridDemo:
         m_screenManager->pushScreen(std::make_unique<ScrollableTileGridDemoScreen>());
         break;
@@ -420,6 +425,10 @@ void Application::advanceScreen()
         break;
 
     case ScreenType::MenuDemoScreen:
+        switchToScreen(ScreenType::WidgetDemoScreen);
+        break;
+
+    case ScreenType::WidgetDemoScreen:
         switchToScreen(ScreenType::ScrollableTileGridDemo);
         break;
 
@@ -481,8 +490,12 @@ void Application::previousScreen()
         switchToScreen(ScreenType::OpsWall);
         break;
 
-    case ScreenType::ScrollableTileGridDemo:
+    case ScreenType::WidgetDemoScreen:
         switchToScreen(ScreenType::MenuDemoScreen);
+        break;
+
+    case ScreenType::ScrollableTileGridDemo:
+        switchToScreen(ScreenType::WidgetDemoScreen);
         break;
 
     case ScreenType::WindowDemo:

--- a/TUI/App/Application.h
+++ b/TUI/App/Application.h
@@ -43,6 +43,7 @@ private:
         NeonDialog,
         OpsWall,
         MenuDemoScreen,
+        WidgetDemoScreen,
         ScrollableTileGridDemo,
         WindowDemo,
         DigitalRain,

--- a/TUI/Input/CommandMap.cpp
+++ b/TUI/Input/CommandMap.cpp
@@ -62,8 +62,16 @@ namespace Input
         map.bindKey(KeyCode::Escape, CommandCode::Cancel);
 
         map.bindKey(KeyCode::Tab, CommandCode::NextFocus);
-        map.bindKey(KeyCode::Backtab, CommandCode::PreviousFocus);
+
+        // Different terminals/input paths may report Shift+Tab as either:
+        // - Tab + shift modifier
+        // - Backtab with no modifier
+        // - Backtab + shift modifier
+        //
+        // Bind all supported forms so reverse focus traversal works reliably.
         map.bindKey(KeyCode::Tab, shiftModifier(), CommandCode::PreviousFocus);
+        map.bindKey(KeyCode::Backtab, CommandCode::PreviousFocus);
+        map.bindKey(KeyCode::Backtab, shiftModifier(), CommandCode::PreviousFocus);
 
         map.bindKey(KeyCode::F1, CommandCode::OpenHelp);
         map.bindKey(KeyCode::F5, CommandCode::Refresh);

--- a/TUI/Screens/WidgetDemoScreen.cpp
+++ b/TUI/Screens/WidgetDemoScreen.cpp
@@ -1,0 +1,378 @@
+#include "Screens/WidgetDemoScreen.h"
+
+#include <algorithm>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "Core/Rect.h"
+#include "Input/Command.h"
+#include "Input/Event.h"
+#include "Rendering/Composition/PageComposer.h"
+#include "Rendering/ScreenBuffer.h"
+#include "Rendering/Styles/StyleBuilder.h"
+#include "Rendering/Styles/Themes.h"
+#include "Rendering/Styles/UIThemes.h"
+#include "Rendering/Surface.h"
+
+namespace
+{
+    using Composition::PageComposer;
+
+    constexpr int MinimumWidth = 88;
+    constexpr int MinimumHeight = 30;
+
+    const Style ScreenStyle =
+        style::Fg(Color::FromBasic(Color::Basic::BrightWhite))
+        + style::Bg(Color::FromBasic(Color::Basic::Black));
+
+    const Style PanelStyle =
+        style::Fg(Color::FromBasic(Color::Basic::BrightWhite))
+        + style::Bg(Color::FromBasic(Color::Basic::Black));
+
+    const Style HeaderStyle =
+        style::Fg(Color::FromBasic(Color::Basic::BrightCyan))
+        + style::Bg(Color::FromBasic(Color::Basic::Blue))
+        + style::Bold;
+
+    const Style BorderStyle =
+        style::Fg(Color::FromBasic(Color::Basic::BrightCyan))
+        + style::Bg(Color::FromBasic(Color::Basic::Black))
+        + style::Bold;
+
+    const Style AccentStyle =
+        style::Fg(Color::FromBasic(Color::Basic::BrightYellow))
+        + style::Bg(Color::FromBasic(Color::Basic::Black))
+        + style::Bold;
+
+    const Style MutedStyle =
+        style::Fg(Color::FromBasic(Color::Basic::White))
+        + style::Bg(Color::FromBasic(Color::Basic::Black))
+        + style::Dim;
+}
+
+WidgetDemoScreen::WidgetDemoScreen()
+{
+    buildWidgets();
+    configureStyles();
+}
+
+void WidgetDemoScreen::onEnter()
+{
+    m_root.focusFirstChild();
+    m_lastAction = "Widget demo ready. Use Tab to move focus between controls.";
+    syncSelectionMessage();
+    updateStatusBar();
+}
+
+bool WidgetDemoScreen::handleEvent(const Input::Event& event)
+{
+    if (const Input::CommandEvent* commandEvent = event.asCommand())
+    {
+        return handleCommand(commandEvent->command);
+    }
+
+    return m_root.handleEvent(event);
+}
+
+void WidgetDemoScreen::update(double deltaTime)
+{
+    m_root.update(deltaTime);
+}
+
+void WidgetDemoScreen::draw(Surface& surface)
+{
+    ScreenBuffer& buffer = surface.buffer();
+
+    if (buffer.getWidth() < MinimumWidth || buffer.getHeight() < MinimumHeight)
+    {
+        drawTooSmall(surface);
+        return;
+    }
+
+    buffer.clear(ScreenStyle);
+
+    updateLayout(surface);
+    syncSelectionMessage();
+
+    m_root.draw(surface);
+    m_statusBar.draw(surface);
+}
+
+void WidgetDemoScreen::buildWidgets()
+{
+    auto headerPanel = std::make_unique<Panel>();
+    m_headerPanel = headerPanel.get();
+    m_root.addChild(std::move(headerPanel));
+
+    auto titleLabel = std::make_unique<Label>("Phase 11 Widget Demo");
+    m_titleLabel = titleLabel.get();
+    m_root.addChild(std::move(titleLabel));
+
+    auto controlPanel = std::make_unique<Panel>();
+    m_controlPanel = controlPanel.get();
+    m_root.addChild(std::move(controlPanel));
+
+    auto listBox = std::make_unique<ListBox>();
+    listBox->addItem("Dashboard summary");
+    listBox->addItem("Project activity");
+    listBox->addItem("Disabled report sample", false);
+    listBox->addItem("System messages");
+    listBox->addItem("Release checklist");
+    m_listBox = listBox.get();
+    m_root.addChild(std::move(listBox));
+
+    auto applyButton = std::make_unique<Button>("Apply Selection");
+    applyButton->setCommandId("apply");
+    applyButton->setActivationCallback(
+        [this](const ButtonActivationResult& result)
+        {
+            handleButtonActivation(result);
+        });
+    m_applyButton = applyButton.get();
+    m_root.addChild(std::move(applyButton));
+
+    auto resetButton = std::make_unique<Button>("Reset List");
+    resetButton->setCommandId("reset");
+    resetButton->setActivationCallback(
+        [this](const ButtonActivationResult& result)
+        {
+            handleButtonActivation(result);
+        });
+    m_resetButton = resetButton.get();
+    m_root.addChild(std::move(resetButton));
+
+    auto disabledButton = std::make_unique<Button>("Disabled Action");
+    disabledButton->setCommandId("disabled");
+    disabledButton->setEnabled(false);
+    disabledButton->disable();
+    m_disabledButton = disabledButton.get();
+    m_root.addChild(std::move(disabledButton));
+
+    auto stateLabel = std::make_unique<Label>();
+    m_stateLabel = stateLabel.get();
+    m_root.addChild(std::move(stateLabel));
+
+    auto textPanel = std::make_unique<Panel>();
+    m_textPanel = textPanel.get();
+    m_root.addChild(std::move(textPanel));
+
+    auto textView = std::make_unique<TextView>("Read-only TextView");
+    textView->setLines({
+        "This TextView is owned by the same ContainerWidget as the Label, Button, and ListBox controls.",
+        "",
+        "What this screen proves:",
+        "- ContainerWidget owns child widgets with std::unique_ptr.",
+        "- Children draw in stable insertion order.",
+        "- Tab / Shift+Tab traverses focusable children.",
+        "- Button activation is routed through reusable Button callbacks.",
+        "- ListBox selection skips disabled items.",
+        "- Focused, disabled, and selected styles are visible.",
+        "",
+        "Try focusing this TextView and using Up/Down/PageUp/PageDown.",
+        "The screen does not replace the existing Screen lifecycle."
+        });
+    m_textView = textView.get();
+    m_root.addChild(std::move(textView));
+}
+
+void WidgetDemoScreen::configureStyles()
+{
+    m_headerPanel->setTitle("Reusable Widget Framework");
+    m_headerPanel->setBackgroundStyle(HeaderStyle);
+    m_headerPanel->setBorderStyle(HeaderStyle);
+    m_headerPanel->setTitleStyle(HeaderStyle);
+
+    m_controlPanel->setTitle("Controls");
+    m_controlPanel->setBackgroundStyle(PanelStyle);
+    m_controlPanel->setBorderStyle(BorderStyle);
+    m_controlPanel->setTitleStyle(AccentStyle);
+
+    m_textPanel->setTitle("Read-only Content");
+    m_textPanel->setBackgroundStyle(PanelStyle);
+    m_textPanel->setBorderStyle(BorderStyle);
+    m_textPanel->setTitleStyle(AccentStyle);
+
+    m_titleLabel->setTextStyle(HeaderStyle);
+    m_stateLabel->setTextStyle(AccentStyle);
+
+    m_statusBar.setInstructions("Widget demo");
+    m_statusBar.setCommandHints({
+        "Tab: next focus",
+        "Shift+Tab: previous focus",
+        "Up/Down: list/text",
+        "Enter: button/list action",
+        "Esc: cancel"
+        });
+}
+
+void WidgetDemoScreen::updateLayout(Surface& surface)
+{
+    ScreenBuffer& buffer = surface.buffer();
+
+    PageComposer page(buffer);
+    page.clearRegions();
+    page.createFullScreenRegion("Screen");
+    page.createInsetRegion("Safe", "Screen", 2, 1, 2, 1);
+
+    const Rect safe = page.resolveRegion("Safe");
+    const auto [header, afterHeader] = page.splitTop(safe, 5);
+    const auto [status, body] = page.splitBottom(afterHeader, 3);
+    const auto [controls, textArea] = page.splitLeft(body, 36);
+
+    m_root.setBounds(safe);
+    m_headerPanel->setBounds(header);
+    m_statusBar.setBounds(status);
+
+    const Rect headerContent = m_headerPanel->contentBounds();
+    m_titleLabel->setBounds(Rect{
+        Point{ headerContent.position.x + 2, headerContent.position.y + 1 },
+        Size{ std::max(0, headerContent.size.width - 4), 1 }
+        });
+
+    m_controlPanel->setBounds(Rect{
+        Point{ controls.position.x, controls.position.y + 1 },
+        Size{ std::max(0, controls.size.width - 1), std::max(0, controls.size.height - 2) }
+        });
+
+    const Rect controlContent = m_controlPanel->contentBounds();
+    m_listBox->setBounds(Rect{
+        Point{ controlContent.position.x + 2, controlContent.position.y + 1 },
+        Size{ std::max(0, controlContent.size.width - 4), 7 }
+        });
+
+    const int buttonY = controlContent.position.y + 10;
+    const int buttonWidth = std::max(10, (controlContent.size.width - 6) / 2);
+
+    m_applyButton->setBounds(Rect{
+        Point{ controlContent.position.x + 2, buttonY },
+        Size{ buttonWidth, 3 }
+        });
+
+    m_resetButton->setBounds(Rect{
+        Point{ controlContent.position.x + 4 + buttonWidth, buttonY },
+        Size{ buttonWidth, 3 }
+        });
+
+    m_disabledButton->setBounds(Rect{
+        Point{ controlContent.position.x + 2, buttonY + 4 },
+        Size{ std::max(0, controlContent.size.width - 4), 3 }
+        });
+
+    m_stateLabel->setBounds(Rect{
+        Point{ controlContent.position.x + 2, buttonY + 8 },
+        Size{ std::max(0, controlContent.size.width - 4), 1 }
+        });
+
+    m_textPanel->setBounds(Rect{
+        Point{ textArea.position.x + 1, textArea.position.y + 1 },
+        Size{ std::max(0, textArea.size.width - 1), std::max(0, textArea.size.height - 2) }
+        });
+
+    const Rect textContent = m_textPanel->contentBounds();
+    m_textView->setBounds(Rect{
+        Point{ textContent.position.x + 1, textContent.position.y + 1 },
+        Size{ std::max(0, textContent.size.width - 2), std::max(0, textContent.size.height - 2) }
+        });
+}
+
+void WidgetDemoScreen::updateStatusBar()
+{
+    m_statusBar.setInstructions(m_lastAction);
+}
+
+bool WidgetDemoScreen::handleCommand(const Input::Command& command)
+{
+    if (command.code == Input::CommandCode::Confirm && m_root.focusedChild() == m_listBox)
+    {
+        activateSelectedListItem();
+        return true;
+    }
+
+    if (command.code == Input::CommandCode::Cancel)
+    {
+        m_lastAction = "Cancelled widget demo action.";
+        updateStatusBar();
+        return true;
+    }
+
+    const bool handled = m_root.handleEvent(Input::Event::command(command));
+
+    if (handled)
+    {
+        syncSelectionMessage();
+        updateStatusBar();
+    }
+
+    return handled;
+}
+
+void WidgetDemoScreen::activateSelectedListItem()
+{
+    const std::string* selectedText = m_listBox->selectedText();
+
+    if (selectedText == nullptr)
+    {
+        m_lastAction = "No enabled list item is selected.";
+    }
+    else
+    {
+        m_lastAction = "Confirmed list item: " + *selectedText;
+    }
+
+    updateStatusBar();
+}
+
+void WidgetDemoScreen::handleButtonActivation(const ButtonActivationResult& result)
+{
+    if (!result.activated)
+    {
+        return;
+    }
+
+    if (result.commandId == "apply")
+    {
+        activateSelectedListItem();
+    }
+    else if (result.commandId == "reset")
+    {
+        m_listBox->moveToFirst();
+        m_lastAction = "ListBox reset to the first enabled item.";
+        syncSelectionMessage();
+        updateStatusBar();
+    }
+}
+
+void WidgetDemoScreen::syncSelectionMessage()
+{
+    if (!m_listBox)
+    {
+        return;
+    }
+
+    const std::optional<std::size_t> selectedIndex = m_listBox->selectedIndex();
+    if (selectedIndex == m_lastObservedSelection)
+    {
+        return;
+    }
+
+    m_lastObservedSelection = selectedIndex;
+
+    const std::string* selectedText = m_listBox->selectedText();
+    if (selectedText == nullptr)
+    {
+        m_stateLabel->setText("Selection: <none>");
+        return;
+    }
+
+    m_stateLabel->setText("Selection: " + *selectedText);
+}
+
+void WidgetDemoScreen::drawTooSmall(Surface& surface) const
+{
+    ScreenBuffer& buffer = surface.buffer();
+    buffer.clear(ScreenStyle);
+
+    buffer.writeString(2, 2, "WidgetDemoScreen needs a larger terminal.", AccentStyle);
+    buffer.writeString(2, 4, "Recommended minimum: 88 x 30", MutedStyle);
+}

--- a/TUI/Screens/WidgetDemoScreen.h
+++ b/TUI/Screens/WidgetDemoScreen.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <cstddef>
+#include <string>
+
+#include "Screens/Screen.h"
+#include "UI/Panels/Panel.h"
+#include "UI/Panels/StatusBar.h"
+#include "UI/Widgets/Button.h"
+#include "UI/Widgets/ContainerWidget.h"
+#include "UI/Widgets/Label.h"
+#include "UI/Widgets/ListBox.h"
+#include "UI/Widgets/TextView.h"
+
+class Surface;
+
+namespace Input
+{
+    class Event;
+    struct Command;
+}
+
+class WidgetDemoScreen final : public Screen
+{
+public:
+    WidgetDemoScreen();
+    ~WidgetDemoScreen() override = default;
+
+    void onEnter() override;
+    bool handleEvent(const Input::Event& event) override;
+    void update(double deltaTime) override;
+    void draw(Surface& surface) override;
+
+private:
+    void buildWidgets();
+    void configureStyles();
+    void updateLayout(Surface& surface);
+    void updateStatusBar();
+
+    bool handleCommand(const Input::Command& command);
+    void activateSelectedListItem();
+    void handleButtonActivation(const ButtonActivationResult& result);
+    void syncSelectionMessage();
+
+    void drawTooSmall(Surface& surface) const;
+
+private:
+    ContainerWidget m_root;
+
+    Panel* m_headerPanel = nullptr;
+    Panel* m_controlPanel = nullptr;
+    Panel* m_textPanel = nullptr;
+
+    Label* m_titleLabel = nullptr;
+    Label* m_stateLabel = nullptr;
+    ListBox* m_listBox = nullptr;
+    Button* m_applyButton = nullptr;
+    Button* m_resetButton = nullptr;
+    Button* m_disabledButton = nullptr;
+    TextView* m_textView = nullptr;
+
+    StatusBar m_statusBar;
+
+    std::string m_lastAction;
+    std::optional<std::size_t> m_lastObservedSelection;
+};

--- a/TUI/TUI.vcxproj
+++ b/TUI/TUI.vcxproj
@@ -274,6 +274,7 @@
     <ClInclude Include="Screens\Developer\TextObjectExportValidationScreen.h" />
     <ClInclude Include="Screens\WaterEffectScreen.h" />
     <ClInclude Include="Screens\Developer\XpSequenceDiagnosticsScreen.h" />
+    <ClInclude Include="Screens\WidgetDemoScreen.h" />
     <ClInclude Include="Screens\WindowDemoScreen.h" />
     <ClInclude Include="ThirdParty\zlib-1.3.1\zconf.h" />
     <ClInclude Include="ThirdParty\zlib-1.3.1\zutil.h" />
@@ -429,6 +430,7 @@
     <ClCompile Include="Screens\Developer\TextObjectExportValidationScreen.cpp" />
     <ClCompile Include="Screens\WaterEffectScreen.cpp" />
     <ClCompile Include="Screens\Developer\XpSequenceDiagnosticsScreen.cpp" />
+    <ClCompile Include="Screens\WidgetDemoScreen.cpp" />
     <ClCompile Include="Screens\WindowDemoScreen.cpp" />
     <ClCompile Include="ThirdParty\zlib-1.3.1\adler32.c" />
     <ClCompile Include="ThirdParty\zlib-1.3.1\compress.c" />


### PR DESCRIPTION
…et framework integration

Modifies:
- TUI.vcxproj
- App/Application.h/.cpp
- Input/CommandMap.h/.cpp

Adds:
- Screens/WidgetDemoScreen.h/.cpp

- Added WidgetDemoScreen as the first practical reusable widget showcase
- Demonstrated ContainerWidget child ownership and composition
- Integrated Label, Button, ListBox, and TextView controls into a unified screen
- Added focus traversal validation using Tab and Shift+Tab
- Added button activation handling and status updates
- Added ListBox selection interaction and disabled item support
- Demonstrated focused, selected, and disabled widget styling states
- Integrated demo with existing Screen, Panel, StatusBar, and PageComposer systems
- Added responsive layout composition using existing panel/content region patterns
- Verified widget event routing through the reusable widget hierarchy
- Fixed reverse focus traversal by expanding Shift+Tab / Backtab command bindings
- Confirmed runtime interaction, focus management, rendering, and style integration stability

Closes: #274 