### PR TITLE
AnimationBindingResolver: Add animation binding resolution for interp…

### DIFF
--- a/TUI/Animation/AnimationBindingResolver.cpp
+++ b/TUI/Animation/AnimationBindingResolver.cpp
@@ -1,0 +1,338 @@
+#include "Animation/AnimationBindingResolver.h"
+
+#include <algorithm>
+#include <limits>
+#include <utility>
+
+namespace Animation
+{
+    AnimationBindingTarget AnimationBindingTarget::sequenceAssetPlacement(
+        std::string_view targetNameValue,
+        std::string_view controllerNameValue,
+        std::string_view assetNameValue,
+        const Composition::PageComposer::PlacementSpec& placementValue,
+        const Composition::WritePolicy& policyValue)
+    {
+        AnimationBindingTarget target;
+        target.kind = AnimationBindingTargetKind::SequenceAssetPlacement;
+        target.targetName = std::string(targetNameValue);
+        target.controllerName = std::string(controllerNameValue);
+        target.assetName = std::string(assetNameValue);
+        target.placement = placementValue;
+        target.policy = policyValue;
+        return target;
+    }
+
+    AnimationBindingTarget AnimationBindingTarget::framePlaceholder(
+        std::string_view targetNameValue,
+        std::string_view controllerNameValue,
+        const std::vector<TextObject>& frames,
+        const Composition::PageComposer::PlacementSpec& placementValue,
+        const Composition::WritePolicy& policyValue)
+    {
+        AnimationBindingTarget target;
+        target.kind = AnimationBindingTargetKind::FramePlaceholder;
+        target.targetName = std::string(targetNameValue);
+        target.controllerName = std::string(controllerNameValue);
+        target.registeredFrames = &frames;
+        target.placement = placementValue;
+        target.policy = policyValue;
+        return target;
+    }
+
+    AnimationBindingTarget AnimationBindingTarget::animatedTextSequence(
+        std::string_view targetNameValue,
+        std::string_view controllerNameValue,
+        const AnimatedTextAssetSequence& sequence,
+        const Composition::PageComposer::PlacementSpec& placementValue,
+        const Composition::WritePolicy& policyValue)
+    {
+        AnimationBindingTarget target;
+        target.kind = AnimationBindingTargetKind::RegisteredFrameSequence;
+        target.targetName = std::string(targetNameValue);
+        target.controllerName = std::string(controllerNameValue);
+        target.textAssetSequence = &sequence;
+        target.placement = placementValue;
+        target.policy = policyValue;
+        return target;
+    }
+
+    AnimationBindingTarget AnimationBindingTarget::xpSequencePlacement(
+        std::string_view targetNameValue,
+        std::string_view controllerNameValue,
+        const XpArtLoader::XpSequence& sequence,
+        const Composition::PageComposer::PlacementSpec& placementValue,
+        const Composition::WritePolicy& policyValue,
+        const XpArtLoader::XpFrameConversionOptions& frameOptions)
+    {
+        AnimationBindingTarget target;
+        target.kind = AnimationBindingTargetKind::XpSequencePlacement;
+        target.targetName = std::string(targetNameValue);
+        target.controllerName = std::string(controllerNameValue);
+        target.xpSequence = &sequence;
+        target.xpFrameOptions = frameOptions;
+        target.placement = placementValue;
+        target.policy = policyValue;
+        return target;
+    }
+
+    void AnimationBindingResolver::clear()
+    {
+        m_controllers.clear();
+        m_targets.clear();
+    }
+
+    void AnimationBindingResolver::bindController(
+        std::string_view name,
+        Animator& animator)
+    {
+        if (name.empty())
+        {
+            return;
+        }
+
+        m_controllers[std::string(name)] = &animator;
+    }
+
+    void AnimationBindingResolver::unbindController(std::string_view name)
+    {
+        m_controllers.erase(std::string(name));
+    }
+
+    bool AnimationBindingResolver::hasController(std::string_view name) const
+    {
+        return tryGetController(name) != nullptr;
+    }
+
+    Animator* AnimationBindingResolver::tryGetController(std::string_view name)
+    {
+        const auto found = m_controllers.find(std::string(name));
+        return found != m_controllers.end() ? found->second : nullptr;
+    }
+
+    const Animator* AnimationBindingResolver::tryGetController(
+        std::string_view name) const
+    {
+        const auto found = m_controllers.find(std::string(name));
+        return found != m_controllers.end() ? found->second : nullptr;
+    }
+
+    void AnimationBindingResolver::setTargets(
+        const std::vector<AnimationBindingTarget>& targetsValue)
+    {
+        m_targets = targetsValue;
+    }
+
+    void AnimationBindingResolver::addTarget(
+        const AnimationBindingTarget& target)
+    {
+        if (target.targetName.empty() || target.controllerName.empty())
+        {
+            return;
+        }
+
+        m_targets.push_back(target);
+    }
+
+    void AnimationBindingResolver::clearTargets()
+    {
+        m_targets.clear();
+    }
+
+    const std::vector<AnimationBindingTarget>&
+        AnimationBindingResolver::targets() const
+    {
+        return m_targets;
+    }
+
+    std::vector<AnimationBindingResolutionResult>
+        AnimationBindingResolver::resolveAll(
+            Composition::PageComposer& composer) const
+    {
+        std::vector<AnimationBindingResolutionResult> results;
+        results.reserve(m_targets.size());
+
+        for (const AnimationBindingTarget& target : m_targets)
+        {
+            results.push_back(resolveTarget(composer, target));
+        }
+
+        return results;
+    }
+
+    AnimationBindingResolutionResult AnimationBindingResolver::resolveTarget(
+        Composition::PageComposer& composer,
+        const AnimationBindingTarget& target) const
+    {
+        if (target.targetName.empty())
+        {
+            return makeSkippedResult(target, "Animation target name is empty.");
+        }
+
+        if (target.controllerName.empty())
+        {
+            return makeSkippedResult(
+                target,
+                "Animation target has no controller reference.");
+        }
+
+        const Animator* animator = tryGetController(target.controllerName);
+        if (animator == nullptr)
+        {
+            return makeSkippedResult(
+                target,
+                "Animation controller reference could not be resolved.");
+        }
+
+        return placeResolvedFrame(composer, target, *animator);
+    }
+
+    bool AnimationBindingResolver::isValidFrameIndex(
+        std::size_t frameIndex,
+        std::size_t frameCount)
+    {
+        return frameCount > 0 && frameIndex < frameCount;
+    }
+
+    int AnimationBindingResolver::toPlacementFrameIndex(std::size_t frameIndex)
+    {
+        if (frameIndex > static_cast<std::size_t>(std::numeric_limits<int>::max()))
+        {
+            return std::numeric_limits<int>::max();
+        }
+
+        return static_cast<int>(frameIndex);
+    }
+
+    AnimationBindingResolutionResult
+        AnimationBindingResolver::makeSkippedResult(
+            const AnimationBindingTarget& target,
+            std::string message)
+    {
+        AnimationBindingResolutionResult result;
+        result.targetName = target.targetName;
+        result.controllerName = target.controllerName;
+        result.resolved = false;
+        result.placed = false;
+        result.message = std::move(message);
+        return result;
+    }
+
+    AnimationBindingResolutionResult
+        AnimationBindingResolver::placeResolvedFrame(
+            Composition::PageComposer& composer,
+            const AnimationBindingTarget& target,
+            const Animator& animator) const
+    {
+        AnimationBindingResolutionResult result;
+        result.targetName = target.targetName;
+        result.controllerName = target.controllerName;
+        result.resolved = true;
+
+        const std::size_t frameIndex = animator.currentFrameIndex();
+        result.frameIndex = frameIndex;
+
+        switch (target.kind)
+        {
+        case AnimationBindingTargetKind::SequenceAssetPlacement:
+            if (target.assetName.empty())
+            {
+                result.message = "Sequence asset placement has no asset name.";
+                return result;
+            }
+
+            composer.placeSource(
+                Composition::ObjectSource::fromAssetFrame(
+                    target.assetName,
+                    toPlacementFrameIndex(frameIndex)),
+                target.placement,
+                target.policy);
+
+            result.placed = true;
+            result.message = "Placed sequence asset frame.";
+            return result;
+
+        case AnimationBindingTargetKind::FramePlaceholder:
+            if (target.registeredFrames == nullptr)
+            {
+                result.message = "Frame placeholder has no registered frame list.";
+                return result;
+            }
+
+            if (!isValidFrameIndex(frameIndex, target.registeredFrames->size()))
+            {
+                result.message = "Frame placeholder resolved frame is out of range.";
+                return result;
+            }
+
+            composer.placeSource(
+                Composition::ObjectSource::fromRegisteredFrame(
+                    *target.registeredFrames,
+                    toPlacementFrameIndex(frameIndex)),
+                target.placement,
+                target.policy);
+
+            result.placed = true;
+            result.message = "Placed registered frame placeholder.";
+            return result;
+
+        case AnimationBindingTargetKind::RegisteredFrameSequence:
+            if (target.textAssetSequence == nullptr)
+            {
+                result.message = "Animated text sequence target has no sequence.";
+                return result;
+            }
+
+            if (!isValidFrameIndex(frameIndex, target.textAssetSequence->frameCount()))
+            {
+                result.message = "Animated text sequence frame is out of range.";
+                return result;
+            }
+            else
+            {
+                const AnimatedTextAssetFrameBuildResult frameResult =
+                    target.textAssetSequence->buildTextObjectForFrame(frameIndex);
+
+                if (!frameResult.success || !frameResult.hasObject())
+                {
+                    result.message = frameResult.errorMessage.empty()
+                        ? "Animated text sequence did not produce a loaded frame."
+                        : frameResult.errorMessage;
+                    return result;
+                }
+
+                composer.placeSource(
+                    Composition::ObjectSource::fromTextObject(frameResult.object),
+                    target.placement,
+                    target.policy);
+
+                result.placed = true;
+                result.message = "Placed animated text sequence frame.";
+                return result;
+            }
+
+        case AnimationBindingTargetKind::XpSequencePlacement:
+            if (target.xpSequence == nullptr || !target.xpSequence->isValid())
+            {
+                result.message = "XP sequence placement has no valid XP sequence.";
+                return result;
+            }
+
+            composer.placeSource(
+                Composition::ObjectSource::fromXpSequence(
+                    *target.xpSequence,
+                    toPlacementFrameIndex(frameIndex),
+                    target.xpFrameOptions),
+                target.placement,
+                target.policy);
+
+            result.placed = true;
+            result.message = "Placed XP sequence frame.";
+            return result;
+
+        default:
+            result.message = "Unknown animation binding target kind.";
+            return result;
+        }
+    }
+}

--- a/TUI/Animation/AnimationBindingResolver.h
+++ b/TUI/Animation/AnimationBindingResolver.h
@@ -1,0 +1,142 @@
+#pragma once
+
+#include <cstddef>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+#include "Animation/AnimatedTextAssetSequence.h"
+#include "Animation/Animator.h"
+#include "Rendering/Composition/ObjectSource.h"
+#include "Rendering/Composition/PageComposer.h"
+#include "Rendering/Composition/WritePolicy.h"
+#include "Rendering/Composition/WritePresets.h"
+#include "Rendering/Objects/TextObject.h"
+#include "Rendering/Objects/XpArtLoader.h"
+
+namespace Animation
+{
+    enum class AnimationBindingTargetKind
+    {
+        SequenceAssetPlacement,
+        FramePlaceholder,
+        RegisteredFrameSequence,
+        XpSequencePlacement
+    };
+
+    struct AnimationBindingTarget
+    {
+        std::string targetName;
+        std::string controllerName;
+
+        AnimationBindingTargetKind kind =
+            AnimationBindingTargetKind::SequenceAssetPlacement;
+
+        Composition::PageComposer::PlacementSpec placement =
+            Composition::PageComposer::PlacementSpec::at(0, 0);
+
+        Composition::WritePolicy policy =
+            Composition::WritePresets::authoredObject();
+
+        std::string assetName;
+
+        const std::vector<TextObject>* registeredFrames = nullptr;
+        const AnimatedTextAssetSequence* textAssetSequence = nullptr;
+        const XpArtLoader::XpSequence* xpSequence = nullptr;
+
+        XpArtLoader::XpFrameConversionOptions xpFrameOptions;
+
+        static AnimationBindingTarget sequenceAssetPlacement(
+            std::string_view targetName,
+            std::string_view controllerName,
+            std::string_view assetName,
+            const Composition::PageComposer::PlacementSpec& placement,
+            const Composition::WritePolicy& policy =
+            Composition::WritePresets::authoredObject());
+
+        static AnimationBindingTarget framePlaceholder(
+            std::string_view targetName,
+            std::string_view controllerName,
+            const std::vector<TextObject>& frames,
+            const Composition::PageComposer::PlacementSpec& placement,
+            const Composition::WritePolicy& policy =
+            Composition::WritePresets::authoredObject());
+
+        static AnimationBindingTarget animatedTextSequence(
+            std::string_view targetName,
+            std::string_view controllerName,
+            const AnimatedTextAssetSequence& sequence,
+            const Composition::PageComposer::PlacementSpec& placement,
+            const Composition::WritePolicy& policy =
+            Composition::WritePresets::authoredObject());
+
+        static AnimationBindingTarget xpSequencePlacement(
+            std::string_view targetName,
+            std::string_view controllerName,
+            const XpArtLoader::XpSequence& sequence,
+            const Composition::PageComposer::PlacementSpec& placement,
+            const Composition::WritePolicy& policy =
+            Composition::WritePresets::authoredObject(),
+            const XpArtLoader::XpFrameConversionOptions& frameOptions = {});
+    };
+
+    struct AnimationBindingResolutionResult
+    {
+        std::string targetName;
+        std::string controllerName;
+
+        bool resolved = false;
+        bool placed = false;
+
+        std::optional<std::size_t> frameIndex;
+        std::string message;
+    };
+
+    class AnimationBindingResolver
+    {
+    public:
+        void clear();
+
+        void bindController(std::string_view name, Animator& animator);
+        void unbindController(std::string_view name);
+
+        bool hasController(std::string_view name) const;
+        Animator* tryGetController(std::string_view name);
+        const Animator* tryGetController(std::string_view name) const;
+
+        void setTargets(const std::vector<AnimationBindingTarget>& targets);
+        void addTarget(const AnimationBindingTarget& target);
+        void clearTargets();
+
+        const std::vector<AnimationBindingTarget>& targets() const;
+
+        std::vector<AnimationBindingResolutionResult> resolveAll(
+            Composition::PageComposer& composer) const;
+
+        AnimationBindingResolutionResult resolveTarget(
+            Composition::PageComposer& composer,
+            const AnimationBindingTarget& target) const;
+
+    private:
+        static bool isValidFrameIndex(
+            std::size_t frameIndex,
+            std::size_t frameCount);
+
+        static int toPlacementFrameIndex(std::size_t frameIndex);
+
+        static AnimationBindingResolutionResult makeSkippedResult(
+            const AnimationBindingTarget& target,
+            std::string message);
+
+        AnimationBindingResolutionResult placeResolvedFrame(
+            Composition::PageComposer& composer,
+            const AnimationBindingTarget& target,
+            const Animator& animator) const;
+
+    private:
+        std::unordered_map<std::string, Animator*> m_controllers;
+        std::vector<AnimationBindingTarget> m_targets;
+    };
+}

--- a/TUI/TUI.vcxproj
+++ b/TUI/TUI.vcxproj
@@ -133,6 +133,7 @@
   <ItemGroup>
     <ClInclude Include="Animation\AnimatedTextAssetSequence.h" />
     <ClInclude Include="Animation\Animation.h" />
+    <ClInclude Include="Animation\AnimationBindingResolver.h" />
     <ClInclude Include="Animation\Animator.h" />
     <ClInclude Include="Animation\PeriodicTimer.h" />
     <ClInclude Include="Animation\TickClock.h" />
@@ -335,6 +336,7 @@
   <ItemGroup>
     <ClCompile Include="Animation\AnimatedTextAssetSequence.cpp" />
     <ClCompile Include="Animation\Animation.cpp" />
+    <ClCompile Include="Animation\AnimationBindingResolver.cpp" />
     <ClCompile Include="Animation\Animator.cpp" />
     <ClCompile Include="Animation\PeriodicTimer.cpp" />
     <ClCompile Include="Animation\TickClock.cpp" />

--- a/TUI/TUI.vcxproj.filters
+++ b/TUI/TUI.vcxproj.filters
@@ -555,6 +555,9 @@
     <ClInclude Include="UI\Panels\ContentWindow.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="Animation\AnimationBindingResolver.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Rendering\ScreenBuffer.cpp">
@@ -1029,6 +1032,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="UI\Panels\ContentWindow.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Animation\AnimationBindingResolver.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
…reted pages

Modifies:
- TUI.vcxproj
- TUI.vcxproj.filters

Adds:
- Animation/AnimationBindingResolver.h/.cpp

Implemented runtime animation binding support for interpreted pages while preserving the declarative page model and existing PageComposer pipeline.

Added AnimationBindingResolver to connect named Animator controllers to script-declared animation targets without embedding playback state into interpreted page data structures.

Key features:
- Bind named Animator instances by runtime controller name
- Resolve declarative animation target references
- Map Animator::currentFrameIndex() into frame-aware placement calls
- Support sequence asset frame placement
- Support registered TextObject frame placeholders
- Support AnimatedTextAssetSequence playback bindings
- Support XP-backed animated sequence placement
- Route all animated placement through PageComposer::placeSource(...)
- Preserve renderer-independent animation architecture
- Keep interpreter/page AST semantics unchanged
- Keep playback state fully external to interpreted page definitions

Closes: #127 
Closes: #283 