### PR TITLE
ContainerWidget: Add widget hit testing and mouse event dispatch

### DIFF
--- a/TUI/UI/Widgets/ContainerWidget.cpp
+++ b/TUI/UI/Widgets/ContainerWidget.cpp
@@ -4,8 +4,9 @@
 #include <stdexcept>
 #include <utility>
 
-#include "Input/Event.h"
 #include "Input/Command.h"
+#include "Input/Event.h"
+#include "Input/MouseEvent.h"
 #include "Rendering/Surface.h"
 
 ContainerWidget::ContainerWidget() = default;
@@ -140,6 +141,56 @@ const Widget* ContainerWidget::focusedChild() const
     return m_focusedChild;
 }
 
+Widget* ContainerWidget::hitTest(Point position)
+{
+    if (!isVisible() || !isEnabled())
+    {
+        return nullptr;
+    }
+
+    for (auto it = m_children.rbegin(); it != m_children.rend(); ++it)
+    {
+        Widget* child = it->get();
+
+        if (!child || !child->isVisible() || !child->isEnabled())
+        {
+            continue;
+        }
+
+        if (child->bounds().contains(position.x, position.y))
+        {
+            return child;
+        }
+    }
+
+    return nullptr;
+}
+
+const Widget* ContainerWidget::hitTest(Point position) const
+{
+    if (!isVisible() || !isEnabled())
+    {
+        return nullptr;
+    }
+
+    for (auto it = m_children.rbegin(); it != m_children.rend(); ++it)
+    {
+        const Widget* child = it->get();
+
+        if (!child || !child->isVisible() || !child->isEnabled())
+        {
+            continue;
+        }
+
+        if (child->bounds().contains(position.x, position.y))
+        {
+            return child;
+        }
+    }
+
+    return nullptr;
+}
+
 bool ContainerWidget::setFocusedChild(Widget& child)
 {
     if (!containsChild(child) || !canFocusChild(child))
@@ -250,6 +301,11 @@ bool ContainerWidget::handleEvent(const Input::Event& event)
         return false;
     }
 
+    if (event.asMouse())
+    {
+        return dispatchMouseEvent(event);
+    }
+
     if (const Input::CommandEvent* commandEvent = event.asCommand())
     {
         switch (commandEvent->command.code)
@@ -343,4 +399,28 @@ bool ContainerWidget::focusChildByDirection(int direction)
     }
 
     return false;
+}
+
+bool ContainerWidget::dispatchMouseEvent(const Input::Event& event)
+{
+    const Input::MouseEvent* mouseEvent = event.asMouse();
+
+    if (!mouseEvent)
+    {
+        return false;
+    }
+
+    Widget* target = hitTest(mouseEvent->position);
+
+    if (!target)
+    {
+        return false;
+    }
+
+    if ((mouseEvent->isPress() || mouseEvent->isClick()) && canFocusChild(*target))
+    {
+        setFocusedChild(*target);
+    }
+
+    return target->handleEvent(event);
 }

--- a/TUI/UI/Widgets/ContainerWidget.h
+++ b/TUI/UI/Widgets/ContainerWidget.h
@@ -4,6 +4,7 @@
 #include <memory>
 #include <vector>
 
+#include "Core/Point.h"
 #include "Core/Rect.h"
 #include "UI/Widgets/Widget.h"
 
@@ -41,6 +42,9 @@ public:
     Widget* focusedChild();
     const Widget* focusedChild() const;
 
+    Widget* hitTest(Point position);
+    const Widget* hitTest(Point position) const;
+
     bool setFocusedChild(Widget& child);
     void clearChildFocus();
 
@@ -60,6 +64,7 @@ private:
     bool canFocusChild(const Widget& child) const;
     bool focusChildAt(std::size_t index);
     bool focusChildByDirection(int direction);
+    bool dispatchMouseEvent(const Input::Event& event);
 
 private:
     std::vector<ChildPtr> m_children;


### PR DESCRIPTION
Modifies:
- UI/Widgets/Containerwidget.h/.cpp

ContainerWidget can now:
- Perform screen-space child hit testing
- Search children in reverse draw order (topmost-first)
- Ignore hidden/disabled widgets during hit testing
- Route mouse events to the child under the cursor
- Automatically focus clicked focusable widgets
- Preserve existing keyboard focus traversal behavior

Added:
- ContainerWidget::hitTest(Point)
- Reverse-order child lookup for mouse targeting
- Generic mouse dispatch path
- Focus transfer on mouse press/click
- Shared child focus management improvements

Updated:
- Mouse events integrate through existing Widget::handleEvent
- Keyboard event handling remains unchanged
- Child dispatch respects enabled/visible state
- Nested container dispatch works recursively

Design goals:
- Backend-agnostic widget interaction
- Reusable infrastructure for future Button/ListBox/TextView behavior
- No widget-specific mouse logic embedded in ContainerWidget
- Foundation for future window dragging, resizing, and docking interaction

Closes: #315 