### PR TITLE
ContentWindow: content-adapter validation pass and diagnostics

### DIFF
--- a/TUI/UI/Content/BufferWindowContent.cpp
+++ b/TUI/UI/Content/BufferWindowContent.cpp
@@ -107,6 +107,11 @@ namespace UI
 
     BufferWindowContent::~BufferWindowContent() = default;
 
+    std::string_view UI::BufferWindowContent::contentTypeName() const
+    {
+        return "UI::BufferWindowContent";
+    }
+
     bool BufferWindowContent::ownsBuffer() const
     {
         return m_ownedBuffer != nullptr;

--- a/TUI/UI/Content/BufferWindowContent.h
+++ b/TUI/UI/Content/BufferWindowContent.h
@@ -103,6 +103,8 @@ namespace UI
 
         ~BufferWindowContent() override;
 
+        std::string_view contentTypeName() const override;
+
         bool ownsBuffer() const;
         bool hasBuffer() const;
 

--- a/TUI/UI/Content/ComposedWindowContent.cpp
+++ b/TUI/UI/Content/ComposedWindowContent.cpp
@@ -72,6 +72,11 @@ namespace UI
 
     ComposedWindowContent::~ComposedWindowContent() = default;
 
+    std::string_view  ComposedWindowContent::contentTypeName() const
+    {
+        return "UI::ComposedWindowContent";
+    }
+
     void ComposedWindowContent::setComposeCallback(ComposeCallback compose)
     {
         m_compose = std::move(compose);

--- a/TUI/UI/Content/ComposedWindowContent.h
+++ b/TUI/UI/Content/ComposedWindowContent.h
@@ -37,6 +37,8 @@ namespace UI
 
         ~ComposedWindowContent() override;
 
+        std::string_view contentTypeName() const;
+
         void setComposeCallback(ComposeCallback compose);
         void requestRecompose();
 

--- a/TUI/UI/Content/EffectReferenceWindowContent.cpp
+++ b/TUI/UI/Content/EffectReferenceWindowContent.cpp
@@ -11,6 +11,11 @@ namespace UI
 
     EffectReferenceWindowContent::~EffectReferenceWindowContent() = default;
 
+    std::string_view EffectReferenceWindowContent::contentTypeName() const
+    {
+        return "UI::EffectReferenceWindowContent";
+    }
+
     IEffect& EffectReferenceWindowContent::effect()
     {
         return *m_effect;

--- a/TUI/UI/Content/EffectReferenceWindowContent.h
+++ b/TUI/UI/Content/EffectReferenceWindowContent.h
@@ -19,6 +19,8 @@ namespace UI
 
         ~EffectReferenceWindowContent() override;
 
+        std::string_view contentTypeName() const;
+
         IEffect& effect();
         const IEffect& effect() const;
 

--- a/TUI/UI/Content/EffectWindowContent.cpp
+++ b/TUI/UI/Content/EffectWindowContent.cpp
@@ -13,6 +13,11 @@ namespace UI
 
     EffectWindowContent::~EffectWindowContent() = default;
 
+    std::string_view EffectWindowContent::contentTypeName() const
+    {
+        return "UI::EffectWindowContent";
+    }
+
     bool EffectWindowContent::hasEffect() const
     {
         return m_effect != nullptr;

--- a/TUI/UI/Content/EffectWindowContent.h
+++ b/TUI/UI/Content/EffectWindowContent.h
@@ -21,6 +21,8 @@ namespace UI
 
         ~EffectWindowContent() override;
 
+        std::string_view contentTypeName() const;
+
         bool hasEffect() const;
 
         IEffect* effect();

--- a/TUI/UI/Content/IWindowContent.h
+++ b/TUI/UI/Content/IWindowContent.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string_view>
+
 #include "Animation/TickEvent.h"
 #include "Core/Rect.h"
 
@@ -24,6 +26,11 @@ namespace UI
         IWindowContent& operator=(IWindowContent&&) noexcept = default;
 
         virtual ~IWindowContent() = default;
+
+        virtual std::string_view contentTypeName() const
+        {
+            return "UI::IWindowContent";
+        }
 
         virtual void update(const Animation::TickEvent& event) = 0;
 

--- a/TUI/UI/Content/ImmediateModeWindowContent.cpp
+++ b/TUI/UI/Content/ImmediateModeWindowContent.cpp
@@ -26,6 +26,11 @@ namespace UI
 
     ImmediateModeWindowContent::~ImmediateModeWindowContent() = default;
 
+    std::string_view ImmediateModeWindowContent::contentTypeName() const
+    {
+        return "UI::ImmediateModeWindowContent";
+    }
+
     void ImmediateModeWindowContent::setDrawCallback(DrawCallback draw)
     {
         m_draw = std::move(draw);

--- a/TUI/UI/Content/ImmediateModeWindowContent.h
+++ b/TUI/UI/Content/ImmediateModeWindowContent.h
@@ -39,6 +39,8 @@ namespace UI
 
         ~ImmediateModeWindowContent() override;
 
+        std::string_view contentTypeName() const;
+
         void setDrawCallback(DrawCallback draw);
         void setUpdateCallback(UpdateCallback update);
         void setEventCallback(EventCallback handleEvent);

--- a/TUI/UI/Content/WidgetWindowContent.cpp
+++ b/TUI/UI/Content/WidgetWindowContent.cpp
@@ -13,6 +13,11 @@ namespace UI
 
     WidgetWindowContent::~WidgetWindowContent() = default;
 
+    std::string_view WidgetWindowContent::contentTypeName() const
+    {
+        return "UI::WidgetWindowContent";
+    }
+
     bool WidgetWindowContent::hasWidget() const
     {
         return m_widget != nullptr;

--- a/TUI/UI/Content/WidgetWindowContent.h
+++ b/TUI/UI/Content/WidgetWindowContent.h
@@ -21,6 +21,8 @@ namespace UI
 
         ~WidgetWindowContent() override;
 
+        std::string_view contentTypeName() const;
+
         bool hasWidget() const;
 
         Widget* widget();

--- a/TUI/UI/Panels/ContentWindow.cpp
+++ b/TUI/UI/Panels/ContentWindow.cpp
@@ -37,6 +37,23 @@ namespace UI
         detachContent();
     }
 
+    IWindowContent* ContentWindow::content()
+    {
+        return m_content.get();
+    }
+
+    const IWindowContent* ContentWindow::content() const
+    {
+        return m_content.get();
+    }
+
+    std::string_view ContentWindow::contentTypeName() const
+    {
+        return m_content != nullptr
+             ? m_content->contentTypeName()
+             : std::string_view("UI::ContentWindow(empty)");
+    }
+
     bool ContentWindow::hasTransferableContent() const
     {
         return m_content != nullptr;

--- a/TUI/UI/Panels/ContentWindow.h
+++ b/TUI/UI/Panels/ContentWindow.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <string>
+#include <string_view>
 
 #include "UI/Content/IWindowContent.h"
 #include "UI/Panels/Window.h"
@@ -13,6 +14,10 @@ namespace UI
     public:
         ContentWindow(const Rect& bounds, std::string title, std::unique_ptr<IWindowContent> content);
         ~ContentWindow() override;
+
+        IWindowContent* content();
+        const IWindowContent* content() const;
+        std::string_view contentTypeName() const;
 
         bool hasTransferableContent() const override;
         std::unique_ptr<IWindowContent> releaseContent() override;


### PR DESCRIPTION
Modifies:
- UI/Content/BufferWindowContent.h/.cpp
- UI/Content/ComposedWindowContent.h/.cpp
- UI/Content/EffectReferenceWindowContent.h/.cpp
- UI/Content/EffectWindowContent.h/.cpp
- UI/Content/ImmediateModeWindowContent.h/.cpp
- UI/Content/IWindowContent.h
- UI/Content/WidgetWindowContent.h/.cpp
- UI/Panels/ContentWindow.h/.cpp

- Confirmed ContentWindow remains a small generic IWindowContent host
- Confirmed PageComposer usage stays inside content adapters and screen composition code
- Confirmed WindowManager remains content-type agnostic
- Confirmed EffectWindow remains transitional compatibility infrastructure
- Verified Donut3DScreen demonstrates ContentWindow + content-adapter architecture
- Added lightweight content-adapter diagnostics via contentTypeName()
- Added ContentWindow content inspection helpers for development/debugging
- Preserved existing content ownership and transfer semantics

Closes: #372 