### PR TITLE
AnimatedTextAssetSequence: add duration-aware playback helpers

### DIFF
--- a/TUI/Animation/AnimatedTextAssetSequence.cpp
+++ b/TUI/Animation/AnimatedTextAssetSequence.cpp
@@ -4,6 +4,7 @@
 #include <sstream>
 #include <utility>
 
+#include "Animation/Animator.h"
 #include "Rendering/Objects/XpSequenceAnimationAdapter.h"
 
 namespace
@@ -50,6 +51,18 @@ namespace
 
         return fallbackDurationSeconds;
     }
+
+    std::size_t clampSequenceFrameIndex(
+        const std::size_t frameIndex,
+        const std::size_t frameCount)
+    {
+        if (frameCount == 0)
+        {
+            return 0;
+        }
+
+        return std::min(frameIndex, frameCount - 1);
+    }
 }
 
 namespace Animation
@@ -89,6 +102,16 @@ namespace Animation
     bool AnimatedTextAssetFrameBuildResult::hasObject() const
     {
         return success && object.isLoaded();
+    }
+
+    bool AnimatedTextAssetSequencePlaybackResult::success() const
+    {
+        return buildResult.success;
+    }
+
+    bool AnimatedTextAssetSequencePlaybackResult::hasObject() const
+    {
+        return buildResult.hasObject();
     }
 
     AnimatedTextAssetFrame AnimatedTextAssetFrame::fromTextObject(
@@ -631,6 +654,56 @@ namespace Animation
     double AnimatedTextAssetSequence::sanitizeDefaultDuration(const double seconds)
     {
         return seconds > 0.0 ? seconds : 0.0;
+    }
+
+    std::size_t frameIndexForAnimator(
+        const AnimatedTextAssetSequence& sequence,
+        const Animator& animator)
+    {
+        if (sequence.isEmpty())
+        {
+            return 0;
+        }
+
+        if (animator.hasExplicitFrameIndex())
+        {
+            return clampSequenceFrameIndex(
+                animator.explicitFrameIndex().value(),
+                sequence.frameCount());
+        }
+
+        return sequence.frameIndexForElapsedSeconds(animator.elapsedSeconds());
+    }
+
+    AnimatedTextAssetSequencePlaybackResult buildTextObjectForAnimatorWithResult(
+        const AnimatedTextAssetSequence& sequence,
+        const Animator& animator)
+    {
+        AnimatedTextAssetSequencePlaybackResult result;
+        result.elapsedSeconds = animator.elapsedSeconds();
+        result.usedExplicitFrameIndex = animator.hasExplicitFrameIndex();
+
+        if (sequence.isEmpty())
+        {
+            result.buildResult = makeFailure(
+                AnimatedTextAssetFrameResultCode::FrameIndexOutOfRange,
+                "Cannot build a TextObject from an empty animated text asset sequence.");
+
+            return result;
+        }
+
+        result.frameIndex = frameIndexForAnimator(sequence, animator);
+        result.hasFrameIndex = true;
+        result.buildResult = sequence.buildTextObjectForFrame(result.frameIndex);
+
+        return result;
+    }
+
+    AnimatedTextAssetFrameBuildResult buildTextObjectForAnimator(
+        const AnimatedTextAssetSequence& sequence,
+        const Animator& animator)
+    {
+        return buildTextObjectForAnimatorWithResult(sequence, animator).buildResult;
     }
 
     const char* toString(const AnimatedTextAssetFrameSourceKind kind)

--- a/TUI/Animation/AnimatedTextAssetSequence.h
+++ b/TUI/Animation/AnimatedTextAssetSequence.h
@@ -12,6 +12,9 @@
 
 namespace Animation
 {
+    class Animator;
+    class AnimatedTextAssetSequence;
+
     enum class AnimatedTextAssetFrameSourceKind
     {
         Empty,
@@ -61,6 +64,19 @@ namespace Animation
         AnimatedTextAssetFrameResultCode code = AnimatedTextAssetFrameResultCode::None;
         std::string errorMessage;
 
+        bool hasObject() const;
+    };
+
+    struct AnimatedTextAssetSequencePlaybackResult
+    {
+        AnimatedTextAssetFrameBuildResult buildResult;
+
+        std::size_t frameIndex = 0;
+        bool hasFrameIndex = false;
+        bool usedExplicitFrameIndex = false;
+        double elapsedSeconds = 0.0;
+
+        bool success() const;
         bool hasObject() const;
     };
 
@@ -191,6 +207,18 @@ namespace Animation
         bool m_looping = false;
         std::vector<AnimatedTextAssetFrame> m_frames;
     };
+
+    std::size_t frameIndexForAnimator(
+        const AnimatedTextAssetSequence& sequence,
+        const Animator& animator);
+
+    AnimatedTextAssetSequencePlaybackResult buildTextObjectForAnimatorWithResult(
+        const AnimatedTextAssetSequence& sequence,
+        const Animator& animator);
+
+    AnimatedTextAssetFrameBuildResult buildTextObjectForAnimator(
+        const AnimatedTextAssetSequence& sequence,
+        const Animator& animator);
 
     const char* toString(AnimatedTextAssetFrameSourceKind kind);
     const char* toString(AnimatedTextAssetFrameResultCode code);


### PR DESCRIPTION
Modifies:
Animation/AnimatedTextAssetSequence.h/.cpp

- Added frameIndexForAnimator(...) helper for elapsed-time-based frame resolution
- Added buildTextObjectForAnimator(...) helper for reusable sequence playback
- Added AnimatedTextAssetSequencePlaybackResult result type
- Added support for:
  - variable-duration animation frames
  - elapsedSeconds()-driven frame selection
  - explicit frame index override support
  - safe zero-frame sequence handling
- Preserved generic Animator architecture without pFont-specific logic
- Centralized sequence playback logic for reuse by:
  - AnimationBindingResolver
  - WaterEffectScreen
  - future animated text systems
- Established reusable duration-aware playback foundation for global pFont animation

Closes: #349 