### PR TITLE
EffectWindow: Normalize EffectWindow around effect-content adapter ar…

### DIFF
--- a/TUI/UI/Panels/EffectWindow.cpp
+++ b/TUI/UI/Panels/EffectWindow.cpp
@@ -1,27 +1,45 @@
 #include "UI/Panels/EffectWindow.h"
 
-#include <memory>
 #include <utility>
 
-#include "Core/Rect.h"
 #include "Rendering/Surface.h"
 #include "UI/Content/EffectReferenceWindowContent.h"
 
-EffectWindow::EffectWindow(Rect bounds, std::string title, IEffect& effect)
-    : Window(bounds, std::move(title))
-    , m_effect(effect)
+namespace
 {
+    bool areSameBounds(const Rect& lhs, const Rect& rhs)
+    {
+        return lhs.position.x == rhs.position.x &&
+            lhs.position.y == rhs.position.y &&
+            lhs.size.width == rhs.size.width &&
+            lhs.size.height == rhs.size.height;
+    }
 }
 
+EffectWindow::EffectWindow(Rect bounds, std::string title, IEffect& effect)
+    : Window(bounds, std::move(title))
+    , m_content(std::make_unique<UI::EffectReferenceWindowContent>(effect))
+{
+    m_content->onAttached();
+    notifyContentBoundsChanged();
+}
+
+EffectWindow::~EffectWindow()
+{
+    detachContent();
+}
 
 bool EffectWindow::hasTransferableContent() const
 {
-    return true;
+    return m_content != nullptr;
 }
 
 std::unique_ptr<UI::IWindowContent> EffectWindow::releaseContent()
 {
-    return std::make_unique<UI::EffectReferenceWindowContent>(m_effect);
+    detachContent();
+
+    m_hasLastContentBounds = false;
+    return std::move(m_content);
 }
 
 void EffectWindow::update(const Animation::TickEvent& event)
@@ -31,7 +49,12 @@ void EffectWindow::update(const Animation::TickEvent& event)
         return;
     }
 
-    m_effect.update(event);
+    notifyContentBoundsChanged();
+
+    if (m_content != nullptr)
+    {
+        m_content->update(event);
+    }
 }
 
 void EffectWindow::draw(Surface& surface)
@@ -41,7 +64,40 @@ void EffectWindow::draw(Surface& surface)
         return;
     }
 
+    notifyContentBoundsChanged();
+
     Window::draw(surface);
 
-    m_effect.draw(surface, contentBounds());
+    if (m_content != nullptr)
+    {
+        m_content->draw(surface, contentBounds());
+    }
+}
+
+void EffectWindow::detachContent()
+{
+    if (m_content != nullptr)
+    {
+        m_content->onDetached();
+    }
+}
+
+void EffectWindow::notifyContentBoundsChanged()
+{
+    if (m_content == nullptr)
+    {
+        return;
+    }
+
+    const Rect currentBounds = contentBounds();
+
+    if (m_hasLastContentBounds && areSameBounds(currentBounds, m_lastContentBounds))
+    {
+        return;
+    }
+
+    m_lastContentBounds = currentBounds;
+    m_hasLastContentBounds = true;
+
+    m_content->onBoundsChanged(currentBounds);
 }

--- a/TUI/UI/Panels/EffectWindow.h
+++ b/TUI/UI/Panels/EffectWindow.h
@@ -3,13 +3,27 @@
 #include <memory>
 #include <string>
 
+#include "Core/Rect.h"
 #include "UI/Panels/Window.h"
-#include "Rendering/Effects/IEffects.h"
+
+class IEffect;
+
+namespace UI
+{
+    class EffectReferenceWindowContent;
+}
 
 class EffectWindow : public Window
 {
 public:
+    // Compatibility wrapper for older screens that still construct EffectWindow directly.
+    //
+    // New code should prefer:
+    // ContentWindow(bounds, title, std::make_unique<UI::EffectReferenceWindowContent>(effect))
+    //
+    // EffectWindow borrows the effect. It does not own, reset, or destroy it.
     EffectWindow(Rect bounds, std::string title, IEffect& effect);
+    ~EffectWindow() override;
 
     bool hasTransferableContent() const override;
     std::unique_ptr<UI::IWindowContent> releaseContent() override;
@@ -18,5 +32,11 @@ public:
     void draw(Surface& surface) override;
 
 private:
-    IEffect& m_effect;
+    void detachContent();
+    void notifyContentBoundsChanged();
+
+private:
+    std::unique_ptr<UI::EffectReferenceWindowContent> m_content;
+    Rect m_lastContentBounds{};
+    bool m_hasLastContentBounds = false;
 };


### PR DESCRIPTION
…chitecture

Modifies:
- UI/Panels/EffectWindow.h/.cpp

- Refactored EffectWindow to internally host UI::EffectReferenceWindowContent instead of directly managing IEffect update/draw behavior
- Preserved existing EffectWindow construction and usage patterns for compatibility with current screens and call sites
- Repositioned EffectWindow as a transitional compatibility wrapper rather than the preferred long-term architecture
- Unified EffectWindow lifecycle behavior with ContentWindow:
    - onAttached()
    - onDetached()
    - onBoundsChanged(...)
- Added destructor detach handling to guarantee consistent content lifecycle forwarding before wrapper destruction
- Added explicit initial bounds notification after attachment
- Added cached bounds tracking to avoid missing first resize/layout synchronization
- Preserved borrowed-effect semantics:
    - EffectWindow does not own the effect
    - EffectWindow does not destroy/reset the effect
    - releaseContent() safely transfers borrowed adapter ownership
- Preserved Window chrome / content body separation: Window handles framing/chrome EffectReferenceWindowContent owns effect behavior
- Preserved ContentWindow as final and avoided introducing a new window hierarchy
- Established preferred future patterns: borrowed effects: ContentWindow + EffectReferenceWindowContent owned effects: ContentWindow + EffectWindowContent

Closes: #364 