### PR TITLE
BufferWindowContent: Add BufferWindowContent ScreenBuffer-backed cont…

### DIFF
--- a/TUI/TUI.vcxproj
+++ b/TUI/TUI.vcxproj
@@ -296,6 +296,7 @@
     <ClInclude Include="UI\Base\Viewport.h" />
     <ClInclude Include="UI\Base\WindowManager.h" />
     <ClInclude Include="UI\Config\MenuStatusConfig.h" />
+    <ClInclude Include="UI\Content\BufferWindowContent.h" />
     <ClInclude Include="UI\Content\ComposedWindowContent.h" />
     <ClInclude Include="UI\Content\EffectReferenceWindowContent.h" />
     <ClInclude Include="UI\Content\EffectWindowContent.h" />
@@ -488,6 +489,7 @@
     <ClCompile Include="UI\Base\Viewport.cpp" />
     <ClCompile Include="UI\Base\WindowManager.cpp" />
     <ClCompile Include="UI\Config\MenuStatusConfig.cpp" />
+    <ClCompile Include="UI\Content\BufferWindowContent.cpp" />
     <ClCompile Include="UI\Content\ComposedWindowContent.cpp" />
     <ClCompile Include="UI\Content\EffectReferenceWindowContent.cpp" />
     <ClCompile Include="UI\Content\EffectWindowContent.cpp" />

--- a/TUI/UI/Content/BufferWindowContent.cpp
+++ b/TUI/UI/Content/BufferWindowContent.cpp
@@ -1,0 +1,234 @@
+#include "UI/Content/BufferWindowContent.h"
+
+#include <algorithm>
+#include <stdexcept>
+
+#include "Input/Event.h"
+#include "Rendering/Surface.h"
+
+namespace
+{
+    int positiveOrZero(int value)
+    {
+        return std::max(0, value);
+    }
+
+    Size safeSize(Size size)
+    {
+        size.width = positiveOrZero(size.width);
+        size.height = positiveOrZero(size.height);
+        return size;
+    }
+
+    Size sizeFromBounds(const Rect& bounds)
+    {
+        return safeSize(bounds.size);
+    }
+
+    void blitBuffer(
+        const ScreenBuffer& source,
+        ScreenBuffer& destination,
+        const Rect& destinationBounds,
+        bool copyEmptyCells)
+    {
+        const int width = std::min(
+            source.getWidth(),
+            positiveOrZero(destinationBounds.size.width));
+
+        const int height = std::min(
+            source.getHeight(),
+            positiveOrZero(destinationBounds.size.height));
+
+        for (int y = 0; y < height; ++y)
+        {
+            const int destinationY = destinationBounds.position.y + y;
+
+            for (int x = 0; x < width; ++x)
+            {
+                const int destinationX = destinationBounds.position.x + x;
+
+                if (!destination.inBounds(destinationX, destinationY))
+                {
+                    continue;
+                }
+
+                const ScreenCell& cell = source.getCell(x, y);
+
+                if (!copyEmptyCells && cell.isEmpty())
+                {
+                    continue;
+                }
+
+                destination.setCell(destinationX, destinationY, cell);
+            }
+        }
+    }
+}
+
+namespace UI
+{
+    BufferWindowContent::BufferWindowContent()
+        : BufferWindowContent(Size{ 0, 0 })
+    {
+    }
+
+    BufferWindowContent::BufferWindowContent(Size size)
+        : m_ownedBuffer(std::make_unique<ScreenBuffer>(
+            positiveOrZero(size.width),
+            positiveOrZero(size.height)))
+        , m_buffer(m_ownedBuffer.get())
+    {
+    }
+
+    BufferWindowContent::BufferWindowContent(int width, int height)
+        : BufferWindowContent(Size{ width, height })
+    {
+    }
+
+    BufferWindowContent::BufferWindowContent(ScreenBuffer& borrowedBuffer)
+        : m_buffer(&borrowedBuffer)
+    {
+    }
+
+    std::unique_ptr<BufferWindowContent> BufferWindowContent::createOwned(Size size)
+    {
+        return std::make_unique<BufferWindowContent>(size);
+    }
+
+    std::unique_ptr<BufferWindowContent> BufferWindowContent::createOwned(int width, int height)
+    {
+        return std::make_unique<BufferWindowContent>(width, height);
+    }
+
+    std::unique_ptr<BufferWindowContent> BufferWindowContent::createBorrowed(ScreenBuffer& borrowedBuffer)
+    {
+        return std::make_unique<BufferWindowContent>(borrowedBuffer);
+    }
+
+    BufferWindowContent::~BufferWindowContent() = default;
+
+    bool BufferWindowContent::ownsBuffer() const
+    {
+        return m_ownedBuffer != nullptr;
+    }
+
+    bool BufferWindowContent::hasBuffer() const
+    {
+        return m_buffer != nullptr;
+    }
+
+    ScreenBuffer& BufferWindowContent::buffer()
+    {
+        return sourceBuffer();
+    }
+
+    const ScreenBuffer& BufferWindowContent::buffer() const
+    {
+        return sourceBuffer();
+    }
+
+    ScreenBuffer* BufferWindowContent::ownedBuffer()
+    {
+        return m_ownedBuffer.get();
+    }
+
+    const ScreenBuffer* BufferWindowContent::ownedBuffer() const
+    {
+        return m_ownedBuffer.get();
+    }
+
+    ScreenBuffer& BufferWindowContent::sourceBuffer()
+    {
+        if (m_buffer == nullptr)
+        {
+            throw std::logic_error("BufferWindowContent has no source buffer.");
+        }
+
+        return *m_buffer;
+    }
+
+    const ScreenBuffer& BufferWindowContent::sourceBuffer() const
+    {
+        if (m_buffer == nullptr)
+        {
+            throw std::logic_error("BufferWindowContent has no source buffer.");
+        }
+
+        return *m_buffer;
+    }
+
+    void BufferWindowContent::setCopyEmptyCells(bool copyEmptyCells)
+    {
+        m_copyEmptyCells = copyEmptyCells;
+    }
+
+    bool BufferWindowContent::copyEmptyCells() const
+    {
+        return m_copyEmptyCells;
+    }
+
+    void BufferWindowContent::resizeOwnedBuffer(Size size)
+    {
+        if (m_ownedBuffer == nullptr)
+        {
+            return;
+        }
+
+        const Size safe = safeSize(size);
+        m_ownedBuffer->resize(safe.width, safe.height);
+    }
+
+    void BufferWindowContent::resizeOwnedBuffer(int width, int height)
+    {
+        resizeOwnedBuffer(Size{ width, height });
+    }
+
+    void BufferWindowContent::update(const Animation::TickEvent& event)
+    {
+        (void)event;
+    }
+
+    bool BufferWindowContent::handleEvent(const Input::Event& event)
+    {
+        (void)event;
+        return false;
+    }
+
+    void BufferWindowContent::draw(Surface& surface, const Rect& bounds)
+    {
+        if (m_buffer == nullptr)
+        {
+            return;
+        }
+
+        if (bounds.size.width <= 0 || bounds.size.height <= 0)
+        {
+            return;
+        }
+
+        blitBuffer(*m_buffer, surface.buffer(), bounds, m_copyEmptyCells);
+    }
+
+    void BufferWindowContent::onBoundsChanged(const Rect& bounds)
+    {
+        resizeOwnedBufferToBounds(bounds);
+    }
+
+    void BufferWindowContent::resizeOwnedBufferToBounds(const Rect& bounds)
+    {
+        if (m_ownedBuffer == nullptr)
+        {
+            return;
+        }
+
+        const Size size = sizeFromBounds(bounds);
+
+        if (m_ownedBuffer->getWidth() == size.width &&
+            m_ownedBuffer->getHeight() == size.height)
+        {
+            return;
+        }
+
+        m_ownedBuffer->resize(size.width, size.height);
+    }
+}

--- a/TUI/UI/Content/BufferWindowContent.h
+++ b/TUI/UI/Content/BufferWindowContent.h
@@ -1,0 +1,137 @@
+#pragma once
+
+#include <memory>
+
+#include "Core/Rect.h"
+#include "Core/Size.h"
+#include "Rendering/ScreenBuffer.h"
+#include "UI/Content/IWindowContent.h"
+
+/*
+    BufferWindowContent supports two distinct operating modes:
+
+    ------------------------------------------------------------------------
+    OWNED MODE
+    ------------------------------------------------------------------------
+
+    In owned mode, BufferWindowContent internally owns and manages the
+    lifetime of its ScreenBuffer.
+
+        auto content =
+            UI::BufferWindowContent::createOwned(40, 12);
+
+    The content is responsible for:
+        - buffer allocation
+        - buffer destruction
+        - buffer resizing
+        - buffer persistence
+
+    Owned mode is useful when the window content itself is the render target.
+
+    Typical use cases:
+        - cached render targets
+        - framebuffer-style content
+        - telemetry graphs
+        - mini-maps
+        - internal diagnostics
+        - software-rendered panels
+        - temporary offscreen rendering
+        - composition caches
+
+    Owned buffers automatically resize to match content bounds changes.
+
+
+    ------------------------------------------------------------------------
+    BORROWED MODE
+    ------------------------------------------------------------------------
+
+    In borrowed mode, BufferWindowContent references an external
+    ScreenBuffer without owning it.
+
+        ScreenBuffer rendererBuffer(...);
+
+        auto content =
+            UI::BufferWindowContent::createBorrowed(rendererBuffer);
+
+    The external system remains responsible for:
+        - buffer lifetime
+        - buffer resizing
+        - buffer clearing
+        - rendering updates
+
+    BufferWindowContent acts only as a viewport/display adapter.
+
+    Typical use cases:
+        - renderer previews
+        - live framebuffer inspection
+        - debugging external systems
+        - render pipeline visualization
+        - composition previews
+        - emulator/video previews
+        - mirroring another render target
+
+    Borrowed buffers are NEVER automatically resized or destroyed by
+    BufferWindowContent.
+
+    This explicit owned vs borrowed distinction prevents ambiguity around:
+        - lifetime ownership
+        - resize authority
+        - destruction responsibility
+        - render-target synchronization
+*/
+
+namespace UI
+{
+    class BufferWindowContent final : public IWindowContent
+    {
+    public:
+        BufferWindowContent();
+        explicit BufferWindowContent(Size size);
+        BufferWindowContent(int width, int height);
+
+        explicit BufferWindowContent(ScreenBuffer& borrowedBuffer);
+
+        static std::unique_ptr<BufferWindowContent> createOwned(Size size);
+        static std::unique_ptr<BufferWindowContent> createOwned(int width, int height);
+        static std::unique_ptr<BufferWindowContent> createBorrowed(ScreenBuffer& borrowedBuffer);
+
+        BufferWindowContent(const BufferWindowContent&) = delete;
+        BufferWindowContent& operator=(const BufferWindowContent&) = delete;
+
+        BufferWindowContent(BufferWindowContent&&) noexcept = default;
+        BufferWindowContent& operator=(BufferWindowContent&&) noexcept = default;
+
+        ~BufferWindowContent() override;
+
+        bool ownsBuffer() const;
+        bool hasBuffer() const;
+
+        ScreenBuffer& buffer();
+        const ScreenBuffer& buffer() const;
+
+        ScreenBuffer* ownedBuffer();
+        const ScreenBuffer* ownedBuffer() const;
+
+        ScreenBuffer& sourceBuffer();
+        const ScreenBuffer& sourceBuffer() const;
+
+        void setCopyEmptyCells(bool copyEmptyCells);
+        bool copyEmptyCells() const;
+
+        void resizeOwnedBuffer(Size size);
+        void resizeOwnedBuffer(int width, int height);
+
+        void update(const Animation::TickEvent& event) override;
+        bool handleEvent(const Input::Event& event) override;
+        void draw(Surface& surface, const Rect& bounds) override;
+        void onBoundsChanged(const Rect& bounds) override;
+
+    private:
+        void resizeOwnedBufferToBounds(const Rect& bounds);
+
+    private:
+        std::unique_ptr<ScreenBuffer> m_ownedBuffer;
+        ScreenBuffer* m_buffer = nullptr;
+        bool m_copyEmptyCells = true;
+    };
+}


### PR DESCRIPTION
…ent adapter

Modifies:
- TUI.vcxproj

Adds:
- UI/Content/BufferWindowContent.h/.cpp

- Added UI::BufferWindowContent as a reusable ScreenBuffer-backed IWindowContent implementation
- Enables ContentWindow to display precomposed buffer content without introducing specialized BufferWindow types
- Added explicit owned-buffer mode:
    - internally managed ScreenBuffer lifetime
    - automatic resize-to-content-bounds behavior
    - suitable for framebuffer-style rendering and cached content
- Added explicit borrowed-buffer mode:
    - non-owning external ScreenBuffer reference
    - safe preview/display of external render targets
    - avoids accidental resize/destruction of borrowed buffers
- Added factory helpers for explicit ownership semantics: createOwned(...) createBorrowed(...)
- Added buffer accessors for direct caller composition/drawing into owned buffers
- Added clipping/copying path that blits ScreenBuffer cells into the destination Surface inside ContentWindow content bounds
- Added optional empty-cell copy filtering for sparse/transparent buffer presentation behavior
- Preserved ContentWindow as a generic container with no buffer- specific rendering knowledge added
- Established reusable architecture for:
    - render previews
    - framebuffer viewers
    - diagnostics
    - telemetry panels
    - cached render targets
    - composition previews
    - renderer inspection tools
- Reinforced rendering architecture direction: Window = chrome/container IWindowContent = interior rendering behavior ScreenBuffers become reusable composable render targets

Closes: #367 