### PR TITLE
Animator: Add a reusable Animator sequence playback controller

### DIFF
--- a/TUI/Animation/Animator.cpp
+++ b/TUI/Animation/Animator.cpp
@@ -1,0 +1,345 @@
+#include "Animation/Animator.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace Animation
+{
+    Animator::Animator()
+    {
+    }
+
+    Animator::Animator(std::size_t frameCount)
+        : m_frameCount(frameCount)
+    {
+    }
+
+    Animator::Animator(std::size_t frameCount, double framesPerSecond)
+        : m_frameCount(frameCount)
+        , m_framesPerSecond(clampPositiveOrZero(framesPerSecond))
+    {
+    }
+
+    void Animator::configure(std::size_t frameCount, double framesPerSecond)
+    {
+        m_frameCount = frameCount;
+        m_framesPerSecond = clampPositiveOrZero(framesPerSecond);
+        m_elapsedSeconds = std::min(m_elapsedSeconds, durationSeconds());
+        applyEndBehavior();
+    }
+
+    void Animator::setFrameCount(std::size_t frameCount)
+    {
+        m_frameCount = frameCount;
+
+        if (m_explicitFrameIndex.has_value())
+        {
+            m_explicitFrameIndex = clampFrameIndex(m_explicitFrameIndex.value(), m_frameCount);
+        }
+
+        m_elapsedSeconds = std::min(m_elapsedSeconds, durationSeconds());
+        applyEndBehavior();
+    }
+
+    std::size_t Animator::frameCount() const
+    {
+        return m_frameCount;
+    }
+
+    void Animator::setFramesPerSecond(double framesPerSecond)
+    {
+        m_framesPerSecond = clampPositiveOrZero(framesPerSecond);
+        m_elapsedSeconds = std::min(m_elapsedSeconds, durationSeconds());
+        applyEndBehavior();
+    }
+
+    double Animator::framesPerSecond() const
+    {
+        return m_framesPerSecond;
+    }
+
+    void Animator::setPlaybackRate(double playbackRate)
+    {
+        m_playbackRate = std::max(0.0, playbackRate);
+    }
+
+    double Animator::playbackRate() const
+    {
+        return m_playbackRate;
+    }
+
+    void Animator::setLooping(bool looping)
+    {
+        m_playbackMode = looping ? PlaybackMode::Loop : PlaybackMode::Once;
+        applyEndBehavior();
+    }
+
+    bool Animator::isLooping() const
+    {
+        return m_playbackMode == PlaybackMode::Loop;
+    }
+
+    void Animator::setPlaybackMode(PlaybackMode mode)
+    {
+        m_playbackMode = mode;
+        applyEndBehavior();
+    }
+
+    PlaybackMode Animator::playbackMode() const
+    {
+        return m_playbackMode;
+    }
+
+    void Animator::play()
+    {
+        if (m_playbackState == PlaybackState::Finished)
+        {
+            m_elapsedSeconds = 0.0;
+        }
+
+        m_playbackState = PlaybackState::Playing;
+        applyEndBehavior();
+    }
+
+    void Animator::pause()
+    {
+        if (m_playbackState == PlaybackState::Playing)
+        {
+            m_playbackState = PlaybackState::Paused;
+        }
+    }
+
+    void Animator::stop()
+    {
+        m_elapsedSeconds = 0.0;
+        m_playbackState = PlaybackState::Stopped;
+    }
+
+    void Animator::restart()
+    {
+        m_elapsedSeconds = 0.0;
+        m_playbackState = PlaybackState::Playing;
+        applyEndBehavior();
+    }
+
+    void Animator::update(double deltaSeconds)
+    {
+        if (m_playbackState != PlaybackState::Playing)
+        {
+            return;
+        }
+
+        const double safeDeltaSeconds = clampNonNegative(deltaSeconds);
+        if (safeDeltaSeconds <= 0.0 || m_playbackRate <= 0.0)
+        {
+            return;
+        }
+
+        m_elapsedSeconds += safeDeltaSeconds * m_playbackRate;
+        applyEndBehavior();
+    }
+
+    void Animator::update(const TickEvent& event)
+    {
+        if (event.paused)
+        {
+            return;
+        }
+
+        update(event.deltaSeconds);
+    }
+
+    PlaybackState Animator::playbackState() const
+    {
+        return m_playbackState;
+    }
+
+    bool Animator::isPlaying() const
+    {
+        return m_playbackState == PlaybackState::Playing;
+    }
+
+    bool Animator::isPaused() const
+    {
+        return m_playbackState == PlaybackState::Paused;
+    }
+
+    bool Animator::isStopped() const
+    {
+        return m_playbackState == PlaybackState::Stopped;
+    }
+
+    bool Animator::isFinished() const
+    {
+        return m_playbackState == PlaybackState::Finished;
+    }
+
+    void Animator::setElapsedSeconds(double seconds)
+    {
+        m_elapsedSeconds = clampNonNegative(seconds);
+        applyEndBehavior();
+    }
+
+    double Animator::elapsedSeconds() const
+    {
+        return m_elapsedSeconds;
+    }
+
+    double Animator::durationSeconds() const
+    {
+        if (m_frameCount == 0 || m_framesPerSecond <= 0.0)
+        {
+            return 0.0;
+        }
+
+        return static_cast<double>(m_frameCount) / m_framesPerSecond;
+    }
+
+    double Animator::progress() const
+    {
+        const double duration = durationSeconds();
+        if (duration <= 0.0)
+        {
+            return 0.0;
+        }
+
+        if (m_playbackMode == PlaybackMode::Loop)
+        {
+            return std::fmod(m_elapsedSeconds, duration) / duration;
+        }
+
+        return std::max(0.0, std::min(1.0, m_elapsedSeconds / duration));
+    }
+
+    void Animator::setCurrentFrameIndex(std::size_t frameIndex)
+    {
+        setExplicitFrameIndex(frameIndex);
+    }
+
+    void Animator::setExplicitFrameIndex(std::optional<std::size_t> frameIndex)
+    {
+        if (!frameIndex.has_value())
+        {
+            m_explicitFrameIndex.reset();
+            return;
+        }
+
+        m_explicitFrameIndex = clampFrameIndex(frameIndex.value(), m_frameCount);
+    }
+
+    void Animator::clearExplicitFrameIndex()
+    {
+        m_explicitFrameIndex.reset();
+    }
+
+    bool Animator::hasExplicitFrameIndex() const
+    {
+        return m_explicitFrameIndex.has_value();
+    }
+
+    std::optional<std::size_t> Animator::explicitFrameIndex() const
+    {
+        return m_explicitFrameIndex;
+    }
+
+    std::size_t Animator::currentFrameIndex() const
+    {
+        if (m_frameCount == 0)
+        {
+            return 0;
+        }
+
+        if (m_explicitFrameIndex.has_value())
+        {
+            return clampFrameIndex(m_explicitFrameIndex.value(), m_frameCount);
+        }
+
+        if (m_framesPerSecond <= 0.0)
+        {
+            return 0;
+        }
+
+        const double duration = durationSeconds();
+        if (duration <= 0.0)
+        {
+            return 0;
+        }
+
+        double effectiveElapsed = m_elapsedSeconds;
+
+        if (m_playbackMode == PlaybackMode::Loop)
+        {
+            effectiveElapsed = std::fmod(effectiveElapsed, duration);
+        }
+        else
+        {
+            effectiveElapsed = std::min(effectiveElapsed, duration);
+        }
+
+        std::size_t frameIndex =
+            static_cast<std::size_t>(std::floor(effectiveElapsed * m_framesPerSecond));
+
+        if (frameIndex >= m_frameCount)
+        {
+            frameIndex = m_frameCount - 1;
+        }
+
+        return frameIndex;
+    }
+
+    double Animator::clampNonNegative(double value)
+    {
+        return std::max(0.0, value);
+    }
+
+    double Animator::clampPositiveOrZero(double value)
+    {
+        return std::max(0.0, value);
+    }
+
+    std::size_t Animator::clampFrameIndex(std::size_t frameIndex, std::size_t frameCount)
+    {
+        if (frameCount == 0)
+        {
+            return 0;
+        }
+
+        return std::min(frameIndex, frameCount - 1);
+    }
+
+    void Animator::syncDuration()
+    {
+        m_elapsedSeconds = std::min(m_elapsedSeconds, durationSeconds());
+    }
+
+    void Animator::applyEndBehavior()
+    {
+        const double duration = durationSeconds();
+
+        if (duration <= 0.0 || m_frameCount == 0)
+        {
+            if (m_playbackState == PlaybackState::Playing)
+            {
+                m_playbackState = PlaybackState::Finished;
+            }
+
+            m_elapsedSeconds = 0.0;
+            return;
+        }
+
+        if (m_playbackMode == PlaybackMode::Loop)
+        {
+            return;
+        }
+
+        if (m_elapsedSeconds >= duration)
+        {
+            m_elapsedSeconds = duration;
+
+            if (m_playbackState == PlaybackState::Playing)
+            {
+                m_playbackState = PlaybackState::Finished;
+            }
+        }
+    }
+}

--- a/TUI/Animation/Animator.h
+++ b/TUI/Animation/Animator.h
@@ -1,0 +1,82 @@
+#pragma once
+
+#include <cstddef>
+#include <optional>
+
+#include "Animation/Animation.h"
+#include "Animation/TickEvent.h"
+
+namespace Animation
+{
+    class Animator
+    {
+    public:
+        Animator();
+        explicit Animator(std::size_t frameCount);
+        Animator(std::size_t frameCount, double framesPerSecond);
+
+        void configure(std::size_t frameCount, double framesPerSecond);
+        void setFrameCount(std::size_t frameCount);
+        std::size_t frameCount() const;
+
+        void setFramesPerSecond(double framesPerSecond);
+        double framesPerSecond() const;
+
+        void setPlaybackRate(double playbackRate);
+        double playbackRate() const;
+
+        void setLooping(bool looping);
+        bool isLooping() const;
+
+        void setPlaybackMode(PlaybackMode mode);
+        PlaybackMode playbackMode() const;
+
+        void play();
+        void pause();
+        void stop();
+        void restart();
+
+        void update(double deltaSeconds);
+        void update(const TickEvent& event);
+
+        PlaybackState playbackState() const;
+        bool isPlaying() const;
+        bool isPaused() const;
+        bool isStopped() const;
+        bool isFinished() const;
+
+        void setElapsedSeconds(double seconds);
+        double elapsedSeconds() const;
+
+        double durationSeconds() const;
+        double progress() const;
+
+        void setCurrentFrameIndex(std::size_t frameIndex);
+        void setExplicitFrameIndex(std::optional<std::size_t> frameIndex);
+        void clearExplicitFrameIndex();
+
+        bool hasExplicitFrameIndex() const;
+        std::optional<std::size_t> explicitFrameIndex() const;
+
+        std::size_t currentFrameIndex() const;
+
+    private:
+        static double clampNonNegative(double value);
+        static double clampPositiveOrZero(double value);
+        static std::size_t clampFrameIndex(std::size_t frameIndex, std::size_t frameCount);
+
+        void syncDuration();
+        void applyEndBehavior();
+
+    private:
+        std::size_t m_frameCount = 0;
+        double m_framesPerSecond = 0.0;
+        double m_playbackRate = 1.0;
+        double m_elapsedSeconds = 0.0;
+
+        PlaybackState m_playbackState = PlaybackState::Stopped;
+        PlaybackMode m_playbackMode = PlaybackMode::Once;
+
+        std::optional<std::size_t> m_explicitFrameIndex;
+    };
+}

--- a/TUI/TUI.vcxproj
+++ b/TUI/TUI.vcxproj
@@ -132,6 +132,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="Animation\Animation.h" />
+    <ClInclude Include="Animation\Animator.h" />
     <ClInclude Include="Animation\PeriodicTimer.h" />
     <ClInclude Include="Animation\TickClock.h" />
     <ClInclude Include="Animation\TickEvent.h" />
@@ -322,6 +323,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Animation\Animation.cpp" />
+    <ClCompile Include="Animation\Animator.cpp" />
     <ClCompile Include="Animation\PeriodicTimer.cpp" />
     <ClCompile Include="Animation\TickClock.cpp" />
     <ClCompile Include="App\Application.cpp" />


### PR DESCRIPTION
Modifies:
- TUI.vcxproj

Adds:
- Animation/Animator.h/.cpp

- Added Animation::Animator as a renderer-independent sequence playback controller for XP animations, text frame sequences, and future animation asset types.

Core playback functionality:
- Added play(), pause(), stop(), and restart() controls.
- Added playback state tracking using existing PlaybackState model.
- Added one-shot and looping playback modes.
- Added deterministic time-based frame selection.

Timing and frame mapping:
- Added frame-count and frames-per-second configuration.
- Added elapsed-time tracking and normalized progress support.
- Added playback rate scaling support.
- Added time-to-frame mapping logic.
- Added TickEvent integration overload for runtime updates.

Frame control:
- Added explicit frame index override support.
- Added currentFrameIndex() query API.
- Added ability to clear explicit frame overrides and resume time-driven playback.
- Added frame index clamping and safe handling of empty animations.

Runtime behavior:
- Non-looping animations automatically transition to Finished state.
- Looping animations wrap elapsed playback time cleanly.
- Stopped animations reset to frame 0.
- Restart resets elapsed playback and resumes playback immediately.

Architecture and design:
- Kept Animator asset-format agnostic and independent from rendering systems.
- Avoided XP-specific assumptions.
- Avoided direct ScreenBuffer/PageComposer mutation.
- Designed for polling-based recomposition where composers/interpreters query currentFrameIndex() during draw/update passes.

Closes: #280 