### PR TITLE
Animation: Add Core Renderer-Independent Animation Model

### DIFF
--- a/TUI/Animation/Animation.cpp
+++ b/TUI/Animation/Animation.cpp
@@ -1,0 +1,341 @@
+#include "Animation/Animation.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace Animation
+{
+    bool AnimationTarget::hasTarget() const
+    {
+        return !targetId.empty()
+            && property != TargetProperty::None;
+    }
+
+    Animation::Animation(double durationSeconds)
+        : m_durationSeconds(clampNonNegative(durationSeconds))
+    {
+    }
+
+    Animation::Animation(double durationSeconds, const AnimationTarget& target)
+        : m_durationSeconds(clampNonNegative(durationSeconds))
+        , m_target(target)
+    {
+    }
+
+    void Animation::reset()
+    {
+        m_elapsedSeconds = 0.0;
+        m_playbackState = PlaybackState::Stopped;
+    }
+
+    void Animation::play()
+    {
+        if (m_playbackState == PlaybackState::Finished)
+        {
+            m_elapsedSeconds = 0.0;
+        }
+
+        m_playbackState = PlaybackState::Playing;
+        applyEndBehavior();
+    }
+
+    void Animation::pause()
+    {
+        if (m_playbackState == PlaybackState::Playing)
+        {
+            m_playbackState = PlaybackState::Paused;
+        }
+    }
+
+    void Animation::resume()
+    {
+        if (m_playbackState == PlaybackState::Paused)
+        {
+            m_playbackState = PlaybackState::Playing;
+        }
+    }
+
+    void Animation::stop()
+    {
+        m_elapsedSeconds = 0.0;
+        m_playbackState = PlaybackState::Stopped;
+    }
+
+    void Animation::finish()
+    {
+        m_elapsedSeconds = m_durationSeconds;
+        m_playbackState = PlaybackState::Finished;
+    }
+
+    void Animation::update(double deltaSeconds)
+    {
+        if (m_playbackState != PlaybackState::Playing)
+        {
+            return;
+        }
+
+        const double safeDeltaSeconds = clampNonNegative(deltaSeconds);
+        if (safeDeltaSeconds <= 0.0)
+        {
+            return;
+        }
+
+        m_elapsedSeconds += safeDeltaSeconds;
+        applyEndBehavior();
+    }
+
+    void Animation::update(const TickEvent& event)
+    {
+        if (event.paused)
+        {
+            return;
+        }
+
+        update(event.deltaSeconds);
+    }
+
+    void Animation::setDurationSeconds(double seconds)
+    {
+        m_durationSeconds = clampNonNegative(seconds);
+
+        if (m_playbackMode != PlaybackMode::Loop)
+        {
+            m_elapsedSeconds = std::min(m_elapsedSeconds, m_durationSeconds);
+        }
+
+        applyEndBehavior();
+    }
+
+    double Animation::durationSeconds() const
+    {
+        return m_durationSeconds;
+    }
+
+    void Animation::setElapsedSeconds(double seconds)
+    {
+        m_elapsedSeconds = clampNonNegative(seconds);
+        applyEndBehavior();
+    }
+
+    double Animation::elapsedSeconds() const
+    {
+        return m_elapsedSeconds;
+    }
+
+    double Animation::progress() const
+    {
+        if (m_durationSeconds <= 0.0)
+        {
+            return m_elapsedSeconds > 0.0 || m_playbackState == PlaybackState::Finished
+                ? 1.0
+                : 0.0;
+        }
+
+        if (m_playbackMode == PlaybackMode::Loop)
+        {
+            return std::fmod(m_elapsedSeconds, m_durationSeconds) / m_durationSeconds;
+        }
+
+        return clamp01(m_elapsedSeconds / m_durationSeconds);
+    }
+
+    double Animation::pingPongProgress() const
+    {
+        if (m_durationSeconds <= 0.0)
+        {
+            return progress();
+        }
+
+        const double cycleSeconds = m_durationSeconds * 2.0;
+        const double cyclePosition = std::fmod(m_elapsedSeconds, cycleSeconds);
+
+        if (cyclePosition <= m_durationSeconds)
+        {
+            return cyclePosition / m_durationSeconds;
+        }
+
+        return 1.0 - ((cyclePosition - m_durationSeconds) / m_durationSeconds);
+    }
+
+    PlaybackState Animation::playbackState() const
+    {
+        return m_playbackState;
+    }
+
+    void Animation::setPlaybackMode(PlaybackMode mode)
+    {
+        m_playbackMode = mode;
+        applyEndBehavior();
+    }
+
+    PlaybackMode Animation::playbackMode() const
+    {
+        return m_playbackMode;
+    }
+
+    bool Animation::isPlaying() const
+    {
+        return m_playbackState == PlaybackState::Playing;
+    }
+
+    bool Animation::isPaused() const
+    {
+        return m_playbackState == PlaybackState::Paused;
+    }
+
+    bool Animation::isStopped() const
+    {
+        return m_playbackState == PlaybackState::Stopped;
+    }
+
+    bool Animation::isFinished() const
+    {
+        return m_playbackState == PlaybackState::Finished;
+    }
+
+    void Animation::setTarget(const AnimationTarget& target)
+    {
+        m_target = target;
+    }
+
+    const AnimationTarget& Animation::target() const
+    {
+        return m_target;
+    }
+
+    void Animation::setExplicitFrameIndexOverride(std::optional<std::size_t> frameIndex)
+    {
+        m_explicitFrameIndexOverride = frameIndex;
+    }
+
+    void Animation::clearExplicitFrameIndexOverride()
+    {
+        m_explicitFrameIndexOverride.reset();
+    }
+
+    bool Animation::hasExplicitFrameIndexOverride() const
+    {
+        return m_explicitFrameIndexOverride.has_value();
+    }
+
+    std::optional<std::size_t> Animation::explicitFrameIndexOverride() const
+    {
+        return m_explicitFrameIndexOverride;
+    }
+
+    std::size_t Animation::selectFrameIndex(const FrameSelectionInput& input) const
+    {
+        if (input.frameCount == 0)
+        {
+            return input.firstFrameIndex;
+        }
+
+        if (m_explicitFrameIndexOverride.has_value())
+        {
+            return clampFrameIndex(m_explicitFrameIndexOverride.value(), input);
+        }
+
+        if (input.framesPerSecond > 0.0)
+        {
+            const double rawFrame =
+                effectiveFrameProgress() * static_cast<double>(input.frameCount);
+
+            std::size_t selectedFrame = static_cast<std::size_t>(std::floor(rawFrame));
+
+            if (selectedFrame >= input.frameCount)
+            {
+                selectedFrame = input.frameCount - 1;
+            }
+
+            return input.firstFrameIndex + selectedFrame;
+        }
+
+        const double rawFrame =
+            effectiveFrameProgress() * static_cast<double>(input.frameCount - 1);
+
+        return input.firstFrameIndex
+            + static_cast<std::size_t>(std::round(rawFrame));
+    }
+
+    std::size_t Animation::selectFrameIndex(std::size_t frameCount, double framesPerSecond) const
+    {
+        FrameSelectionInput input;
+        input.frameCount = frameCount;
+        input.framesPerSecond = framesPerSecond;
+
+        return selectFrameIndex(input);
+    }
+
+    double Animation::clampNonNegative(double value)
+    {
+        return std::max(0.0, value);
+    }
+
+    double Animation::clamp01(double value)
+    {
+        return std::max(0.0, std::min(1.0, value));
+    }
+
+    std::size_t Animation::clampFrameIndex(std::size_t frameIndex, const FrameSelectionInput& input)
+    {
+        if (input.frameCount == 0)
+        {
+            return input.firstFrameIndex;
+        }
+
+        const std::size_t firstFrame = input.firstFrameIndex;
+        const std::size_t lastFrame = input.firstFrameIndex + input.frameCount - 1;
+
+        if (frameIndex < firstFrame)
+        {
+            return firstFrame;
+        }
+
+        if (frameIndex > lastFrame)
+        {
+            return input.clampToLastFrame
+                ? lastFrame
+                : firstFrame + ((frameIndex - firstFrame) % input.frameCount);
+        }
+
+        return frameIndex;
+    }
+
+    double Animation::effectiveFrameProgress() const
+    {
+        if (m_playbackMode == PlaybackMode::PingPong)
+        {
+            return pingPongProgress();
+        }
+
+        return progress();
+    }
+
+    void Animation::applyEndBehavior()
+    {
+        if (m_durationSeconds <= 0.0)
+        {
+            if (m_playbackState == PlaybackState::Playing)
+            {
+                m_playbackState = PlaybackState::Finished;
+            }
+
+            return;
+        }
+
+        if (m_playbackMode == PlaybackMode::Loop || m_playbackMode == PlaybackMode::PingPong)
+        {
+            return;
+        }
+
+        if (m_elapsedSeconds >= m_durationSeconds)
+        {
+            m_elapsedSeconds = m_durationSeconds;
+
+            if (m_playbackState == PlaybackState::Playing)
+            {
+                m_playbackState = PlaybackState::Finished;
+            }
+        }
+    }
+}

--- a/TUI/Animation/Animation.h
+++ b/TUI/Animation/Animation.h
@@ -1,0 +1,119 @@
+#pragma once
+
+#include <cstddef>
+#include <optional>
+#include <string>
+
+#include "Animation/TickEvent.h"
+
+namespace Animation
+{
+    enum class PlaybackState
+    {
+        Stopped,
+        Playing,
+        Paused,
+        Finished
+    };
+
+    enum class PlaybackMode
+    {
+        Once,
+        Loop,
+        PingPong
+    };
+
+    enum class TargetProperty
+    {
+        None,
+        FrameIndex,
+        OffsetX,
+        OffsetY,
+        Opacity,
+        Color,
+        Style,
+        Glyph,
+        Custom
+    };
+
+    struct AnimationTarget
+    {
+        std::string targetId;
+        TargetProperty property = TargetProperty::None;
+        std::string customPropertyName;
+
+        bool hasTarget() const;
+    };
+
+    struct FrameSelectionInput
+    {
+        std::size_t frameCount = 0;
+        double framesPerSecond = 0.0;
+        bool clampToLastFrame = true;
+        std::size_t firstFrameIndex = 0;
+    };
+
+    class Animation
+    {
+    public:
+        explicit Animation(double durationSeconds = 0.0);
+        Animation(double durationSeconds, const AnimationTarget& target);
+
+        void reset();
+        void play();
+        void pause();
+        void resume();
+        void stop();
+        void finish();
+
+        void update(double deltaSeconds);
+        void update(const TickEvent& event);
+
+        void setDurationSeconds(double seconds);
+        double durationSeconds() const;
+
+        void setElapsedSeconds(double seconds);
+        double elapsedSeconds() const;
+
+        double progress() const;
+        double pingPongProgress() const;
+
+        PlaybackState playbackState() const;
+        void setPlaybackMode(PlaybackMode mode);
+        PlaybackMode playbackMode() const;
+
+        bool isPlaying() const;
+        bool isPaused() const;
+        bool isStopped() const;
+        bool isFinished() const;
+
+        void setTarget(const AnimationTarget& target);
+        const AnimationTarget& target() const;
+
+        void setExplicitFrameIndexOverride(std::optional<std::size_t> frameIndex);
+        void clearExplicitFrameIndexOverride();
+        bool hasExplicitFrameIndexOverride() const;
+        std::optional<std::size_t> explicitFrameIndexOverride() const;
+
+        std::size_t selectFrameIndex(const FrameSelectionInput& input) const;
+        std::size_t selectFrameIndex(std::size_t frameCount, double framesPerSecond) const;
+
+    private:
+        static double clampNonNegative(double value);
+        static double clamp01(double value);
+        static std::size_t clampFrameIndex(std::size_t frameIndex, const FrameSelectionInput& input);
+
+        double effectiveFrameProgress() const;
+        void applyEndBehavior();
+
+    private:
+        double m_durationSeconds = 0.0;
+        double m_elapsedSeconds = 0.0;
+
+        PlaybackState m_playbackState = PlaybackState::Stopped;
+        PlaybackMode m_playbackMode = PlaybackMode::Once;
+
+        AnimationTarget m_target;
+        std::optional<std::size_t> m_explicitFrameIndexOverride;
+    };
+}

--- a/TUI/TUI.vcxproj
+++ b/TUI/TUI.vcxproj
@@ -131,6 +131,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="Animation\Animation.h" />
     <ClInclude Include="Animation\PeriodicTimer.h" />
     <ClInclude Include="Animation\TickClock.h" />
     <ClInclude Include="Animation\TickEvent.h" />
@@ -320,6 +321,7 @@
     <ClInclude Include="Utilities\Unicode\UnicodeWidth.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="Animation\Animation.cpp" />
     <ClCompile Include="Animation\PeriodicTimer.cpp" />
     <ClCompile Include="Animation\TickClock.cpp" />
     <ClCompile Include="App\Application.cpp" />

--- a/TUI/TUI.vcxproj.filters
+++ b/TUI/TUI.vcxproj.filters
@@ -507,6 +507,18 @@
     <ClInclude Include="UI\Layout\DockDragPreview.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="Animation\PeriodicTimer.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Animation\TickClock.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Animation\TickEvent.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Animation\Animation.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Rendering\ScreenBuffer.cpp">
@@ -942,6 +954,15 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="UI\Layout\DockDragPreview.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Animation\PeriodicTimer.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Animation\TickClock.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Animation\Animation.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
Modifies:
- TUI.vcxproj
- TUI.vcxproj.filters

Adds:
- Animation/Animation.h/.cpp

Implemented the foundational Animation system. Added a reusable, renderer-independent animation state model capable of tracking playback time, normalized progress, playback state, and deterministic frame selection without directly rendering output.

Core playback model
- Duration tracking
- Elapsed time tracking
- Normalized progress calculation
- Ping-pong progress support
- Deterministic state progression

Playback state management
- Play
- Pause
- Resume
- Stop
- Finish
- Reset

Playback behavior modes
- Once
- Loop
- PingPong

Frame selection support
- Deterministic frame index calculation from animation state
- Explicit frame index override support
- Time-driven frame selection
- Frame clamping and wrapping helpers
- Stable frame output for identical animation state

Target abstraction
- Generic AnimationTarget structure
- Target property identification
- Custom property support
- Renderer-independent animation binding preparation

Tick integration
- TickEvent-based update support
- Delta-time update support
- Pause-aware update behavior

Architecture improvements
- Fully separated animation state from rendering/composition
- No Surface, ScreenBuffer, PageComposer, or XP-specific dependencies
- Generic enough for future:
  - XP sequence playback
  - interpreted page bindings
  - UI transitions
  - animated widgets
  - sprite/frame animation systems

Technical notes
- Added PlaybackState enum
- Added PlaybackMode enum
- Added TargetProperty enum
- Added FrameSelectionInput helper structure
- Added explicit frame override handling using std::optional
- Added deterministic progress/frame helper methods
- Added safe clamping and end-state handling utilities

This establishes the reusable animation-state foundation required for future animation playback, sequencing, interpolation, and UI polish systems.

Closes: #279 