### PR TITLE
ImmediateModeWindowContent: Add ImmediateModeWindowContent lightweigh…

### DIFF
--- a/TUI/TUI.vcxproj
+++ b/TUI/TUI.vcxproj
@@ -299,6 +299,7 @@
     <ClInclude Include="UI\Content\ComposedWindowContent.h" />
     <ClInclude Include="UI\Content\EffectReferenceWindowContent.h" />
     <ClInclude Include="UI\Content\EffectWindowContent.h" />
+    <ClInclude Include="UI\Content\ImmediateModeWindowContent.h" />
     <ClInclude Include="UI\Content\IWindowContent.h" />
     <ClInclude Include="UI\Content\TileGrid.h" />
     <ClInclude Include="UI\Content\WidgetWindowContent.h" />
@@ -490,6 +491,7 @@
     <ClCompile Include="UI\Content\ComposedWindowContent.cpp" />
     <ClCompile Include="UI\Content\EffectReferenceWindowContent.cpp" />
     <ClCompile Include="UI\Content\EffectWindowContent.cpp" />
+    <ClCompile Include="UI\Content\ImmediateModeWindowContent.cpp" />
     <ClCompile Include="UI\Content\TileGrid.cpp" />
     <ClCompile Include="UI\Content\WidgetWindowContent.cpp" />
     <ClCompile Include="UI\Interaction\WindowInteraction.cpp" />

--- a/TUI/UI/Content/ImmediateModeWindowContent.cpp
+++ b/TUI/UI/Content/ImmediateModeWindowContent.cpp
@@ -1,0 +1,82 @@
+#include "UI/Content/ImmediateModeWindowContent.h"
+
+#include <utility>
+
+#include "Input/Event.h"
+#include "Rendering/Surface.h"
+
+namespace UI
+{
+    ImmediateModeWindowContent::ImmediateModeWindowContent(DrawCallback draw)
+        : m_draw(std::move(draw))
+    {
+    }
+
+    ImmediateModeWindowContent::ImmediateModeWindowContent(
+        DrawCallback draw,
+        UpdateCallback update,
+        EventCallback handleEvent,
+        BoundsChangedCallback onBoundsChanged)
+        : m_draw(std::move(draw))
+        , m_update(std::move(update))
+        , m_handleEvent(std::move(handleEvent))
+        , m_onBoundsChanged(std::move(onBoundsChanged))
+    {
+    }
+
+    ImmediateModeWindowContent::~ImmediateModeWindowContent() = default;
+
+    void ImmediateModeWindowContent::setDrawCallback(DrawCallback draw)
+    {
+        m_draw = std::move(draw);
+    }
+
+    void ImmediateModeWindowContent::setUpdateCallback(UpdateCallback update)
+    {
+        m_update = std::move(update);
+    }
+
+    void ImmediateModeWindowContent::setEventCallback(EventCallback handleEvent)
+    {
+        m_handleEvent = std::move(handleEvent);
+    }
+
+    void ImmediateModeWindowContent::setBoundsChangedCallback(BoundsChangedCallback onBoundsChanged)
+    {
+        m_onBoundsChanged = std::move(onBoundsChanged);
+    }
+
+    void ImmediateModeWindowContent::update(const Animation::TickEvent& event)
+    {
+        if (m_update)
+        {
+            m_update(event);
+        }
+    }
+
+    bool ImmediateModeWindowContent::handleEvent(const Input::Event& event)
+    {
+        if (!m_handleEvent)
+        {
+            return false;
+        }
+
+        return m_handleEvent(event);
+    }
+
+    void ImmediateModeWindowContent::draw(Surface& surface, const Rect& bounds)
+    {
+        if (m_draw)
+        {
+            m_draw(surface, bounds);
+        }
+    }
+
+    void ImmediateModeWindowContent::onBoundsChanged(const Rect& bounds)
+    {
+        if (m_onBoundsChanged)
+        {
+            m_onBoundsChanged(bounds);
+        }
+    }
+}

--- a/TUI/UI/Content/ImmediateModeWindowContent.h
+++ b/TUI/UI/Content/ImmediateModeWindowContent.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <functional>
+
+#include "Animation/TickEvent.h"
+#include "Core/Rect.h"
+#include "UI/Content/IWindowContent.h"
+
+class Surface;
+
+namespace Input
+{
+    class Event;
+}
+
+namespace UI
+{
+    class ImmediateModeWindowContent final : public IWindowContent
+    {
+    public:
+        using DrawCallback = std::function<void(Surface& surface, const Rect& bounds)>;
+        using UpdateCallback = std::function<void(const Animation::TickEvent& event)>;
+        using EventCallback = std::function<bool(const Input::Event& event)>;
+        using BoundsChangedCallback = std::function<void(const Rect& bounds)>;
+
+        explicit ImmediateModeWindowContent(DrawCallback draw);
+
+        ImmediateModeWindowContent(
+            DrawCallback draw,
+            UpdateCallback update,
+            EventCallback handleEvent = nullptr,
+            BoundsChangedCallback onBoundsChanged = nullptr);
+
+        ImmediateModeWindowContent(const ImmediateModeWindowContent&) = delete;
+        ImmediateModeWindowContent& operator=(const ImmediateModeWindowContent&) = delete;
+
+        ImmediateModeWindowContent(ImmediateModeWindowContent&&) noexcept = default;
+        ImmediateModeWindowContent& operator=(ImmediateModeWindowContent&&) noexcept = default;
+
+        ~ImmediateModeWindowContent() override;
+
+        void setDrawCallback(DrawCallback draw);
+        void setUpdateCallback(UpdateCallback update);
+        void setEventCallback(EventCallback handleEvent);
+        void setBoundsChangedCallback(BoundsChangedCallback onBoundsChanged);
+
+        void update(const Animation::TickEvent& event) override;
+        bool handleEvent(const Input::Event& event) override;
+        void draw(Surface& surface, const Rect& bounds) override;
+        void onBoundsChanged(const Rect& bounds) override;
+
+    private:
+        DrawCallback m_draw;
+        UpdateCallback m_update;
+        EventCallback m_handleEvent;
+        BoundsChangedCallback m_onBoundsChanged;
+    };
+}


### PR DESCRIPTION
…t callback-driven adapter

Modifies:
TUI.vcxproj

Adds:
- UI/Content/ImmediateModeWindowContent.h/.cpp

- Added UI::ImmediateModeWindowContent as a lightweight callback-based IWindowContent implementation
- Enables quick custom rendering inside ContentWindow without creating dedicated one-off content subclasses
- Added required draw callback support: void(Surface&, const Rect&)
- Added optional update callback support: void(const Animation::TickEvent&)
- Added optional event callback support: bool(const Input::Event&)
- Added optional bounds-changed callback support: void(const Rect&)
- Preserved ContentWindow as a generic chrome/container host with no immediate-mode rendering knowledge added
- Kept adapter intentionally small and low-overhead for:
    - diagnostics
    - telemetry
    - temporary debug UI
    - quick demo panels
    - lightweight custom overlays
- Preserved architecture direction: Window = chrome/container IWindowContent = interior behavior/rendering

Closes: #366 