### PR TITLE
TabbedWindow: Harden transferable-content lifecycle behavior across T…

### DIFF
--- a/TUI/UI/Panels/TabbedWindow.cpp
+++ b/TUI/UI/Panels/TabbedWindow.cpp
@@ -26,7 +26,10 @@ namespace UI
     {
     }
 
-    TabbedWindow::~TabbedWindow() = default;
+    TabbedWindow::~TabbedWindow()
+    {
+        detachAllPageContent();
+    }
 
     TabbedWindowModel& TabbedWindow::model()
     {
@@ -50,11 +53,19 @@ namespace UI
 
     bool TabbedWindow::addPage(TabbedWindowPage page, bool selectNewPage)
     {
+        const std::string contentId = page.contentId();
+
         const bool added = m_model.addPage(std::move(page), selectNewPage);
 
         if (!added)
         {
             return false;
+        }
+
+        const int addedIndex = m_model.indexOfContentId(contentId);
+        if (addedIndex >= 0)
+        {
+            attachPageContent(m_model.pages()[static_cast<std::size_t>(addedIndex)]);
         }
 
         synchronizeTitleWithSelectedPage();
@@ -95,6 +106,7 @@ namespace UI
     TabbedWindowPage TabbedWindow::removePageAt(std::size_t index)
     {
         TabbedWindowPage removed = m_model.removePageAt(index);
+        detachPageContent(removed);
 
         if (m_model.empty())
         {
@@ -119,6 +131,7 @@ namespace UI
         const std::string& contentId)
     {
         TabbedWindowPage removed = m_model.removePageByContentId(contentId);
+        detachPageContent(removed);
 
         if (m_model.empty())
         {
@@ -452,6 +465,39 @@ namespace UI
         }
     }
 
+    void TabbedWindow::attachPageContent(TabbedWindowPage& page)
+    {
+        IWindowContent* content = page.content();
+
+        if (content == nullptr)
+        {
+            return;
+        }
+
+        content->onAttached();
+        content->onBoundsChanged(selectedContentBounds());
+    }
+
+    void TabbedWindow::detachPageContent(TabbedWindowPage& page)
+    {
+        IWindowContent* content = page.content();
+
+        if (content == nullptr)
+        {
+            return;
+        }
+
+        content->onDetached();
+    }
+
+    void TabbedWindow::detachAllPageContent()
+    {
+        for (TabbedWindowPage& page : m_model.pages())
+        {
+            detachPageContent(page);
+        }
+    }
+
     bool TabbedWindow::handleMouseEvent(const Input::MouseEvent& mouseEvent)
     {
         updateHoveredTabFromPoint(mouseEvent.position);
@@ -522,7 +568,6 @@ namespace UI
     void TabbedWindow::updateHoveredTabFromPoint(Point screenPosition)
     {
         const int tabIndex = tabIndexAt(screenPosition);
-
         if (tabIndex >= 0)
         {
             setHoveredTabIndex(tabIndex);

--- a/TUI/UI/Panels/TabbedWindow.h
+++ b/TUI/UI/Panels/TabbedWindow.h
@@ -86,6 +86,10 @@ namespace UI
         void synchronizeTitleWithSelectedPage();
         void notifyContentBoundsChanged();
 
+        void attachPageContent(TabbedWindowPage& page);
+        void detachPageContent(TabbedWindowPage& page);
+        void detachAllPageContent();
+
         bool handleMouseEvent(const Input::MouseEvent& mouseEvent);
         bool handleTabHeaderMouseEvent(const Input::MouseEvent& mouseEvent);
         bool routeContentMouseEvent(const Input::MouseEvent& mouseEvent);


### PR DESCRIPTION
…abbedWindow and content adapters

Modifies:
- UI/Panels/TabbedWindow.h/.cpp

- Reviewed transferable-content architecture across:
    - Window
    - ContentWindow
    - EffectWindow
    - TabbedWindow
    - WindowManager flows
- Preserved content transfer model based on: std::unique_ptr<UI::IWindowContent>
- Added explicit content lifecycle handling to TabbedWindow
- Added:
    - attachPageContent(...)
    - detachPageContent(...)
    - detachAllPageContent(...)
- Ensured tab page content receives:
    - onAttached()
    - onDetached()
    - onBoundsChanged(...) during add/remove/select/destroy flows
- Hardened docking/tabbing/detach behavior for Phase 11.1 content adapters
- Ensured moved content reattaches cleanly when hosted by a new container
- Preserved WindowManager content-type agnostic behavior
- Preserved borrowed vs owned content semantics
- Preserved compatibility with:
    - EffectReferenceWindowContent
    - ContentWindow
    - EffectWindow
    - existing docking/tabbing systems
- Ensured detached tab content safely exits host lifecycle before transfer
- Added TabbedWindow destructor cleanup to detach hosted content safely
- Preserved selected-content bounds synchronization during tab changes and resizing
- Avoided introducing type-specific content handling into WindowManager

This update hardens the Phase 11.1 content-adapter architecture so docking, tabbing, detaching, and content transfer flows behave consistently and safely across all current transferable content types.