### PR TITLE
InvalidateRegion: Add renderer-independent invalidation region system

### DIFF
--- a/TUI/Rendering/InvalidationRegion.cpp
+++ b/TUI/Rendering/InvalidationRegion.cpp
@@ -1,0 +1,111 @@
+#include "Rendering/InvalidationRegion.h"
+
+#include <algorithm>
+
+namespace Rendering
+{
+    namespace
+    {
+        bool intersectsOrTouches(const Rect& a, const Rect& b)
+        {
+            return !(
+                a.position.x + a.size.width  < b.position.x ||
+                b.position.x + b.size.width  < a.position.x ||
+                a.position.y + a.size.height < b.position.y ||
+                b.position.y + b.size.height < a.position.y
+                );
+        }
+
+        Rect unionRect(const Rect& a, const Rect& b)
+        {
+            const int left   = std::min(a.position.x, b.position.x);
+            const int top    = std::min(a.position.y, b.position.y);
+            const int right  = std::max(a.position.x + a.size.width, b.position.x + b.size.width);
+            const int bottom = std::max(a.position.y + a.size.height, b.position.y + b.size.height);
+
+            return Rect{ Point{left,top}, Size{right - left, bottom - top} };
+        }
+
+        bool isValidRect(const Rect& rect)
+        {
+            return rect.size.width > 0 && rect.size.height > 0;
+        }
+    }
+
+    InvalidationRegion::InvalidationRegion()
+        : m_wholePageInvalidated(false)
+    {
+    }
+
+    void InvalidationRegion::invalidateAll()
+    {
+        m_wholePageInvalidated = true;
+        m_dirtyRegions.clear();
+    }
+
+    void InvalidationRegion::invalidateRect(const Rect& rect)
+    {
+        if (m_wholePageInvalidated)
+        {
+            return;
+        }
+
+        if (!isValidRect(rect))
+        {
+            return;
+        }
+
+        tryMergeRegion(rect);
+    }
+
+    void InvalidationRegion::clear()
+    {
+        m_wholePageInvalidated = false;
+        m_dirtyRegions.clear();
+    }
+
+    bool InvalidationRegion::isEmpty() const
+    {
+        return !m_wholePageInvalidated
+            && m_dirtyRegions.empty();
+    }
+
+    bool InvalidationRegion::isWholePageInvalidated() const
+    {
+        return m_wholePageInvalidated;
+    }
+
+    const std::vector<Rect>& InvalidationRegion::dirtyRegions() const
+    {
+        return m_dirtyRegions;
+    }
+
+    void InvalidationRegion::tryMergeRegion(const Rect& rect)
+    {
+        Rect mergedRect = rect;
+
+        bool merged = true;
+
+        while (merged)
+        {
+            merged = false;
+
+            for (auto it = m_dirtyRegions.begin();
+                it != m_dirtyRegions.end();)
+            {
+                if (intersectsOrTouches(*it, mergedRect))
+                {
+                    mergedRect = unionRect(*it, mergedRect);
+                    it = m_dirtyRegions.erase(it);
+                    merged = true;
+                }
+                else
+                {
+                    ++it;
+                }
+            }
+        }
+
+        m_dirtyRegions.push_back(mergedRect);
+    }
+}

--- a/TUI/Rendering/InvalidationRegion.h
+++ b/TUI/Rendering/InvalidationRegion.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <vector>
+
+#include "Core/Rect.h"
+
+namespace Rendering
+{
+    class InvalidationRegion
+    {
+    public:
+        InvalidationRegion();
+
+        // Invalidates the entire render target/page.
+        void invalidateAll();
+
+        // Invalidates a specific rectangular region.
+        void invalidateRect(const Rect& rect);
+
+        // Clears all invalidation state.
+        void clear();
+
+        // Returns true if no invalidation is pending.
+        bool isEmpty() const;
+
+        // Returns true if the entire page is invalidated.
+        bool isWholePageInvalidated() const;
+
+        // Access dirty regions.
+        const std::vector<Rect>& dirtyRegions() const;
+
+    private:
+        // Attempts simple safe region coalescing.
+        void tryMergeRegion(const Rect& rect);
+
+    private:
+        bool m_wholePageInvalidated;
+        std::vector<Rect> m_dirtyRegions;
+    };
+}

--- a/TUI/TUI.vcxproj
+++ b/TUI/TUI.vcxproj
@@ -198,6 +198,7 @@
     </ClInclude>
     <ClInclude Include="Rendering\Effects\IEffects.h" />
     <ClInclude Include="Rendering\FrameDiff.h" />
+    <ClInclude Include="Rendering\InvalidationRegion.h" />
     <ClInclude Include="Rendering\IRenderer.h" />
     <ClInclude Include="Rendering\LayerInstance.h" />
     <ClInclude Include="Rendering\Objects\AnsiLoader.h" />
@@ -366,6 +367,7 @@
     <ClCompile Include="Rendering\Diagnostics\RenderDiagnosticsWriter.cpp" />
     <ClCompile Include="Rendering\Diagnostics\RendererSelectionTrace.cpp" />
     <ClCompile Include="Rendering\FrameDiff.cpp" />
+    <ClCompile Include="Rendering\InvalidationRegion.cpp" />
     <ClCompile Include="Rendering\LayerInstance.cpp" />
     <ClCompile Include="Rendering\Objects\AnsiLoader.cpp" />
     <ClCompile Include="Rendering\Objects\AsciiBanner.cpp" />


### PR DESCRIPTION
Modifies:
- TUI.vcxproj

Adds:
- Rendering/InvalidationRegion.h/.cpp

Implemented the foundational invalidation tracking system for UI rendering optimization.

Added Rendering::InvalidationRegion to track dirty UI regions, support whole-page invalidation, and accumulate redraw requests from windows, widgets, panels, animations, and future composition systems without coupling invalidation to rendering behavior.

Features:
- Added invalidateRect() support for region-based invalidation
- Added invalidateAll() support for full-page redraw requests
- Added clear() and isEmpty() state management
- Added whole-page invalidation tracking flag
- Added dirty region collection storage
- Added safe region coalescing/merge behavior for overlapping or touching rects
- Added validation to reject zero/negative sized rects
- Kept system fully renderer-independent and animation-independent

Implementation details:
- Dirty regions are stored as Rect collections
- Overlapping/touching regions merge into unified redraw regions
- Whole-page invalidation clears region lists and overrides region-level invalidation
- Geometry helpers added for:
  - intersectsOrTouches()
  - unionRect()
  - isValidRect()

Architecture notes:
- Designed as retained-mode UI infrastructure for future partial redraw rendering
- Intended for integration with widgets, windows, hover effects, animations, docking previews, scrolling, and composition systems
- Prioritizes correctness and simplicity before advanced optimization
- Does not mutate render buffers or perform renderer-specific logic

Closes: #281 