### PR TITLE
ComposedWindowContent: Add ComposedWindowContent PageComposer-backed …

### DIFF
--- a/TUI/TUI.vcxproj
+++ b/TUI/TUI.vcxproj
@@ -296,6 +296,7 @@
     <ClInclude Include="UI\Base\Viewport.h" />
     <ClInclude Include="UI\Base\WindowManager.h" />
     <ClInclude Include="UI\Config\MenuStatusConfig.h" />
+    <ClInclude Include="UI\Content\ComposedWindowContent.h" />
     <ClInclude Include="UI\Content\EffectReferenceWindowContent.h" />
     <ClInclude Include="UI\Content\EffectWindowContent.h" />
     <ClInclude Include="UI\Content\IWindowContent.h" />
@@ -486,6 +487,7 @@
     <ClCompile Include="UI\Base\Viewport.cpp" />
     <ClCompile Include="UI\Base\WindowManager.cpp" />
     <ClCompile Include="UI\Config\MenuStatusConfig.cpp" />
+    <ClCompile Include="UI\Content\ComposedWindowContent.cpp" />
     <ClCompile Include="UI\Content\EffectReferenceWindowContent.cpp" />
     <ClCompile Include="UI\Content\EffectWindowContent.cpp" />
     <ClCompile Include="UI\Content\TileGrid.cpp" />

--- a/TUI/TUI.vcxproj.filters
+++ b/TUI/TUI.vcxproj.filters
@@ -570,6 +570,9 @@
     <ClInclude Include="Animation\PseudoFontAnimationSequence.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="UI\Content\ComposedWindowContent.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Rendering\ScreenBuffer.cpp">
@@ -1059,6 +1062,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="Animation\PseudoFontAnimationSequence.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="UI\Content\ComposedWindowContent.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/TUI/UI/Content/ComposedWindowContent.cpp
+++ b/TUI/UI/Content/ComposedWindowContent.cpp
@@ -1,0 +1,170 @@
+#include "UI/Content/ComposedWindowContent.h"
+
+#include <algorithm>
+#include <utility>
+
+#include "Input/Event.h"
+#include "Rendering/Composition/PageComposer.h"
+#include "Rendering/ScreenBuffer.h"
+
+namespace
+{
+    int positiveOrZero(int value)
+    {
+        return std::max(0, value);
+    }
+
+    Rect makeLocalBoundsFromContentBounds(const Rect& bounds)
+    {
+        Rect localBounds;
+        localBounds.position = { 0, 0 };
+        localBounds.size.width = positiveOrZero(bounds.size.width);
+        localBounds.size.height = positiveOrZero(bounds.size.height);
+        return localBounds;
+    }
+
+    bool areSameSize(const Rect& lhs, const Rect& rhs)
+    {
+        return lhs.size.width == rhs.size.width &&
+            lhs.size.height == rhs.size.height;
+    }
+
+    void blitVisibleCells(
+        const ScreenBuffer& source,
+        ScreenBuffer& destination,
+        const Rect& destinationBounds)
+    {
+        const int width = std::min(source.getWidth(), positiveOrZero(destinationBounds.size.width));
+        const int height = std::min(source.getHeight(), positiveOrZero(destinationBounds.size.height));
+
+        for (int y = 0; y < height; ++y)
+        {
+            const int destinationY = destinationBounds.position.y + y;
+
+            for (int x = 0; x < width; ++x)
+            {
+                const int destinationX = destinationBounds.position.x + x;
+
+                if (!destination.inBounds(destinationX, destinationY))
+                {
+                    continue;
+                }
+
+                const ScreenCell& cell = source.getCell(x, y);
+
+                if (cell.isEmpty())
+                {
+                    continue;
+                }
+
+                destination.setCell(destinationX, destinationY, cell);
+            }
+        }
+    }
+}
+
+namespace UI
+{
+    ComposedWindowContent::ComposedWindowContent(ComposeCallback compose)
+        : m_compose(std::move(compose))
+    {
+    }
+
+    ComposedWindowContent::~ComposedWindowContent() = default;
+
+    void ComposedWindowContent::setComposeCallback(ComposeCallback compose)
+    {
+        m_compose = std::move(compose);
+        requestRecompose();
+    }
+
+    void ComposedWindowContent::requestRecompose()
+    {
+        m_dirty = true;
+    }
+
+    void ComposedWindowContent::update(const Animation::TickEvent& event)
+    {
+        (void)event;
+    }
+
+    bool ComposedWindowContent::handleEvent(const Input::Event& event)
+    {
+        (void)event;
+        return false;
+    }
+
+    void ComposedWindowContent::draw(Surface& surface, const Rect& bounds)
+    {
+        resizeLocalSurface(bounds);
+        rebuildIfDirty();
+
+        if (m_localBounds.size.width <= 0 || m_localBounds.size.height <= 0)
+        {
+            return;
+        }
+
+        blitVisibleCells(m_surface.buffer(), surface.buffer(), bounds);
+    }
+
+    void ComposedWindowContent::onAttached()
+    {
+        m_attached = true;
+        requestRecompose();
+    }
+
+    void ComposedWindowContent::onDetached()
+    {
+        m_attached = false;
+    }
+
+    void ComposedWindowContent::onBoundsChanged(const Rect& bounds)
+    {
+        resizeLocalSurface(bounds);
+    }
+
+    void ComposedWindowContent::resizeLocalSurface(const Rect& bounds)
+    {
+        const Rect newLocalBounds = makeLocalBoundsFromContentBounds(bounds);
+
+        if (areSameSize(newLocalBounds, m_localBounds))
+        {
+            return;
+        }
+
+        m_localBounds = newLocalBounds;
+        m_surface.resize(m_localBounds.size.width, m_localBounds.size.height);
+        requestRecompose();
+    }
+
+    void ComposedWindowContent::rebuildIfDirty()
+    {
+        if (!m_dirty)
+        {
+            return;
+        }
+
+        m_dirty = false;
+
+        m_surface.clear(Style());
+
+        if (!m_attached)
+        {
+            return;
+        }
+
+        if (m_localBounds.size.width <= 0 || m_localBounds.size.height <= 0)
+        {
+            return;
+        }
+
+        if (!m_compose)
+        {
+            return;
+        }
+
+        Composition::PageComposer composer(m_surface.buffer());
+        composer.clear(Style());
+        m_compose(composer, m_localBounds);
+    }
+}

--- a/TUI/UI/Content/ComposedWindowContent.h
+++ b/TUI/UI/Content/ComposedWindowContent.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <functional>
+
+#include "Core/Rect.h"
+#include "Rendering/Surface.h"
+#include "UI/Content/IWindowContent.h"
+
+namespace Composition
+{
+    class PageComposer;
+}
+
+namespace UI
+{
+    class ComposedWindowContent final : public IWindowContent
+    {
+    public:
+        using ComposeCallback =
+            std::function<void(Composition::PageComposer& composer, const Rect& bounds)>;
+
+        explicit ComposedWindowContent(ComposeCallback compose);
+
+        ComposedWindowContent(const ComposedWindowContent&) = delete;
+        ComposedWindowContent& operator=(const ComposedWindowContent&) = delete;
+
+        ComposedWindowContent(ComposedWindowContent&&) noexcept = default;
+        ComposedWindowContent& operator=(ComposedWindowContent&&) noexcept = default;
+
+        ~ComposedWindowContent() override;
+
+        void setComposeCallback(ComposeCallback compose);
+        void requestRecompose();
+
+        void update(const Animation::TickEvent& event) override;
+        bool handleEvent(const Input::Event& event) override;
+        void draw(Surface& surface, const Rect& bounds) override;
+        void onAttached() override;
+        void onDetached() override;
+        void onBoundsChanged(const Rect& bounds) override;
+
+    private:
+        void resizeLocalSurface(const Rect& bounds);
+        void rebuildIfDirty();
+
+    private:
+        ComposeCallback m_compose;
+        Surface m_surface;
+        Rect m_localBounds{};
+        bool m_dirty = true;
+        bool m_attached = false;
+    };
+}


### PR DESCRIPTION
…IWindowContent adapter

Modifies:
- TUI.vcxproj
- TUI.vcxproj.filters

Adds:
- UI/Content/ComposedWindowContent.h/.cpp

- Added UI::ComposedWindowContent as a reusable PageComposer-backed IWindowContent implementation
- Enables ContentWindow to host borderless composed interiors without nested Window or Panel chrome
- Preserved ContentWindow as a generic content host with no PageComposer-specific knowledge added
- Added callback-based composition API: std::function<void(PageComposer&, const Rect&)>
- Added internal local composition surface/buffer management sized to current content bounds
- Added automatic recomposition invalidation when:
    - bounds change
    - composition callback changes
    - content attaches
    - explicit requestRecompose() is called
- Added safe handling for zero/negative content bounds
- Added local-to-destination buffer blitting path so composed content renders only inside ContentWindow content bounds
- Added visible-cell-only blit helper to preserve transparent/ sparse composition behavior
- Preserved coordinate isolation: PageComposer composes in local content-space ContentWindow controls final screen placement
- Established reusable architecture for:
    - borderless render-info panels
    - HUD interiors
    - diagnostic overlays
    - composed dashboards
    - text-layout-driven window interiors
- Reinforced architecture direction: Window = chrome/container IWindowContent = interior behavior/rendering PageComposer composition remains fully encapsulated inside content adapters

Closes: #365 