### PR TITLE
Mouse Decoding: Add terminal mouse decoding foundation with SGR mouse…

### DIFF
--- a/TUI/App/Application.cpp
+++ b/TUI/App/Application.cpp
@@ -245,14 +245,17 @@ void Application::run()
 
             std::vector<Input::Event> events;
 
-            for (const Input::KeyEvent& keyEvent : m_inputManager->drainEvents())
+            for (const Input::Event& inputEvent : m_inputManager->drainEvents())
             {
-                events.push_back(Input::Event::key(keyEvent));
+                events.push_back(inputEvent);
 
-                std::optional<Input::Command> command = m_commandMap.map(keyEvent);
-                if (command.has_value())
+                if (const Input::KeyEvent* keyEvent = inputEvent.asKey())
                 {
-                    events.push_back(Input::Event::command(command.value()));
+                    std::optional<Input::Command> command = m_commandMap.map(*keyEvent);
+                    if (command.has_value())
+                    {
+                        events.push_back(Input::Event::command(command.value()));
+                    }
                 }
             }
 
@@ -278,6 +281,7 @@ void Application::run()
         render();
 
         ++m_frameIndex;
+
         std::this_thread::sleep_for(std::chrono::milliseconds(16));
     }
 }

--- a/TUI/Input/InputManager.cpp
+++ b/TUI/Input/InputManager.cpp
@@ -138,13 +138,20 @@ namespace Input
 
         while (true)
         {
-            std::optional<RawKeyEvent> raw = m_keyboardSource->pollRawKey();
+            std::optional<RawInputEvent> raw = m_keyboardSource->pollRawInput();
             if (!raw.has_value())
             {
                 break;
             }
 
-            m_events.push_back(normalizeRawKey(raw.value()));
+            if (const RawKeyEvent* key = std::get_if<RawKeyEvent>(&raw.value()))
+            {
+                m_events.push_back(Event::key(normalizeRawKey(*key)));
+            }
+            else if (const MouseEvent* mouse = std::get_if<MouseEvent>(&raw.value()))
+            {
+                m_events.push_back(Event::mouse(*mouse));
+            }
         }
     }
 
@@ -153,23 +160,62 @@ namespace Input
         return !m_events.empty();
     }
 
-    std::optional<KeyEvent> InputManager::popEvent()
+    std::optional<Event> InputManager::popEvent()
     {
         if (m_events.empty())
         {
             return std::nullopt;
         }
 
-        KeyEvent event = m_events.front();
+        Event event = m_events.front();
         m_events.erase(m_events.begin());
         return event;
     }
 
-    std::vector<KeyEvent> InputManager::drainEvents()
+    std::vector<Event> InputManager::drainEvents()
     {
-        std::vector<KeyEvent> drained;
+        std::vector<Event> drained;
         drained.swap(m_events);
         return drained;
+    }
+
+    std::optional<KeyEvent> InputManager::popKeyEvent()
+    {
+        while (!m_events.empty())
+        {
+            Event event = m_events.front();
+            m_events.erase(m_events.begin());
+
+            if (const KeyEvent* key = event.asKey())
+            {
+                return *key;
+            }
+        }
+
+        return std::nullopt;
+    }
+
+    std::vector<KeyEvent> InputManager::drainKeyEvents()
+    {
+        std::vector<KeyEvent> keys;
+
+        std::vector<Event> remaining;
+        remaining.reserve(m_events.size());
+
+        for (const Event& event : m_events)
+        {
+            if (const KeyEvent* key = event.asKey())
+            {
+                keys.push_back(*key);
+            }
+            else
+            {
+                remaining.push_back(event);
+            }
+        }
+
+        m_events.swap(remaining);
+        return keys;
     }
 
     void InputManager::clear()
@@ -184,10 +230,6 @@ namespace Input
         event.character = event.code == KeyCode::Character ? raw.character : U'\0';
         event.modifiers = raw.modifiers;
 
-        // Windows console reports Ctrl+A through Ctrl+Z as ASCII control
-        // characters 1 through 26. Normalize them back into the project's
-        // normal Character + ctrl modifier form so CommandMap bindings such as
-        // Ctrl+Q can match bindCharacter(U'q', ctrlModifier(), ...).
         if (event.code == KeyCode::Character
             && event.character >= 1
             && event.character <= 26)

--- a/TUI/Input/InputManager.h
+++ b/TUI/Input/InputManager.h
@@ -4,6 +4,7 @@
 #include <optional>
 #include <vector>
 
+#include "Input/Event.h"
 #include "Input/KeyEvent.h"
 #include "Input/RawKeyboardSource.h"
 
@@ -22,8 +23,11 @@ namespace Input
         void poll();
 
         bool hasEvents() const;
-        std::optional<KeyEvent> popEvent();
-        std::vector<KeyEvent> drainEvents();
+        std::optional<Event> popEvent();
+        std::vector<Event> drainEvents();
+
+        std::optional<KeyEvent> popKeyEvent();
+        std::vector<KeyEvent> drainKeyEvents();
 
         void clear();
 
@@ -32,7 +36,7 @@ namespace Input
 
     private:
         std::unique_ptr<IRawKeyboardSource> m_keyboardSource;
-        std::vector<KeyEvent> m_events;
+        std::vector<Event> m_events;
         bool m_initialized = false;
     };
 }

--- a/TUI/Input/RawKeyboardSource.h
+++ b/TUI/Input/RawKeyboardSource.h
@@ -2,8 +2,10 @@
 
 #include <cstdint>
 #include <optional>
+#include <variant>
 
 #include "Input/KeyCodes.h"
+#include "Input/MouseEvent.h"
 
 namespace Input
 {
@@ -16,6 +18,8 @@ namespace Input
         std::uint16_t repeatCount = 1;
     };
 
+    using RawInputEvent = std::variant<RawKeyEvent, MouseEvent>;
+
     class IRawKeyboardSource
     {
     public:
@@ -24,6 +28,23 @@ namespace Input
         virtual bool initialize() = 0;
         virtual void shutdown() = 0;
 
-        virtual std::optional<RawKeyEvent> pollRawKey() = 0;
+        virtual std::optional<RawInputEvent> pollRawInput() = 0;
+
+        virtual std::optional<RawKeyEvent> pollRawKey()
+        {
+            while (true)
+            {
+                std::optional<RawInputEvent> event = pollRawInput();
+                if (!event.has_value())
+                {
+                    return std::nullopt;
+                }
+
+                if (const RawKeyEvent* key = std::get_if<RawKeyEvent>(&event.value()))
+                {
+                    return *key;
+                }
+            }
+        }
     };
 }

--- a/TUI/Input/WindowsConsoleKeyboardSource.cpp
+++ b/TUI/Input/WindowsConsoleKeyboardSource.cpp
@@ -3,6 +3,12 @@
 #define NOMINMAX
 #include <windows.h>
 
+#include <algorithm>
+#include <cwctype>
+#include <iostream>
+#include <sstream>
+#include <vector>
+
 namespace Input
 {
     namespace
@@ -19,6 +25,110 @@ namespace Input
                 (controlKeyState & RIGHT_ALT_PRESSED) != 0;
 
             return modifiers;
+        }
+
+        KeyModifiers readSgrModifiers(int buttonCode)
+        {
+            KeyModifiers modifiers;
+            modifiers.shift = (buttonCode & 4) != 0;
+            modifiers.alt = (buttonCode & 8) != 0;
+            modifiers.ctrl = (buttonCode & 16) != 0;
+            return modifiers;
+        }
+
+        MouseButton mapSgrButton(int buttonCode)
+        {
+            if ((buttonCode & 64) != 0)
+            {
+                return (buttonCode & 1) == 0
+                    ? MouseButton::WheelUp
+                    : MouseButton::WheelDown;
+            }
+
+            switch (buttonCode & 3)
+            {
+            case 0: return MouseButton::Left;
+            case 1: return MouseButton::Middle;
+            case 2: return MouseButton::Right;
+            default: return MouseButton::None;
+            }
+        }
+
+        MouseButtonState buttonStateFor(MouseButton button, bool pressed)
+        {
+            MouseButtonState state;
+
+            if (!pressed)
+            {
+                return state;
+            }
+
+            switch (button)
+            {
+            case MouseButton::Left:
+                state.left = true;
+                break;
+            case MouseButton::Right:
+                state.right = true;
+                break;
+            case MouseButton::Middle:
+                state.middle = true;
+                break;
+            default:
+                break;
+            }
+
+            return state;
+        }
+
+        bool isSgrMouseTerminator(wchar_t ch)
+        {
+            return ch == L'M' || ch == L'm';
+        }
+
+        bool isCsiKeyboardTerminator(wchar_t ch)
+        {
+            return ch == L'A'
+                || ch == L'B'
+                || ch == L'C'
+                || ch == L'D';
+        }
+
+        bool isLikelyEscapeSequenceCharacter(wchar_t ch)
+        {
+            return ch == L'\x1B'
+                || ch == L'['
+                || ch == L'<'
+                || ch == L';'
+                || ch == L'M'
+                || ch == L'm'
+                || ch == L'A'
+                || ch == L'B'
+                || ch == L'C'
+                || ch == L'D'
+                || ch == L'Z'
+                || std::iswdigit(ch) != 0;
+        }
+
+        std::optional<int> parseInt(const std::wstring& text)
+        {
+            if (text.empty())
+            {
+                return std::nullopt;
+            }
+
+            int value = 0;
+            for (wchar_t ch : text)
+            {
+                if (ch < L'0' || ch > L'9')
+                {
+                    return std::nullopt;
+                }
+
+                value = (value * 10) + static_cast<int>(ch - L'0');
+            }
+
+            return value;
         }
     }
 
@@ -51,16 +161,15 @@ namespace Input
 
         DWORD rawMode = mode;
 
-        // Keyboard polling should own only keyboard/window input for Phase 7.
-        // Do not preserve mouse or VT input here; mouse support is not implemented yet,
-        // and VT mouse/escape sequences can be misread as Escape -> Cancel -> Quit.
         rawMode &= ~ENABLE_LINE_INPUT;
         rawMode &= ~ENABLE_ECHO_INPUT;
-        rawMode &= ~ENABLE_PROCESSED_INPUT;
-        rawMode &= ~ENABLE_MOUSE_INPUT;
-        rawMode &= ~ENABLE_VIRTUAL_TERMINAL_INPUT;
+
+        // Keep processed input enabled so normal console key behavior remains stable.
+        // Do NOT clear ENABLE_PROCESSED_INPUT here.
 
         rawMode |= ENABLE_WINDOW_INPUT;
+        rawMode |= ENABLE_MOUSE_INPUT;
+        rawMode |= ENABLE_VIRTUAL_TERMINAL_INPUT;
 
         if (!SetConsoleMode(handle, rawMode))
         {
@@ -68,6 +177,8 @@ namespace Input
             m_originalMode = 0;
             return false;
         }
+
+        emitMouseReportingEnable();
 
         m_initialized = true;
         return true;
@@ -80,18 +191,33 @@ namespace Input
             return;
         }
 
+        emitMouseReportingDisable();
+
         HANDLE handle = static_cast<HANDLE>(m_inputHandle);
         if (handle != INVALID_HANDLE_VALUE && handle != nullptr)
         {
             SetConsoleMode(handle, m_originalMode);
         }
 
+        m_pendingEvents.clear();
         m_inputHandle = nullptr;
         m_originalMode = 0;
         m_initialized = false;
     }
 
-    std::optional<RawKeyEvent> WindowsConsoleKeyboardSource::pollRawKey()
+    std::optional<RawInputEvent> WindowsConsoleKeyboardSource::pollRawInput()
+    {
+        if (!m_pendingEvents.empty())
+        {
+            RawInputEvent event = m_pendingEvents.front();
+            m_pendingEvents.pop_front();
+            return event;
+        }
+
+        return pollFromConsole();
+    }
+
+    std::optional<RawInputEvent> WindowsConsoleKeyboardSource::pollFromConsole()
     {
         if (!m_initialized)
         {
@@ -121,15 +247,292 @@ namespace Input
             }
 
             const KEY_EVENT_RECORD& key = record.Event.KeyEvent;
+            if (key.bKeyDown == FALSE)
+            {
+                continue;
+            }
+
+            const char32_t character = static_cast<char32_t>(key.uChar.UnicodeChar);
+
+            // Only attempt SGR parsing when the sequence starts ESC [ <
+            if (character == U'\x1B')
+            {
+                std::optional<std::wstring> sequence = tryReadEscapeSequence(character);
+
+                if (sequence.has_value())
+                {
+                    const std::wstring& value = sequence.value();
+
+                    // SGR mouse: ESC [ < b ; x ; y M/m
+                    if (value.size() >= 3
+                        && value[0] == L'\x1B'
+                        && value[1] == L'['
+                        && value[2] == L'<')
+                    {
+                        std::optional<MouseEvent> mouse = tryParseSgrMouseSequence(value);
+                        if (mouse.has_value())
+                        {
+                            return RawInputEvent(mouse.value());
+                        }
+
+                        return std::nullopt;
+                    }
+
+                    // VT arrow keys generated when ENABLE_VIRTUAL_TERMINAL_INPUT is active.
+                    if (value == L"\x1B[A")
+                    {
+                        RawKeyEvent raw;
+                        raw.virtualKey = 0x26; // VK_UP
+                        raw.character = U'\0';
+                        raw.modifiers = readModifiers(key.dwControlKeyState);
+                        raw.pressed = true;
+                        raw.repeatCount = 1;
+                        return RawInputEvent(raw);
+                    }
+
+                    if (value == L"\x1B[B")
+                    {
+                        RawKeyEvent raw;
+                        raw.virtualKey = 0x28; // VK_DOWN
+                        raw.character = U'\0';
+                        raw.modifiers = readModifiers(key.dwControlKeyState);
+                        raw.pressed = true;
+                        raw.repeatCount = 1;
+                        return RawInputEvent(raw);
+                    }
+
+                    if (value == L"\x1B[C")
+                    {
+                        RawKeyEvent raw;
+                        raw.virtualKey = 0x27; // VK_RIGHT
+                        raw.character = U'\0';
+                        raw.modifiers = readModifiers(key.dwControlKeyState);
+                        raw.pressed = true;
+                        raw.repeatCount = 1;
+                        return RawInputEvent(raw);
+                    }
+
+                    if (value == L"\x1B[D")
+                    {
+                        RawKeyEvent raw;
+                        raw.virtualKey = 0x25; // VK_LEFT
+                        raw.character = U'\0';
+                        raw.modifiers = readModifiers(key.dwControlKeyState);
+                        raw.pressed = true;
+                        raw.repeatCount = 1;
+                        return RawInputEvent(raw);
+                    }
+
+                    // VT Shift+Tab / Backtab: ESC [ Z
+                    if (value == L"\x1B[Z")
+                    {
+                        RawKeyEvent raw;
+                        raw.virtualKey = 0x09; // VK_TAB
+                        raw.character = U'\0';
+                        raw.modifiers = readModifiers(key.dwControlKeyState);
+                        raw.modifiers.shift = true;
+                        raw.pressed = true;
+                        raw.repeatCount = 1;
+                        return RawInputEvent(raw);
+                    }
+
+                    // Do not convert unknown CSI sequences into Escape.
+                    // That was causing arrow keys to close the app.
+                    if (value.size() > 1)
+                    {
+                        return std::nullopt;
+                    }
+                }
+
+                RawKeyEvent raw;
+                raw.virtualKey = 0x1B;
+                raw.character = U'\x1B';
+                raw.modifiers = readModifiers(key.dwControlKeyState);
+                raw.pressed = true;
+                raw.repeatCount = 1;
+                return RawInputEvent(raw);
+            }
 
             RawKeyEvent raw;
             raw.virtualKey = static_cast<std::uint16_t>(key.wVirtualKeyCode);
-            raw.character = static_cast<char32_t>(key.uChar.UnicodeChar);
+            raw.character = character;
             raw.modifiers = readModifiers(key.dwControlKeyState);
-            raw.pressed = key.bKeyDown != FALSE;
+            raw.pressed = true;
             raw.repeatCount = static_cast<std::uint16_t>(key.wRepeatCount == 0 ? 1 : key.wRepeatCount);
 
-            return raw;
+            return RawInputEvent(raw);
         }
+    }
+
+    std::optional<std::wstring> WindowsConsoleKeyboardSource::tryReadEscapeSequence(char32_t firstCharacter)
+    {
+        std::wstring sequence;
+        sequence.push_back(static_cast<wchar_t>(firstCharacter));
+
+        HANDLE handle = static_cast<HANDLE>(m_inputHandle);
+
+        while (sequence.size() < 32)
+        {
+            DWORD eventCount = 0;
+            if (!GetNumberOfConsoleInputEvents(handle, &eventCount) || eventCount == 0)
+            {
+                break;
+            }
+
+            INPUT_RECORD peek{};
+            DWORD recordsPeeked = 0;
+            if (!PeekConsoleInputW(handle, &peek, 1, &recordsPeeked) || recordsPeeked == 0)
+            {
+                break;
+            }
+
+            if (peek.EventType != KEY_EVENT || peek.Event.KeyEvent.bKeyDown == FALSE)
+            {
+                break;
+            }
+
+            const wchar_t ch = peek.Event.KeyEvent.uChar.UnicodeChar;
+            if (!isLikelyEscapeSequenceCharacter(ch))
+            {
+                break;
+            }
+
+            INPUT_RECORD consumed{};
+            DWORD recordsRead = 0;
+            if (!ReadConsoleInputW(handle, &consumed, 1, &recordsRead) || recordsRead == 0)
+            {
+                break;
+            }
+
+            sequence.push_back(ch);
+
+            if (isSgrMouseTerminator(ch) || isCsiKeyboardTerminator(ch))
+            {
+                break;
+            }
+        }
+
+        return sequence;
+    }
+
+    std::optional<MouseEvent> WindowsConsoleKeyboardSource::tryParseSgrMouseSequence(const std::wstring& sequence) const
+    {
+        // Expected SGR format:
+        // ESC [ < b ; x ; y M
+        // ESC [ < b ; x ; y m
+        if (sequence.size() < 9)
+        {
+            return std::nullopt;
+        }
+
+        if (sequence[0] != L'\x1B' || sequence[1] != L'[' || sequence[2] != L'<')
+        {
+            return std::nullopt;
+        }
+
+        const wchar_t terminator = sequence.back();
+        if (!isSgrMouseTerminator(terminator))
+        {
+            return std::nullopt;
+        }
+
+        const std::wstring payload = sequence.substr(3, sequence.size() - 4);
+
+        std::vector<std::wstring> parts;
+        std::wstring current;
+
+        for (wchar_t ch : payload)
+        {
+            if (ch == L';')
+            {
+                parts.push_back(current);
+                current.clear();
+            }
+            else
+            {
+                current.push_back(ch);
+            }
+        }
+
+        parts.push_back(current);
+
+        if (parts.size() != 3)
+        {
+            return std::nullopt;
+        }
+
+        std::optional<int> buttonCode = parseInt(parts[0]);
+        std::optional<int> x = parseInt(parts[1]);
+        std::optional<int> y = parseInt(parts[2]);
+
+        if (!buttonCode.has_value() || !x.has_value() || !y.has_value())
+        {
+            return std::nullopt;
+        }
+
+        if (x.value() <= 0 || y.value() <= 0)
+        {
+            return std::nullopt;
+        }
+
+        MouseEvent event;
+        event.position.x = x.value() - 1;
+        event.position.y = y.value() - 1;
+        event.modifiers = readSgrModifiers(buttonCode.value());
+
+        const bool release = terminator == L'm';
+        const bool wheel = (buttonCode.value() & 64) != 0;
+        const bool motion = (buttonCode.value() & 32) != 0;
+
+        event.button = mapSgrButton(buttonCode.value());
+
+        if (wheel)
+        {
+            event.action = MouseAction::Wheel;
+            event.wheelDelta = event.button == MouseButton::WheelUp ? 1 : -1;
+            event.buttons = MouseButtonState{};
+            return event;
+        }
+
+        if (release)
+        {
+            event.action = MouseAction::Released;
+            event.buttons = MouseButtonState{};
+            return event;
+        }
+
+        if (motion)
+        {
+            event.action = event.button == MouseButton::None
+                ? MouseAction::Moved
+                : MouseAction::Dragged;
+            event.buttons = buttonStateFor(event.button, event.button != MouseButton::None);
+            return event;
+        }
+
+        event.action = MouseAction::Pressed;
+        event.buttons = buttonStateFor(event.button, true);
+        event.clickCount = 1;
+
+        return event;
+    }
+
+    void WindowsConsoleKeyboardSource::emitMouseReportingEnable() const
+    {
+        // 1000: button press/release
+        // 1002: drag reporting
+        // 1006: SGR extended mouse format
+        std::cout << "\x1b[?1000h"
+            << "\x1b[?1002h"
+            << "\x1b[?1006h"
+            << std::flush;
+    }
+
+    void WindowsConsoleKeyboardSource::emitMouseReportingDisable() const
+    {
+        std::cout << "\x1b[?1002l"
+            << "\x1b[?1000l"
+            << "\x1b[?1006l"
+            << std::flush;
     }
 }

--- a/TUI/Input/WindowsConsoleKeyboardSource.h
+++ b/TUI/Input/WindowsConsoleKeyboardSource.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <deque>
+#include <optional>
+#include <string>
+
 #include "Input/RawKeyboardSource.h"
 
 namespace Input
@@ -13,11 +17,19 @@ namespace Input
         bool initialize() override;
         void shutdown() override;
 
-        std::optional<RawKeyEvent> pollRawKey() override;
+        std::optional<RawInputEvent> pollRawInput() override;
+
+    private:
+        std::optional<RawInputEvent> pollFromConsole();
+        std::optional<MouseEvent> tryParseSgrMouseSequence(const std::wstring& sequence) const;
+        std::optional<std::wstring> tryReadEscapeSequence(char32_t firstCharacter);
+        void emitMouseReportingEnable() const;
+        void emitMouseReportingDisable() const;
 
     private:
         void* m_inputHandle = nullptr;
         unsigned long m_originalMode = 0;
         bool m_initialized = false;
+        std::deque<RawInputEvent> m_pendingEvents;
     };
 }


### PR DESCRIPTION
… support

Modifies:
- App/Application.cpp
- Input/InputManager.h/.cpp
- Input/RawKeyboardSource.h
- Input/WindowsConsoleKeyboardSource.h/.cpp

Note: At this stage input will cause

- Extended raw input abstraction to support both keyboard and mouse events
- Added RawInputEvent variant for backend-agnostic input transport
- Updated InputManager to process mixed keyboard/mouse event streams
- Preserved existing keyboard command mapping behavior
- Added terminal mouse reporting enable/disable lifecycle handling
- Enabled SGR mouse protocol support (1000/1002/1006 modes)
- Implemented parsing for SGR mouse escape sequences:
  - ESC [ < b ; x ; y M
  - ESC [ < b ; x ; y m
- Added translation of terminal mouse data into Input::MouseEvent
- Added support for:
  - mouse press
  - mouse release
  - mouse move
  - mouse drag
  - wheel up/down
  - modifier keys
- Converted terminal 1-based coordinates to engine zero-based coordinates
- Added safe fallback handling for malformed or unsupported sequences
- Preserved compatibility with existing keyboard-only event consumers
- Added pending input queue support for escape sequence reconstruction
- Kept terminal decoding layer widget-agnostic
- Maintained backend separation between terminal parsing and UI behavior

Updated:
- Input/RawKeyboardSource.h
- Input/WindowsConsoleKeyboardSource.h
- Input/WindowsConsoleKeyboardSource.cpp
- Input/InputManager.h
- Input/InputManager.cpp
- App/Application.cpp

Closes: #314 