### PR TITLE
AnimationDrivenRecompositionLoop: Add animation-driven interpreted pa…

### DIFF
--- a/TUI/Animation/AnimationBindingResolver.cpp
+++ b/TUI/Animation/AnimationBindingResolver.cpp
@@ -187,6 +187,60 @@ namespace Animation
         return placeResolvedFrame(composer, target, *animator);
     }
 
+    void AnimationBindingResolver::updateBoundControllers(const TickEvent& event)
+    {
+        std::vector<Animator*> updatedControllers;
+        updatedControllers.reserve(m_controllers.size());
+
+        for (const auto& entry : m_controllers)
+        {
+            Animator* animator = entry.second;
+            if (animator == nullptr)
+            {
+                continue;
+            }
+
+            const bool alreadyUpdated =
+                std::find(
+                    updatedControllers.begin(),
+                    updatedControllers.end(),
+                    animator) != updatedControllers.end();
+
+            if (alreadyUpdated)
+            {
+                continue;
+            }
+
+            animator->update(event);
+            updatedControllers.push_back(animator);
+        }
+    }
+
+    std::vector<AnimationBindingFrameState>
+        AnimationBindingResolver::captureFrameState() const
+    {
+        std::vector<AnimationBindingFrameState> states;
+        states.reserve(m_targets.size());
+
+        for (const AnimationBindingTarget& target : m_targets)
+        {
+            AnimationBindingFrameState state;
+            state.targetName = target.targetName;
+            state.controllerName = target.controllerName;
+
+            const Animator* animator = tryGetController(target.controllerName);
+            if (animator != nullptr)
+            {
+                state.resolved = true;
+                state.frameIndex = animator->currentFrameIndex();
+            }
+
+            states.push_back(state);
+        }
+
+        return states;
+    }
+
     bool AnimationBindingResolver::isValidFrameIndex(
         std::size_t frameIndex,
         std::size_t frameCount)

--- a/TUI/Animation/AnimationBindingResolver.h
+++ b/TUI/Animation/AnimationBindingResolver.h
@@ -9,6 +9,7 @@
 
 #include "Animation/AnimatedTextAssetSequence.h"
 #include "Animation/Animator.h"
+#include "Animation/TickEvent.h"
 #include "Rendering/Composition/ObjectSource.h"
 #include "Rendering/Composition/PageComposer.h"
 #include "Rendering/Composition/WritePolicy.h"
@@ -94,6 +95,27 @@ namespace Animation
         std::string message;
     };
 
+    struct AnimationBindingFrameState
+    {
+        std::string targetName;
+        std::string controllerName;
+        bool resolved = false;
+        std::optional<std::size_t> frameIndex;
+
+        bool operator==(const AnimationBindingFrameState& other) const
+        {
+            return targetName == other.targetName
+                && controllerName == other.controllerName
+                && resolved == other.resolved
+                && frameIndex == other.frameIndex;
+        }
+
+        bool operator!=(const AnimationBindingFrameState& other) const
+        {
+            return !(*this == other);
+        }
+    };
+
     class AnimationBindingResolver
     {
     public:
@@ -118,6 +140,10 @@ namespace Animation
         AnimationBindingResolutionResult resolveTarget(
             Composition::PageComposer& composer,
             const AnimationBindingTarget& target) const;
+
+        void updateBoundControllers(const TickEvent& event);
+
+        std::vector<AnimationBindingFrameState> captureFrameState() const;
 
     private:
         static bool isValidFrameIndex(

--- a/TUI/Animation/AnimationDrivenRecompositionLoop.cpp
+++ b/TUI/Animation/AnimationDrivenRecompositionLoop.cpp
@@ -1,0 +1,158 @@
+#include "Animation/AnimationDrivenRecompositionLoop.h"
+
+#include <utility>
+
+namespace Animation
+{
+    void AnimationDrivenRecompositionLoop::setComposePageCallback(
+        ComposePageCallback callback)
+    {
+        m_composePage = std::move(callback);
+        requestRecompose();
+    }
+
+    void AnimationDrivenRecompositionLoop::clearComposePageCallback()
+    {
+        m_composePage = nullptr;
+        requestRecompose();
+    }
+
+    void AnimationDrivenRecompositionLoop::setBindingResolver(
+        AnimationBindingResolver* resolver)
+    {
+        m_bindingResolver = resolver;
+        resetFrameTracking();
+        requestRecompose();
+    }
+
+    void AnimationDrivenRecompositionLoop::clearBindingResolver()
+    {
+        m_bindingResolver = nullptr;
+        resetFrameTracking();
+        requestRecompose();
+    }
+
+    void AnimationDrivenRecompositionLoop::setInvalidationRegion(
+        Rendering::InvalidationRegion* invalidation)
+    {
+        m_invalidation = invalidation;
+    }
+
+    void AnimationDrivenRecompositionLoop::clearInvalidationRegion()
+    {
+        m_invalidation = nullptr;
+    }
+
+    void AnimationDrivenRecompositionLoop::setClearStyle(const Style& style)
+    {
+        m_clearStyle = style;
+        requestRecompose();
+    }
+
+    void AnimationDrivenRecompositionLoop::requestRecompose()
+    {
+        m_forceRecompose = true;
+    }
+
+    void AnimationDrivenRecompositionLoop::resetFrameTracking()
+    {
+        m_lastFrameState.clear();
+    }
+
+    AnimationDrivenRecompositionLoop::Result
+        AnimationDrivenRecompositionLoop::updateAndRecomposeIfNeeded(
+            ScreenBuffer& buffer,
+            const TickEvent& event)
+    {
+        if (m_bindingResolver != nullptr)
+        {
+            m_bindingResolver->updateBoundControllers(event);
+        }
+
+        const std::vector<AnimationBindingFrameState> currentFrameState =
+            m_bindingResolver != nullptr
+            ? m_bindingResolver->captureFrameState()
+            : std::vector<AnimationBindingFrameState>{};
+
+        const bool frameStateChanged = shouldRecompose(currentFrameState);
+
+        if (!m_forceRecompose && !frameStateChanged)
+        {
+            Result result;
+            result.frameStateChanged = false;
+            result.forced = false;
+            result.recomposed = false;
+            return result;
+        }
+
+        m_lastFrameState = currentFrameState;
+
+        return composeIntoBuffer(
+            buffer,
+            m_forceRecompose,
+            frameStateChanged);
+    }
+
+    AnimationDrivenRecompositionLoop::Result
+        AnimationDrivenRecompositionLoop::recomposeNow(ScreenBuffer& buffer)
+    {
+        const std::vector<AnimationBindingFrameState> currentFrameState =
+            m_bindingResolver != nullptr
+            ? m_bindingResolver->captureFrameState()
+            : std::vector<AnimationBindingFrameState>{};
+
+        m_lastFrameState = currentFrameState;
+
+        return composeIntoBuffer(
+            buffer,
+            true,
+            true);
+    }
+
+    AnimationDrivenRecompositionLoop::Result
+        AnimationDrivenRecompositionLoop::composeIntoBuffer(
+            ScreenBuffer& buffer,
+            bool forced,
+            bool frameStateChanged)
+    {
+        Result result;
+        result.recomposed = true;
+        result.forced = forced;
+        result.frameStateChanged = frameStateChanged;
+
+        Composition::PageComposer composer(buffer);
+        composer.clear(m_clearStyle);
+
+        if (m_composePage)
+        {
+            m_composePage(composer);
+        }
+
+        if (m_bindingResolver != nullptr)
+        {
+            result.bindingResults = m_bindingResolver->resolveAll(composer);
+        }
+
+        result.deterministicSignature =
+            composer.computeDeterministicSignature();
+
+        if (m_invalidation != nullptr)
+        {
+            m_invalidation->invalidateAll();
+        }
+
+        m_forceRecompose = false;
+        return result;
+    }
+
+    bool AnimationDrivenRecompositionLoop::shouldRecompose(
+        const std::vector<AnimationBindingFrameState>& currentFrameState) const
+    {
+        if (m_forceRecompose)
+        {
+            return true;
+        }
+
+        return currentFrameState != m_lastFrameState;
+    }
+}

--- a/TUI/Animation/AnimationDrivenRecompositionLoop.h
+++ b/TUI/Animation/AnimationDrivenRecompositionLoop.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <vector>
+
+#include "Animation/AnimationBindingResolver.h"
+#include "Animation/TickEvent.h"
+#include "Rendering/Composition/PageComposer.h"
+#include "Rendering/InvalidationRegion.h"
+#include "Rendering/ScreenBuffer.h"
+#include "Rendering/Styles/Style.h"
+
+namespace Animation
+{
+    class AnimationDrivenRecompositionLoop
+    {
+    public:
+        using ComposePageCallback =
+            std::function<void(Composition::PageComposer& composer)>;
+
+        struct Result
+        {
+            bool recomposed = false;
+            bool frameStateChanged = false;
+            bool forced = false;
+            std::uint64_t deterministicSignature = 0;
+            std::vector<AnimationBindingResolutionResult> bindingResults;
+        };
+
+        void setComposePageCallback(ComposePageCallback callback);
+        void clearComposePageCallback();
+
+        void setBindingResolver(AnimationBindingResolver* resolver);
+        void clearBindingResolver();
+
+        void setInvalidationRegion(Rendering::InvalidationRegion* invalidation);
+        void clearInvalidationRegion();
+
+        void setClearStyle(const Style& style);
+        void requestRecompose();
+        void resetFrameTracking();
+
+        Result updateAndRecomposeIfNeeded(
+            ScreenBuffer& buffer,
+            const TickEvent& event);
+
+        Result recomposeNow(ScreenBuffer& buffer);
+
+    private:
+        Result composeIntoBuffer(
+            ScreenBuffer& buffer,
+            bool forced,
+            bool frameStateChanged);
+
+        bool shouldRecompose(
+            const std::vector<AnimationBindingFrameState>& currentFrameState) const;
+
+    private:
+        ComposePageCallback m_composePage;
+        AnimationBindingResolver* m_bindingResolver = nullptr;
+        Rendering::InvalidationRegion* m_invalidation = nullptr;
+
+        Style m_clearStyle;
+        bool m_forceRecompose = true;
+
+        std::vector<AnimationBindingFrameState> m_lastFrameState;
+    };
+}

--- a/TUI/TUI.vcxproj
+++ b/TUI/TUI.vcxproj
@@ -134,6 +134,7 @@
     <ClInclude Include="Animation\AnimatedTextAssetSequence.h" />
     <ClInclude Include="Animation\Animation.h" />
     <ClInclude Include="Animation\AnimationBindingResolver.h" />
+    <ClInclude Include="Animation\AnimationDrivenRecompositionLoop.h" />
     <ClInclude Include="Animation\Animator.h" />
     <ClInclude Include="Animation\PeriodicTimer.h" />
     <ClInclude Include="Animation\TickClock.h" />
@@ -337,6 +338,7 @@
     <ClCompile Include="Animation\AnimatedTextAssetSequence.cpp" />
     <ClCompile Include="Animation\Animation.cpp" />
     <ClCompile Include="Animation\AnimationBindingResolver.cpp" />
+    <ClCompile Include="Animation\AnimationDrivenRecompositionLoop.cpp" />
     <ClCompile Include="Animation\Animator.cpp" />
     <ClCompile Include="Animation\PeriodicTimer.cpp" />
     <ClCompile Include="Animation\TickClock.cpp" />


### PR DESCRIPTION
…ge recomposition loop

Modifies:
- TUI.vcxproj
- Animation/Animation/AnimationBindingResolver.h/.cpp

Adds:
- Animation/DrivenRecompositionLoop.h/.cpp

- Coordinate animation updates and page recomposition
- Added automatic animation controller ticking through TickEvent integration
- Added frame-state snapshot tracking for deterministic animation change detection
- Triggered interpreted page recomposition only when visible animation frame selection changes
- Added invalidateAll() integration for animation-driven redraw requests
- Prevented duplicate Animator updates when multiple targets share the same controller
- Avoided renderer-side animation and direct composed-buffer mutation

Closes: #284 