### PR TITLE
LayeredTextObject: add non-mutating LayeredTextObject frame extractio…

### DIFF
--- a/TUI/Rendering/Objects/LayeredTextObject.cpp
+++ b/TUI/Rendering/Objects/LayeredTextObject.cpp
@@ -113,6 +113,12 @@ namespace Rendering
         return (it != m_layers.end()) ? &(*it) : nullptr;
     }
 
+    const TextObject* LayeredTextObject::findLayerTextObjectByName(std::string_view name) const
+    {
+        const TextObjectLayer* layer = findLayer(name);
+        return (layer != nullptr) ? &layer->object : nullptr;
+    }
+
     bool LayeredTextObject::hasLayer(std::string_view name) const
     {
         return findLayer(name) != nullptr;

--- a/TUI/Rendering/Objects/LayeredTextObject.h
+++ b/TUI/Rendering/Objects/LayeredTextObject.h
@@ -76,6 +76,8 @@ namespace Rendering
         const TextObjectLayer* findLayer(std::string_view name) const;
         TextObjectLayer* findLayer(std::string_view name);
 
+        const TextObject* findLayerTextObjectByName(std::string_view name) const;
+
         bool hasLayer(std::string_view name) const;
         bool addLayer(const TextObjectLayer& layer);
         bool addLayer(TextObjectLayer&& layer);

--- a/TUI/TUI.vcxproj.filters
+++ b/TUI/TUI.vcxproj.filters
@@ -564,6 +564,9 @@
     <ClInclude Include="Animation\XpSequencePlayback.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="Animation\AnimationDiagnostics.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Rendering\ScreenBuffer.cpp">
@@ -1047,6 +1050,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="Animation\XpSequencePlayback.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Animation\AnimationDiagnostic.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
…n helper

Modifies:
- TUI.vcxproj.filters
- Rendering/Objects/LayeredTextObject

- Added LayeredTextObject::findLayerTextObjectByName(...)
- Supports direct TextObject extraction by authored layer name
- Enables Animation/ to access pFont animation frames without mutating layer visibility
- Preserves existing LayeredTextObject architecture and metadata access
- Prepares foundation for global pFont animation sequence generation

Closes: #346 