### PR TITLE
Mouse Interactions: Window Mouse Focus and Raise Behavior

### DIFF
--- a/TUI/Screens/WindowDemo.cpp
+++ b/TUI/Screens/WindowDemo.cpp
@@ -146,6 +146,11 @@ void WindowDemo::onEnter()
     m_modalPopup.open();
 }
 
+bool WindowDemo::handleEvent(const Input::Event& event)
+{
+    return m_windowManager.handleEvent(event);
+}
+
 void WindowDemo::update(double deltaTime)
 {
     m_elapsedSeconds += deltaTime;

--- a/TUI/Screens/WindowDemo.h
+++ b/TUI/Screens/WindowDemo.h
@@ -14,6 +14,7 @@ public:
     WindowDemo();
 
     void onEnter() override;
+    bool handleEvent(const Input::Event& event) override;
     void update(double deltaTime) override;
     void draw(Surface& surface) override;
 

--- a/TUI/Screens/WindowDemoScreen.cpp
+++ b/TUI/Screens/WindowDemoScreen.cpp
@@ -140,6 +140,11 @@ void WindowDemo::onEnter()
     m_digiRain.setOptions(DigiRainOptions);
 }
 
+bool WindowDemo::handleEvent(const Input::Event& event)
+{
+    return m_windowManager.handleEvent(event);
+}
+
 void WindowDemo::onExit()
 {
     m_fire.onExit();

--- a/TUI/Screens/WindowDemoScreen.h
+++ b/TUI/Screens/WindowDemoScreen.h
@@ -19,6 +19,7 @@ public:
     ~WindowDemo() override;
 
     void onEnter() override;
+    bool handleEvent(const Input::Event& event) override;
     void onExit() override;
     void update(double deltaTime) override;
     void draw(Surface& surface) override;

--- a/TUI/UI/Base/WindowManager.cpp
+++ b/TUI/UI/Base/WindowManager.cpp
@@ -5,6 +5,8 @@
 
 #include "Core/Rect.h"
 #include "UI/Panels/Window.h"
+#include "Input/Event.h"
+#include "Input/MouseEvent.h"
 
 WindowManager::WindowManager() = default;
 
@@ -28,6 +30,21 @@ void WindowManager::addWindow(Window& window)
 
 void WindowManager::removeWindow(Window& window)
 {
+    if (m_hoveredWindow == &window)
+    {
+        setHoveredWindow(nullptr);
+    }
+
+    if (m_focusedWindow == &window)
+    {
+        setFocusedWindow(nullptr);
+    }
+
+    if (m_pointerCapture.window == &window)
+    {
+        releasePointer();
+    }
+
     m_windows.erase(
         std::remove_if(
             m_windows.begin(),
@@ -41,6 +58,11 @@ void WindowManager::removeWindow(Window& window)
 
 void WindowManager::clear()
 {
+    setHoveredWindow(nullptr);
+    setFocusedWindow(nullptr);
+    releasePointer();
+    m_dragState.clear();
+    m_resizeState.clear();
     m_windows.clear();
 }
 
@@ -73,6 +95,16 @@ void WindowManager::hide(Window& window)
 {
     if (ManagedWindow* entry = findEntry(window))
     {
+        if (m_hoveredWindow == &window)
+        {
+            setHoveredWindow(nullptr);
+        }
+
+        if (m_focusedWindow == &window)
+        {
+            setFocusedWindow(nullptr);
+        }
+
         entry->window->hide();
     }
 }
@@ -197,6 +229,26 @@ const Window* WindowManager::topModalWindow() const
     return nullptr;
 }
 
+Window* WindowManager::hoveredWindow()
+{
+    return m_hoveredWindow;
+}
+
+const Window* WindowManager::hoveredWindow() const
+{
+    return m_hoveredWindow;
+}
+
+Window* WindowManager::focusedWindow()
+{
+    return m_focusedWindow;
+}
+
+const Window* WindowManager::focusedWindow() const
+{
+    return m_focusedWindow;
+}
+
 bool WindowManager::hasModalWindow() const
 {
     return topModalWindow() != nullptr;
@@ -231,6 +283,46 @@ bool WindowManager::canRouteTo(const Window& window) const
     }
 
     return targetEntry->zOrder >= modalEntry->zOrder;
+}
+
+bool WindowManager::handleEvent(const Input::Event& event)
+{
+    const Input::MouseEvent* mouseEvent = event.asMouse();
+    if (!mouseEvent)
+    {
+        return false;
+    }
+
+    return handleMouseEvent(*mouseEvent);
+}
+
+bool WindowManager::handleMouseEvent(const Input::MouseEvent& mouseEvent)
+{
+    UI::WindowHitTestResult result = hitTest(mouseEvent.position);
+    Window* target = result.hit() ? result.window : nullptr;
+
+    setHoveredWindow(target);
+
+    if (target == nullptr)
+    {
+        return false;
+    }
+
+    const bool isPrimaryActivation =
+        mouseEvent.button == Input::MouseButton::Left &&
+        (mouseEvent.isPress() || mouseEvent.isClick());
+
+    bool consumedByWindow = target->handleEvent(Input::Event::mouse(mouseEvent));
+
+    if (isPrimaryActivation)
+    {
+        setFocusedWindow(target);
+        bringToFront(*target);
+        setHoveredWindow(target);
+        return true;
+    }
+
+    return consumedByWindow;
 }
 
 UI::WindowHitTestResult WindowManager::hitTest(Point screenPosition)
@@ -635,4 +727,44 @@ int WindowManager::nextBackZOrder() const
         });
 
     return it->zOrder - 1;
+}
+
+void WindowManager::setHoveredWindow(Window* window)
+{
+    if (m_hoveredWindow == window)
+    {
+        return;
+    }
+
+    if (m_hoveredWindow != nullptr)
+    {
+        m_hoveredWindow->setHovered(false);
+    }
+
+    m_hoveredWindow = window;
+
+    if (m_hoveredWindow != nullptr)
+    {
+        m_hoveredWindow->setHovered(true);
+    }
+}
+
+void WindowManager::setFocusedWindow(Window* window)
+{
+    if (m_focusedWindow == window)
+    {
+        return;
+    }
+
+    if (m_focusedWindow != nullptr)
+    {
+        m_focusedWindow->blur();
+    }
+
+    m_focusedWindow = window;
+
+    if (m_focusedWindow != nullptr && m_focusedWindow->canReceiveFocus())
+    {
+        m_focusedWindow->focus();
+    }
 }

--- a/TUI/UI/Base/WindowManager.h
+++ b/TUI/UI/Base/WindowManager.h
@@ -8,6 +8,13 @@
 #include "Rendering/LayerInstance.h"
 #include "Rendering/Surface.h"
 #include "UI/Interaction/WindowInteraction.h"
+#include "Input/MouseEvent.h"
+
+namespace Input
+{
+    class Event;
+    struct MouseEvent;
+}
 
 class Window;
 
@@ -40,8 +47,16 @@ public:
     Window* topModalWindow();
     const Window* topModalWindow() const;
 
+    Window* hoveredWindow();
+    const Window* hoveredWindow() const;
+
+    Window* focusedWindow();
+    const Window* focusedWindow() const;
+
     bool hasModalWindow() const;
     bool canRouteTo(const Window& window) const;
+    bool handleEvent(const Input::Event& event);
+    bool handleMouseEvent(const Input::MouseEvent& mouseEvent);
 
     UI::WindowHitTestResult hitTest(Point screenPosition);
     UI::WindowHitTestResult hitTest(Point screenPosition) const;
@@ -89,6 +104,9 @@ private:
     int nextFrontZOrder() const;
     int nextBackZOrder() const;
 
+    void setHoveredWindow(Window* window);
+    void setFocusedWindow(Window* window);
+
 private:
     std::vector<ManagedWindow> m_windows;
     std::size_t m_nextInsertionOrder = 0;
@@ -96,4 +114,7 @@ private:
     UI::PointerCaptureState m_pointerCapture;
     UI::WindowDragState m_dragState;
     UI::WindowResizeState m_resizeState;
+
+    Window* m_hoveredWindow = nullptr;
+    Window* m_focusedWindow = nullptr;
 };

--- a/TUI/UI/Panels/Window.cpp
+++ b/TUI/UI/Panels/Window.cpp
@@ -3,25 +3,31 @@
 #include <algorithm>
 #include <utility>
 
+#include "Rendering/Styles/StyleBuilder.h"
+
 Window::Window()
     : Panel()
 {
+    setFocusable(true);
 }
 
 Window::Window(const Rect& bounds)
     : Panel(bounds)
 {
+    setFocusable(true);
 }
 
 Window::Window(const Rect& bounds, std::string title)
     : Panel(bounds, std::move(title))
 {
+    setFocusable(true);
 }
 
 Window::Window(const Rect& bounds, std::string title, bool modal)
     : Panel(bounds, std::move(title))
     , m_modal(modal)
 {
+    setFocusable(true);
 }
 
 bool Window::isModal() const
@@ -109,4 +115,31 @@ UI::CursorRegion Window::hitTest(Point screenPosition) const
 bool Window::containsScreenPoint(Point screenPosition) const
 {
     return hitTest(screenPosition) != UI::CursorRegion::Outside;
+}
+
+bool Window::isHovered() const
+{
+    return m_hovered;
+}
+
+void Window::setHovered(bool hovered)
+{
+    m_hovered = hovered;
+}
+
+void Window::draw(Surface& surface)
+{
+    const Style originalBorderStyle = borderStyle();
+    const Style originalTitleStyle = titleStyle();
+
+    if (isFocused() || isHovered())
+    {
+        setBorderStyle(originalBorderStyle + style::Bold);
+        setTitleStyle(originalTitleStyle + style::Bold);
+    }
+
+    Panel::draw(surface);
+
+    setBorderStyle(originalBorderStyle);
+    setTitleStyle(originalTitleStyle);
 }

--- a/TUI/UI/Panels/Window.h
+++ b/TUI/UI/Panels/Window.h
@@ -37,10 +37,16 @@ public:
     UI::CursorRegion hitTest(Point screenPosition) const;
     bool containsScreenPoint(Point screenPosition) const;
 
+    bool isHovered() const;
+    void setHovered(bool hovered);
+
+    void draw(Surface& surface) override;
+
 private:
     bool m_modal = false;
     bool m_draggable = true;
     bool m_resizable = true;
+    bool m_hovered = false;
     Size m_minimumSize{ 4, 3 };
     int m_resizeBorderThickness = 1;
     int m_titleBarHeight = 1;


### PR DESCRIPTION
Modifies:
- Screens/WindowDemo.h/.cpp
- Screens/WindowDemoScreen.h/.cpp
- UI/Base/WindowMange.h/.cpp
- UI/Panels/Window.h/.cpp

- Added mouse-aware window interaction handling through WindowManager.
- Added reusable window hit-testing based activation routing.
- Added hovered window tracking.
- Added focused window tracking.
- Added window hover highlighting support.
- Clicking a window now:
  - focuses the window
  - raises the window to the front
  - preserves existing widget event routing
- Added WindowManager::handleEvent().
- Added WindowManager::handleMouseEvent().
- Added reusable hoveredWindow()/focusedWindow() accessors.
- Added internal setHoveredWindow()/setFocusedWindow() helpers.
- Integrated focus cleanup when windows are hidden, removed, or cleared.
- Added hover visual state support to Window.
- Added hover/focus border/title highlighting behavior.
- Ensured Window instances are focusable by default.
- Preserved existing keyboard navigation and window behavior.
- Preserved compatibility with future drag/resize interaction tiers.
- Avoided special-case demo logic and maintained centralized WindowManager ownership.

Closes: #318 