### PR TITLE
Playback Invalidation: Integrate animation playback with invalidation…

### DIFF
--- a/TUI/Animation/AnimationBindingResolver.cpp
+++ b/TUI/Animation/AnimationBindingResolver.cpp
@@ -307,6 +307,7 @@ namespace Animation
             return result;
 
         case AnimationBindingTargetKind::FramePlaceholder:
+        {
             if (target.registeredFrames == nullptr)
             {
                 result.message = "Frame placeholder has no registered frame list.";
@@ -319,6 +320,12 @@ namespace Animation
                 return result;
             }
 
+            const TextObject& frame = (*target.registeredFrames)[frameIndex];
+
+            result.placementBounds = composer.resolvePlacementBounds(
+                target.placement,
+                Size{ frame.getWidth(), frame.getHeight() });
+
             composer.placeSource(
                 Composition::ObjectSource::fromRegisteredFrame(
                     *target.registeredFrames,
@@ -329,8 +336,10 @@ namespace Animation
             result.placed = true;
             result.message = "Placed registered frame placeholder.";
             return result;
+        }
 
         case AnimationBindingTargetKind::RegisteredFrameSequence:
+        {
             if (target.textAssetSequence == nullptr)
             {
                 result.message = "Animated text sequence target has no sequence.";
@@ -342,28 +351,31 @@ namespace Animation
                 result.message = "Animated text sequence frame is out of range.";
                 return result;
             }
-            else
+
+            const AnimatedTextAssetFrameBuildResult frameResult =
+                target.textAssetSequence->buildTextObjectForFrame(frameIndex);
+
+            if (!frameResult.success || !frameResult.hasObject())
             {
-                const AnimatedTextAssetFrameBuildResult frameResult =
-                    target.textAssetSequence->buildTextObjectForFrame(frameIndex);
-
-                if (!frameResult.success || !frameResult.hasObject())
-                {
-                    result.message = frameResult.errorMessage.empty()
-                        ? "Animated text sequence did not produce a loaded frame."
-                        : frameResult.errorMessage;
-                    return result;
-                }
-
-                composer.placeSource(
-                    Composition::ObjectSource::fromTextObject(frameResult.object),
-                    target.placement,
-                    target.policy);
-
-                result.placed = true;
-                result.message = "Placed animated text sequence frame.";
+                result.message = frameResult.errorMessage.empty()
+                    ? "Animated text sequence did not produce a loaded frame."
+                    : frameResult.errorMessage;
                 return result;
             }
+
+            result.placementBounds = composer.resolvePlacementBounds(
+                target.placement,
+                Size{ frameResult.object.getWidth(), frameResult.object.getHeight() });
+
+            composer.placeSource(
+                Composition::ObjectSource::fromTextObject(frameResult.object),
+                target.placement,
+                target.policy);
+
+            result.placed = true;
+            result.message = "Placed animated text sequence frame.";
+            return result;
+        }
 
         case AnimationBindingTargetKind::XpSequencePlacement:
             if (target.xpSequence == nullptr || !target.xpSequence->isValid())

--- a/TUI/Animation/AnimationBindingResolver.h
+++ b/TUI/Animation/AnimationBindingResolver.h
@@ -92,6 +92,7 @@ namespace Animation
         bool placed = false;
 
         std::optional<std::size_t> frameIndex;
+        std::optional<Rect> placementBounds;
         std::string message;
     };
 

--- a/TUI/Animation/AnimationDrivenRecompositionLoop.cpp
+++ b/TUI/Animation/AnimationDrivenRecompositionLoop.cpp
@@ -1,5 +1,6 @@
 #include "Animation/AnimationDrivenRecompositionLoop.h"
 
+#include <algorithm>
 #include <utility>
 
 namespace Animation
@@ -57,6 +58,7 @@ namespace Animation
     void AnimationDrivenRecompositionLoop::resetFrameTracking()
     {
         m_lastFrameState.clear();
+        m_lastKnownBindingBounds.clear();
     }
 
     AnimationDrivenRecompositionLoop::Result
@@ -85,12 +87,14 @@ namespace Animation
             return result;
         }
 
-        m_lastFrameState = currentFrameState;
-
-        return composeIntoBuffer(
+        Result result = composeIntoBuffer(
             buffer,
             m_forceRecompose,
             frameStateChanged);
+
+        applyInvalidation(result, currentFrameState);
+        m_lastFrameState = currentFrameState;
+        return result;
     }
 
     AnimationDrivenRecompositionLoop::Result
@@ -101,12 +105,14 @@ namespace Animation
             ? m_bindingResolver->captureFrameState()
             : std::vector<AnimationBindingFrameState>{};
 
-        m_lastFrameState = currentFrameState;
-
-        return composeIntoBuffer(
+        Result result = composeIntoBuffer(
             buffer,
             true,
             true);
+
+        applyInvalidation(result, currentFrameState);
+        m_lastFrameState = currentFrameState;
+        return result;
     }
 
     AnimationDrivenRecompositionLoop::Result
@@ -136,13 +142,107 @@ namespace Animation
         result.deterministicSignature =
             composer.computeDeterministicSignature();
 
-        if (m_invalidation != nullptr)
-        {
-            m_invalidation->invalidateAll();
-        }
-
         m_forceRecompose = false;
         return result;
+    }
+
+    void AnimationDrivenRecompositionLoop::applyInvalidation(
+        Result& result,
+        const std::vector<AnimationBindingFrameState>& currentFrameState)
+    {
+        if (m_invalidation == nullptr || !result.recomposed)
+        {
+            return;
+        }
+
+        if (result.forced)
+        {
+            m_invalidation->invalidateAll();
+            result.invalidated = true;
+            result.wholePageInvalidated = true;
+            result.dirtyRegionCount = 0;
+
+            m_lastKnownBindingBounds.clear();
+            for (const AnimationBindingResolutionResult& bindingResult : result.bindingResults)
+            {
+                if (bindingResult.placementBounds.has_value())
+                {
+                    m_lastKnownBindingBounds[makeBindingKey(
+                        bindingResult.targetName,
+                        bindingResult.controllerName)] = *bindingResult.placementBounds;
+                }
+            }
+            return;
+        }
+
+        if (!result.frameStateChanged)
+        {
+            return;
+        }
+
+        std::unordered_map<std::string, Rect> nextKnownBounds;
+        nextKnownBounds.reserve(result.bindingResults.size());
+
+        for (const AnimationBindingResolutionResult& bindingResult : result.bindingResults)
+        {
+            const std::string key = makeBindingKey(
+                bindingResult.targetName,
+                bindingResult.controllerName);
+
+            const auto oldBounds = m_lastKnownBindingBounds.find(key);
+            const bool hadOldBounds = oldBounds != m_lastKnownBindingBounds.end();
+
+            if (bindingResult.placementBounds.has_value())
+            {
+                m_invalidation->invalidateRect(*bindingResult.placementBounds);
+                nextKnownBounds[key] = *bindingResult.placementBounds;
+            }
+
+            if (hadOldBounds)
+            {
+                m_invalidation->invalidateRect(oldBounds->second);
+            }
+
+            if (!bindingResult.placementBounds.has_value() && !hadOldBounds)
+            {
+                m_invalidation->invalidateAll();
+                result.invalidated = true;
+                result.wholePageInvalidated = true;
+                result.dirtyRegionCount = 0;
+                m_lastKnownBindingBounds = std::move(nextKnownBounds);
+                return;
+            }
+        }
+
+        for (const auto& oldEntry : m_lastKnownBindingBounds)
+        {
+            const bool stillPresent = std::any_of(
+                currentFrameState.begin(),
+                currentFrameState.end(),
+                [&oldEntry](const AnimationBindingFrameState& state)
+                {
+                    return makeBindingKey(
+                        state.targetName,
+                        state.controllerName) == oldEntry.first;
+                });
+
+            if (!stillPresent)
+            {
+                m_invalidation->invalidateRect(oldEntry.second);
+            }
+        }
+
+        result.invalidated = !m_invalidation->isEmpty();
+        result.wholePageInvalidated = m_invalidation->isWholePageInvalidated();
+        result.dirtyRegionCount = m_invalidation->dirtyRegions().size();
+        m_lastKnownBindingBounds = std::move(nextKnownBounds);
+    }
+
+    std::string AnimationDrivenRecompositionLoop::makeBindingKey(
+        const std::string& targetName,
+        const std::string& controllerName)
+    {
+        return targetName + "\x1f" + controllerName;
     }
 
     bool AnimationDrivenRecompositionLoop::shouldRecompose(

--- a/TUI/Animation/AnimationDrivenRecompositionLoop.h
+++ b/TUI/Animation/AnimationDrivenRecompositionLoop.h
@@ -2,6 +2,8 @@
 
 #include <cstdint>
 #include <functional>
+#include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "Animation/AnimationBindingResolver.h"
@@ -25,6 +27,9 @@ namespace Animation
             bool frameStateChanged = false;
             bool forced = false;
             std::uint64_t deterministicSignature = 0;
+            bool invalidated = false;
+            bool wholePageInvalidated = false;
+            std::size_t dirtyRegionCount = 0;
             std::vector<AnimationBindingResolutionResult> bindingResults;
         };
 
@@ -56,6 +61,14 @@ namespace Animation
         bool shouldRecompose(
             const std::vector<AnimationBindingFrameState>& currentFrameState) const;
 
+        void applyInvalidation(
+            Result& result,
+            const std::vector<AnimationBindingFrameState>& currentFrameState);
+
+        static std::string makeBindingKey(
+            const std::string& targetName,
+            const std::string& controllerName);
+
     private:
         ComposePageCallback m_composePage;
         AnimationBindingResolver* m_bindingResolver = nullptr;
@@ -65,5 +78,6 @@ namespace Animation
         bool m_forceRecompose = true;
 
         std::vector<AnimationBindingFrameState> m_lastFrameState;
+        std::unordered_map<std::string, Rect> m_lastKnownBindingBounds;
     };
 }

--- a/TUI/Rendering/Composition/PageComposer.cpp
+++ b/TUI/Rendering/Composition/PageComposer.cpp
@@ -591,6 +591,18 @@ namespace Composition
         return makeRectValue(x, base.position.y, nextX - x, base.size.height);
     }
 
+    Rect PageComposer::resolvePlacementBounds(
+        const PlacementSpec& placement,
+        const Size& contentSize) const
+    {
+        const PlacementResult result = resolvePlacementResult(placement, contentSize);
+        return makeRectValue(
+            result.origin.x,
+            result.origin.y,
+            std::max(0, result.contentSize.width),
+            std::max(0, result.contentSize.height));
+    }
+
     void PageComposer::placeSource(
         const ObjectSource& source,
         const PlacementSpec& placement,

--- a/TUI/Rendering/Composition/PageComposer.h
+++ b/TUI/Rendering/Composition/PageComposer.h
@@ -182,6 +182,10 @@ namespace Composition
         Rect gridRow(const Rect& base, int rows, int row) const;
         Rect gridColumn(const Rect& base, int cols, int col) const;
 
+        Rect resolvePlacementBounds(
+            const PlacementSpec& placement,
+            const Size& contentSize) const;
+
         // ---------------------------------------------------------------------
         // Core composition API
         // ---------------------------------------------------------------------


### PR DESCRIPTION
… and redraw tracking

Modifies:
- Animation/AnimationBindingResolover.h/.cpp
- Animation/AnimationDrivenRecompositionLoop.h/.cpp
- Rendering/Composition/PageComposer.h/.cpp

- Added animation-driven invalidation integration to recomposition flow
- Detect visible animation frame changes separately from non-visual animation state updates
- Trigger recomposition only when captured animation frame state changes
- Added placement-bound tracking for animation binding results
- Added PageComposer placement-bound resolution helper
- Integrated optional region-level invalidation using resolved placement bounds
- Preserve full-page invalidation fallback for correctness and unknown bounds
- Invalidate both previous and current animation regions during frame transitions
- Kept invalidation fully renderer-agnostic with no direct ScreenBuffer patching
- Fixed switch-case scoping issues in AnimationBindingResolver by adding explicit case scopes
- Maintained deterministic composition pipeline through normal PageComposer flow

Closes: #285 